### PR TITLE
Update secret namespace to be from request

### DIFF
--- a/pkg/controller/account/account_controller.go
+++ b/pkg/controller/account/account_controller.go
@@ -128,10 +128,9 @@ func (r *ReconcileAccount) Reconcile(request reconcile.Request) (reconcile.Resul
 		// get awsclient to setup  account
 		awsSetupClient, err := r.getAWSClient(newAwsClientInput{
 			secretName: "aws-config",
-			nameSpace:  "default",
+			nameSpace:  request.Namespace,
 			awsRegion:  "us-east-1",
 		})
-
 
 		if err != nil {
 			return reconcile.Result{}, err


### PR DESCRIPTION
This PR uses the namespace from the request when looking for the secret containing the master AWS organization credentials