### PR TITLE
Add service account aws-account-operator-client for UHC

### DIFF
--- a/deploy/uhc_cluster_role.yaml
+++ b/deploy/uhc_cluster_role.yaml
@@ -1,0 +1,15 @@
+- apiVersion: rbac.authorization.k8s.io/v1
+  kind: ClusterRole
+  metadata:
+    name: aws-account-operator-client
+  rules:
+  - apiGroups:
+    - "aws.managed.openshift.io"
+    resources:
+    - accountclaims
+    verbs:
+    - create
+    - delete
+    - get
+    - list
+    - watch

--- a/deploy/uhc_cluster_role_binding.yaml
+++ b/deploy/uhc_cluster_role_binding.yaml
@@ -1,0 +1,12 @@
+- apiVersion: rbac.authorization.k8s.io/v1
+  kind: ClusterRoleBinding
+  metadata:
+    name: aws-account-operator-client
+  subjects:
+  - kind: ServiceAccount
+    namespace: aws-account-operator-client
+    name: aws-account-operator-client
+  roleRef:
+    kind: ClusterRole
+    name: aws-account-operator-client
+    apiGroup: rbac.authorization.k8s.io

--- a/deploy/uhc_service_account.yaml
+++ b/deploy/uhc_service_account.yaml
@@ -1,0 +1,5 @@
+- apiVersion: v1
+  kind: ServiceAccount
+  metadata:
+    name: aws-account-operator-client
+    namespace: aws-account-operator-client # This namespace needs to be created in advance.

--- a/hack/generate-operator-bundle.py
+++ b/hack/generate-operator-bundle.py
@@ -62,6 +62,15 @@ with open('deploy/cluster_role.yaml', 'r') as stream:
             'serviceAccountName': 'aws-account-operator',
         })
 
+# Add aws-account-operator-client role to the CSV:
+with open('deploy/uhc_cluster_role.yaml', 'r') as stream:
+    operator_role = yaml.load(stream)
+    csv['spec']['install']['spec']['clusterPermissions'].append(
+        {
+            'rules': operator_role['rules'],
+            'serviceAccountName': 'aws-account-operator-client',
+        })
+
 # Add our deployment spec for the hive operator:
 with open('deploy/operator.yaml', 'r') as stream:
     operator_components = []


### PR DESCRIPTION
This PR creates a service account for UHC to consume and use, it will be deployed as part of the CSV.