### PR TITLE
Finished MVP logic for reconcile function

### DIFF
--- a/pkg/awsclient/client.go
+++ b/pkg/awsclient/client.go
@@ -138,13 +138,11 @@ func (c *awsClient) AssumeRole(input *sts.AssumeRoleInput) (*sts.AssumeRoleOutpu
 }
 
 // NewClient creates our client wrapper object for the actual AWS clients we use.
-// For authentication the underlying clients will use either the cluster AWS credentials
-func NewClient(kubeClient client.Client, awsAccessID, awsAccessSecret, region string) (Client, error) {
+func NewClient(kubeClient client.Client, awsAccessID, awsAccessSecret, token, region string) (Client, error) {
 	awsConfig := &aws.Config{Region: aws.String(region)}
 	awsConfig.Credentials = credentials.NewStaticCredentials(
-		awsAccessID, awsAccessSecret, "")
+		awsAccessID, awsAccessSecret, token)
 
-	// Otherwise default to relying on the IAM role of the masters where the actuator is running:
 	s, err := session.NewSession(awsConfig)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
This PR ties the logic together in the reconcile function. It also refactors other functions used in the reconcile function.

The `NewClient()` from the `awsclient/client.go` file has been modified to include a token field. 

For now the initial aws credentials used are taken from the environment variables. 
```
"aws_access_key_id"
"aws_secret_access_key"
```
For creating accounts in testing comment line 172 out of the account pool controller and add this line
```
accountName := "EmailUserName-" + uuid
Example:
accountName := "razevedo-" + uuid
```

The following items are hard coded right now.

- IAM user name to be created is "osdManagedAdmin"
- email suffix "redhat.com"
- region "us-east-1"


The IAM user secrets are created in the namespace the operator is running in as "accountName-secret"
```
apiVersion: v1
data:
  aws_access_key_id: "some secret"
  aws_secret_access_key: "some secret"
  aws_user_name: b3NkTWFuYWdlZEFkbWlu
kind: Secret
metadata:
  creationTimestamp: 2019-03-26T22:15:46Z
  name: razevedo-gjqmqd-secret
  namespace: default
  resourceVersion: "425657"
  selfLink: /api/v1/namespaces/default/secrets/razevedo-gjqmqd-secret
  uid: b4233903-5014-11e9-8c8e-0800278a78dc
type: Opaque
```

One question moving forward is should the aws_access_key_id and aws_secret_access_key be stored as plain text in those secrets?

What still needs to be done.
- We need to grab the aws credentials from a secret instead of a env variable
- Refactor logic so that reconcile looping makes more sense and items can come back into the loop at different stages
- Remove hard coded items or move them into constants 
- Create EC2 instances 
- Better testing before attempting to assume role in a new account instead of a sleep function
