### PR TITLE
Added aws metrics to account controller

### DIFF
--- a/pkg/controller/account/account_controller.go
+++ b/pkg/controller/account/account_controller.go
@@ -182,7 +182,7 @@ func (r *ReconcileAccount) Reconcile(request reconcile.Request) (reconcile.Resul
 		}
 
 		metrics.UpdateAWSMetrics(accountTotal)
-		
+
 		if accountTotal >= awsLimit {
 			reqLogger.Error(ErrAwsAccountLimitExceeded, "AWS Account limit reached", "Account Total", accountTotal)
 			return reconcile.Result{}, ErrAwsAccountLimitExceeded

--- a/pkg/controller/account/account_controller.go
+++ b/pkg/controller/account/account_controller.go
@@ -17,6 +17,7 @@ import (
 	awsv1alpha1 "github.com/openshift/aws-account-operator/pkg/apis/aws/v1alpha1"
 	"github.com/openshift/aws-account-operator/pkg/awsclient"
 	controllerutils "github.com/openshift/aws-account-operator/pkg/controller/utils"
+	"github.com/openshift/aws-account-operator/pkg/metrics"
 	corev1 "k8s.io/api/core/v1"
 	k8serr "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -180,6 +181,8 @@ func (r *ReconcileAccount) Reconcile(request reconcile.Request) (reconcile.Resul
 			return reconcile.Result{}, err
 		}
 
+		metrics.UpdateAWSMetrics(accountTotal)
+		
 		if accountTotal >= awsLimit {
 			reqLogger.Error(ErrAwsAccountLimitExceeded, "AWS Account limit reached", "Account Total", accountTotal)
 			return reconcile.Result{}, ErrAwsAccountLimitExceeded

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -15,13 +15,10 @@
 package metrics
 
 import (
-	"fmt"
 	"math"
 	"net/http"
 
-	"github.com/aws/aws-sdk-go/service/organizations"
 	awsv1alpha1 "github.com/openshift/aws-account-operator/pkg/apis/aws/v1alpha1"
-	"github.com/openshift/aws-account-operator/pkg/awsclient"
 	"github.com/prometheus/client_golang/prometheus"
 )
 
@@ -91,26 +88,8 @@ func RegisterMetrics() error {
 }
 
 // UpdateAWSMetrics updates all AWS related metrics
-func UpdateAWSMetrics(awsClient awsclient.Client) {
-	var awsAccounts []*organizations.Account
-
-	var nextToken *string
-
-	// Ensure we paginate through the account list
-	for {
-		awsAccountList, err := awsClient.ListAccounts(&organizations.ListAccountsInput{NextToken: nextToken})
-		if err != nil {
-			fmt.Println("Error getting a list of accounts")
-		}
-		awsAccounts = append(awsAccounts, awsAccountList.Accounts...)
-		if awsAccountList.NextToken != nil {
-			nextToken = awsAccountList.NextToken
-		} else {
-			break
-		}
-	}
-
-	metricTotalAWSAccounts.With(prometheus.Labels{"name": "aws-account-operator"}).Set(float64(len(awsAccounts)))
+func UpdateAWSMetrics(totalAccounts int) {
+	metricTotalAWSAccounts.With(prometheus.Labels{"name": "aws-account-operator"}).Set(float64(totalAccounts))
 }
 
 // UpdateAccountCRMetrics updates all metrics related to Account CRs


### PR DESCRIPTION
This PR adds aws metrics to the account controller and refactors the aws metrics call to not use the aws api where not needed.