### PR TITLE
Expose metrics when Operator start. Update metrics in respecitve reconcile loops

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/openshift/aws-account-operator/pkg/apis"
 	"github.com/openshift/aws-account-operator/pkg/controller"
+	operatormetrics "github.com/openshift/aws-account-operator/pkg/metrics"
 	"github.com/operator-framework/operator-sdk/pkg/leader"
 	"github.com/operator-framework/operator-sdk/pkg/log/zap"
 	"github.com/operator-framework/operator-sdk/pkg/metrics"
@@ -102,6 +103,9 @@ func main() {
 	if err != nil {
 		log.Info(err.Error())
 	}
+
+	log.Info("Starting prometheus metrics")
+	operatormetrics.StartMetrics()
 
 	log.Info("Starting the Cmd.")
 

--- a/pkg/controller/accountclaim/accountclaim_controller.go
+++ b/pkg/controller/accountclaim/accountclaim_controller.go
@@ -7,6 +7,7 @@ import (
 	"github.com/go-logr/logr"
 	awsv1alpha1 "github.com/openshift/aws-account-operator/pkg/apis/aws/v1alpha1"
 	controllerutils "github.com/openshift/aws-account-operator/pkg/controller/utils"
+	"github.com/openshift/aws-account-operator/pkg/metrics"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -240,6 +241,14 @@ func (r *ReconcileAccountClaim) Reconcile(request reconcile.Request) (reconcile.
 		return reconcile.Result{}, err
 	}
 
+	accountClaimList := &awsv1alpha1.AccountClaimList{}
+
+	listOps = &client.ListOptions{Namespace: accountClaim.Namespace}
+	if err = r.client.List(context.TODO(), listOps, accountList); err != nil {
+		return reconcile.Result{}, err
+	}
+
+	metrics.UpdateAccountClaimMetrics(accountClaimList)
 	return reconcile.Result{}, nil
 }
 

--- a/pkg/controller/accountpool/accountpool_controller.go
+++ b/pkg/controller/accountpool/accountpool_controller.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	awsv1alpha1 "github.com/openshift/aws-account-operator/pkg/apis/aws/v1alpha1"
+	"github.com/openshift/aws-account-operator/pkg/metrics"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -135,6 +136,9 @@ func (r *ReconcileAccountPool) Reconcile(request reconcile.Request) (reconcile.R
 			return reconcile.Result{}, err
 		}
 	}
+
+	metrics.UpdateAccountCRMetrics(accountList)
+	metrics.UpdatePoolSizeVsUnclaimed(currentAccountPool.Spec.PoolSize, unclaimedAccountCount)
 
 	if unclaimedAccountCount >= poolSizeCount {
 

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -19,6 +19,7 @@ import (
 	"net/http"
 
 	awsv1alpha1 "github.com/openshift/aws-account-operator/pkg/apis/aws/v1alpha1"
+	"github.com/openshift/aws-account-operator/pkg/awsclient"
 	"github.com/prometheus/client_golang/prometheus"
 )
 
@@ -80,17 +81,20 @@ func StartMetrics() {
 func RegisterMetrics() error {
 	for _, metric := range metricsList {
 		err := prometheus.Register(metric)
-		return err
+		if err != nil {
+			return err
+		}
 	}
 	return nil
 }
 
-func updateAWSMetrics() {
+// UpdateAWSMetrics updates all AWS related metrics
+func UpdateAWSMetrics(awsClient awsclient.Client) {
 
 	metricTotalAWSAccounts.With(prometheus.Labels{"name": "aws-account-operator"}).Set(float64(0))
 }
 
-// UpdateAccountCRMetrics ...
+// UpdateAccountCRMetrics updates all metrics related to Account CRs
 func UpdateAccountCRMetrics(accountList *awsv1alpha1.AccountList) {
 
 	unclaimedAccountCount := 0
@@ -115,12 +119,14 @@ func UpdateAccountCRMetrics(accountList *awsv1alpha1.AccountList) {
 	metricTotalAccountCRsFailed.With(prometheus.Labels{"name": "aws-account-operator"}).Set(float64(failedAccountCount))
 }
 
-func updateAccountClaimMetrics(accountClaimList *awsv1alpha1.AccountClaimList) {
+// UpdateAccountClaimMetrics updates all metrics related to AccountClaim CRs
+func UpdateAccountClaimMetrics(accountClaimList *awsv1alpha1.AccountClaimList) {
 
 	metricTotalAccountClaimCRs.With(prometheus.Labels{"name": "aws-account-operator"}).Set(float64(len(accountClaimList.Items)))
 }
 
-func updatePoolSizeVsUnclaimed(poolSize int, unclaimedAccountCount int) {
+// UpdatePoolSizeVsUnclaimed updates the metric that measures the difference between Poolsize and Unclaimed Account CRs
+func UpdatePoolSizeVsUnclaimed(poolSize int, unclaimedAccountCount int) {
 
 	metric := math.Abs(float64(poolSize) - float64(unclaimedAccountCount))
 


### PR DESCRIPTION
This PR uses the metrics package to expose the metrics endpoint on start of the operator, and updates the metrics  in their related contoller's reconcile loops. 