### PR TITLE
Account pool controller bug fixes

### DIFF
--- a/pkg/controller/account/account_controller.go
+++ b/pkg/controller/account/account_controller.go
@@ -110,7 +110,7 @@ func (r *ReconcileAccount) Reconcile(request reconcile.Request) (reconcile.Resul
 	// update the account cr with accountID , create secret for IAm ,
 	// set the secret string to that name
 	// set state to ready
-	reqLogger.Info("Current Account: ", currentAcct)
+	//reqLogger.Info("Current Account: ", currentAcct)
 
 	return reconcile.Result{}, nil
 }


### PR DESCRIPTION
This pr removes status from the account object creation. It also sets the accountpool as the owner of the account object. Lastly it adds error handling to the client.create call. 