### PR TITLE
Make sure we provide the AWS secret access key

### DIFF
--- a/pkg/controller/accountclaim/accountclaim_controller.go
+++ b/pkg/controller/accountclaim/accountclaim_controller.go
@@ -22,10 +22,11 @@ import (
 )
 
 const (
-	AccountClaimed      = "AccountClaimed"
-	AccountUnclaimed    = "AccountUnclaimed"
-	awsCredsUserName    = "aws_user_name"
-	awsCredsSecretIDKey = "aws_access_key_id"
+	AccountClaimed          = "AccountClaimed"
+	AccountUnclaimed        = "AccountUnclaimed"
+	awsCredsUserName        = "aws_user_name"
+	awsCredsAccessKeyId     = "aws_access_key_id"
+	awsCredsSecretAccessKey = "aws_secret_access_key"
 )
 
 var log = logf.Log.WithName("controller_accountclaim")
@@ -228,8 +229,8 @@ func (r *ReconcileAccountClaim) Reconcile(request reconcile.Request) (reconcile.
 
 	UHCSecretName := accountClaim.Spec.AwsCredentialSecret.Name
 	UHCSecretNamespace := accountClaim.Spec.AwsCredentialSecret.Namespace
-	awsAccessKeyID := accountIAMUserSecret.Data[awsCredsSecretIDKey]
-	awsSecretAccessKey := accountIAMUserSecret.Data[awsCredsSecretIDKey]
+	awsAccessKeyID := accountIAMUserSecret.Data[awsCredsAccessKeyId]
+	awsSecretAccessKey := accountIAMUserSecret.Data[awsCredsSecretAccessKey]
 	if string(awsAccessKeyID) == "" || string(awsSecretAccessKey) == "" {
 		reqLogger.Error(err, "Cannot get AWS Credentials from secret referenced from Account")
 	}


### PR DESCRIPTION
This PR fixes an issue where the AWS access key was being provided for both access key and secret access key.