### PR TITLE
Fix genclient tag

### DIFF
--- a/pkg/apis/aws/v1alpha1/accountclaim_types.go
+++ b/pkg/apis/aws/v1alpha1/accountclaim_types.go
@@ -31,8 +31,6 @@ type AccountClaimStatus struct {
 	State            ClaimStatus             `json:"state"`
 }
 
-// +genclient
-
 // AccountClaimCondition contains details for the current condition of a AWS account claim
 type AccountClaimCondition struct {
 	// Type is the type of the condition.
@@ -75,6 +73,7 @@ const (
 	ClaimStatusError ClaimStatus = "Error"
 )
 
+// +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // AccountClaim is the Schema for the accountclaims API


### PR DESCRIPTION
The following [commit](https://github.com/openshift/aws-account-operator/commit/d648742fb15732b80a3f660523dd423c6028fbd0) causes the `kubernetes/gen-client` tool to break. 

This tag is crucial for UHC as it uses it to create internal clients and tools to watch and create `AccountClaim` CRD's. (Please be aware when moving it around..)

cc: @jharrington22 @jewzaam 
