### PR TITLE
This should be the AWS account ID numeric value

### DIFF
--- a/pkg/controller/accountpool/accountpool_controller.go
+++ b/pkg/controller/accountpool/accountpool_controller.go
@@ -177,7 +177,7 @@ func newAccountForCR(namespace string) *awsv1alpha1.Account {
 			Namespace: namespace,
 		},
 		Spec: awsv1alpha1.AccountSpec{
-			AwsAccountID:  accountName,
+			AwsAccountID:  "",
 			IAMUserSecret: "",
 			ClaimLink:     "",
 		},


### PR DESCRIPTION
This PR removes the AWS account name from the AwsAccountID field in the Spec. This field should be filled in by the account controller with the numeric ID for the AWS account once its created.