### PR TITLE
Deploy needed objects for prometheus metrics when the operator comes up

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -105,8 +105,15 @@ func main() {
 	}
 
 	// Create Service object to expose the metrics port.
-	s, _ := operatormetrics.GenerateService(8080, "metrics")
+	s, svcerr := operatormetrics.GenerateService(8080, "metrics")
+	if svcerr != nil {
+		log.Error(err, "Error generating metrics service object.")
+	} else {
+		log.Info("Generated metrics service object")
+	}
+
 	sm := operatormetrics.GenerateServiceMonitor(s)
+	log.Info("Generated metrics servicemonitor object")
 	err = mgr.GetClient().Create(context.TODO(), s)
 	if err != nil {
 		log.Error(err, "error creating metrics Service")

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -12,7 +12,8 @@ import (
 	operatormetrics "github.com/openshift/aws-account-operator/pkg/metrics"
 	"github.com/operator-framework/operator-sdk/pkg/leader"
 	"github.com/operator-framework/operator-sdk/pkg/log/zap"
-	"github.com/operator-framework/operator-sdk/pkg/metrics"
+
+	monitoringv1 "github.com/coreos/prometheus-operator/pkg/apis/monitoring/v1"
 	sdkVersion "github.com/operator-framework/operator-sdk/version"
 	"github.com/spf13/pflag"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
@@ -92,6 +93,11 @@ func main() {
 		os.Exit(1)
 	}
 
+	if err := monitoringv1.AddToScheme(mgr.GetScheme()); err != nil {
+		log.Error(err, "error registering prometheus monitoring objects")
+		os.Exit(1)
+	}
+
 	// Setup all Controllers
 	if err := controller.AddToManager(mgr); err != nil {
 		log.Error(err, "")
@@ -99,9 +105,19 @@ func main() {
 	}
 
 	// Create Service object to expose the metrics port.
-	_, err = metrics.ExposeMetricsPort(ctx, metricsPort)
+	s, _ := operatormetrics.GenerateService(8080, "metrics")
+	sm := operatormetrics.GenerateServiceMonitor(s)
+	err = mgr.GetClient().Create(context.TODO(), s)
 	if err != nil {
-		log.Info(err.Error())
+		log.Error(err, "error creating metrics Service")
+	} else {
+		log.Info("Created Service")
+		err = mgr.GetClient().Create(context.TODO(), sm)
+		if err != nil {
+			log.Error(err, "error creating metrics ServiceMonitor")
+		} else {
+			log.Info("Created ServiceMonitor")
+		}
 	}
 
 	log.Info("Starting prometheus metrics")

--- a/deploy/prometheus-k8s-role.yaml
+++ b/deploy/prometheus-k8s-role.yaml
@@ -1,0 +1,16 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: prometheus-k8s
+  namespace: aws-account-operator
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - services
+  - endpoints
+  - pods
+  verbs:
+  - get
+  - list
+  - watch

--- a/deploy/prometheus-k8s-rolebinding.yaml
+++ b/deploy/prometheus-k8s-rolebinding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: prometheus-k8s
+  namespace: aws-account-operator
+roleRef:
+  kind: Role
+  name: prometheus-k8s
+subjects:
+- kind: ServiceAccount
+  name: prometheus-k8s
+  namespace: openshift-monitoring

--- a/pkg/metrics/service.go
+++ b/pkg/metrics/service.go
@@ -1,0 +1,92 @@
+// Copyright 2019 RedHat
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package metrics
+
+import (
+	monitoringv1 "github.com/coreos/prometheus-operator/pkg/apis/monitoring/v1"
+	"github.com/operator-framework/operator-sdk/pkg/k8sutil"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+)
+
+// GenerateService returns the static service which exposes specifed port.
+func GenerateService(port int32, portName string) (*v1.Service, error) {
+	operatorName, err := k8sutil.GetOperatorName()
+	if err != nil {
+		return nil, err
+	}
+	namespace, err := k8sutil.GetOperatorNamespace()
+	if err != nil {
+		return nil, err
+	}
+	service := &v1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      operatorName,
+			Namespace: namespace,
+			Labels:    map[string]string{"name": operatorName},
+		},
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Service",
+			APIVersion: "v1",
+		},
+		Spec: v1.ServiceSpec{
+			Ports: []v1.ServicePort{
+				{
+					Port:     port,
+					Protocol: v1.ProtocolTCP,
+					TargetPort: intstr.IntOrString{
+						Type:   intstr.Int,
+						IntVal: port,
+					},
+					Name: portName,
+				},
+			},
+			Selector: map[string]string{"name": operatorName},
+		},
+	}
+	return service, nil
+}
+
+// GenerateServiceMonitor generates a prometheus-operator ServiceMonitor object
+// based on the passed Service object.
+func GenerateServiceMonitor(s *v1.Service) *monitoringv1.ServiceMonitor {
+	labels := make(map[string]string)
+	for k, v := range s.ObjectMeta.Labels {
+		labels[k] = v
+	}
+
+	return &monitoringv1.ServiceMonitor{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "ServiceMonitor",
+			APIVersion: "monitoring.coreos.com/v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      s.ObjectMeta.Name,
+			Namespace: s.ObjectMeta.Namespace,
+			Labels:    labels,
+		},
+		Spec: monitoringv1.ServiceMonitorSpec{
+			Selector: metav1.LabelSelector{
+				MatchLabels: labels,
+			},
+			Endpoints: []monitoringv1.Endpoint{
+				{
+					Port: s.Spec.Ports[0].Name,
+				},
+			},
+		},
+	}
+}


### PR DESCRIPTION
This PR ensures that when the operator is deployed, all the proper objects are placed so prometheus can scrape the custom metrics.

-The operator creates an aws-account-operator service to expose the metrics over on deploy
-The operator creates an aws-account-operator servicemonitor to tell prometheus how to digest the metrics
-Removes the operator-sdk metrics service for now
-Includes a prometheus-k8s role for the aws-account-operator namespace that has permissions to get, list and watch services, pods and endpoints.
-Includes a prometheus-k8s rolebinding to allow the prometheus-k8s serviceaccount from the openshift-monitoring namespace to use the aformentioned role.

When the operator and the role/rolebindings are deployed, the aws-account-operator namespace must be given the following label to get everything working: openshift.io/cluster-monitoring="true"