### PR TITLE
Make API usable with the Go client generator

### DIFF
--- a/pkg/apis/aws/v1alpha1/account_types.go
+++ b/pkg/apis/aws/v1alpha1/account_types.go
@@ -28,6 +28,7 @@ type AccountStatus struct {
 	State   string `json:"state"`
 }
 
+// +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // Account is the Schema for the accounts API

--- a/pkg/apis/aws/v1alpha1/accountclaim_types.go
+++ b/pkg/apis/aws/v1alpha1/accountclaim_types.go
@@ -27,6 +27,7 @@ type AccountClaimStatus struct {
 	// Add custom validation using kubebuilder tags: https://book.kubebuilder.io/beyond_basics/generating_crd.html
 }
 
+// +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // AccountClaim is the Schema for the accountclaims API

--- a/pkg/apis/aws/v1alpha1/accountpool_types.go
+++ b/pkg/apis/aws/v1alpha1/accountpool_types.go
@@ -27,6 +27,7 @@ type AccountPoolStatus struct {
 	ClaimedAccounts   int `json:"claimedaccounts"`
 }
 
+// +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // AccountPool is the Schema for the accountpools API

--- a/pkg/apis/aws/v1alpha1/register.go
+++ b/pkg/apis/aws/v1alpha1/register.go
@@ -16,4 +16,12 @@ var (
 
 	// SchemeBuilder is used to add go types to the GroupVersionKind scheme
 	SchemeBuilder = &scheme.Builder{GroupVersion: SchemeGroupVersion}
+
+	// AddToScheme is a shortcut for SchemeBuilder.AddToScheme
+	AddToScheme = SchemeBuilder.AddToScheme
 )
+
+// Resource takes an unqualified resource and returns a Group qualified GroupResource
+func Resource(resource string) schema.GroupResource {
+	return SchemeGroupVersion.WithResource(resource).GroupResource()
+}


### PR DESCRIPTION
The API types generated by the `kubebuilder` tool don't have some of the
things that are needed in order to automatically generate a client using
the Kubernetes code generation tools. In particular they don't have the
`+genclient` annotation. This patch adds these missing things.