### PR TITLE
Fix info msg typo

### DIFF
--- a/pkg/controller/accountpool/accountpool_controller.go
+++ b/pkg/controller/accountpool/accountpool_controller.go
@@ -143,7 +143,7 @@ func (r *ReconcileAccountPool) Reconcile(request reconcile.Request) (reconcile.R
 	metrics.UpdatePoolSizeVsUnclaimed(currentAccountPool.Spec.PoolSize, unclaimedAccountCount)
 
 	if unclaimedAccountCount >= poolSizeCount {
-		reqLogger.Info(fmt.Sprintf("unclaimed account pool satisifed, unclaimedAccounts %d >= poolSize %d", unclaimedAccountCount, poolSizeCount))
+		reqLogger.Info(fmt.Sprintf("unclaimed account pool satisfied, unclaimedAccounts %d >= poolSize %d", unclaimedAccountCount, poolSizeCount))
 		return reconcile.Result{}, nil
 	}
 


### PR DESCRIPTION
This PR fixes a small info message typo in the account pool controller