### PR TITLE
Add account status to AccountPool

### DIFF
--- a/pkg/apis/aws/v1alpha1/accountpool_types.go
+++ b/pkg/apis/aws/v1alpha1/accountpool_types.go
@@ -22,6 +22,9 @@ type AccountPoolStatus struct {
 	// INSERT ADDITIONAL STATUS FIELD - define observed state of cluster
 	// Important: Run "operator-sdk generate k8s" to regenerate code after modifying this file
 	// Add custom validation using kubebuilder tags: https://book.kubebuilder.io/beyond_basics/generating_crd.html
+	PoolSize          int `json:"poolsize"`
+	UnclaimedAccounts int `json:"unclaimedaccounts"`
+	ClaimedAccounts   int `json:"claimedaccounts"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object


### PR DESCRIPTION
This PR adds 3 status fields to the AccountPool schema so that a user can easily see that status of claimed/unclaimed accounts and the desired pool size.