### PR TITLE
Added main logic function to account_controller.go

### DIFF
--- a/pkg/awsclient/client.go
+++ b/pkg/awsclient/client.go
@@ -124,12 +124,15 @@ func (c *awsClient) PutUserPolicy(input *iam.PutUserPolicyInput) (*iam.PutUserPo
 func (c *awsClient) ListAccounts(input *organizations.ListAccountsInput) (*organizations.ListAccountsOutput, error) {
 	return c.orgClient.ListAccounts(input)
 }
+
 func (c *awsClient) CreateAccount(input *organizations.CreateAccountInput) (*organizations.CreateAccountOutput, error) {
 	return c.orgClient.CreateAccount(input)
 }
+
 func (c *awsClient) DescribeCreateAccountStatus(input *organizations.DescribeCreateAccountStatusInput) (*organizations.DescribeCreateAccountStatusOutput, error) {
 	return c.orgClient.DescribeCreateAccountStatus(input)
 }
+
 func (c *awsClient) AssumeRole(input *sts.AssumeRoleInput) (*sts.AssumeRoleOutput, error) {
 	return c.stsClient.AssumeRole(input)
 }


### PR DESCRIPTION
This pr has two commits. One fixes the formatting of the awsclient package. The second commit adds the main logic functions for account_controller.go. It also lets the operator be compiled and run without it creating an necessary resources. 

I also reorganized the functions in account_controller.go