### PR TITLE
[WIP] Add AWS account resuse helper scripts and modify account controller

### DIFF
--- a/scripts/aws_assume_role_cli.sh
+++ b/scripts/aws_assume_role_cli.sh
@@ -6,7 +6,7 @@ usage() {
     Options
     -a         AWS Account ID (10 digit int)
     -p         AWS Profile, leave blank for none
-    -p         AWS Region leave blank for default us-east-1
+    -r         AWS Region leave blank for default us-east-1
 EOF
 }
 
@@ -59,14 +59,4 @@ if [ -z "$AWS_DEFAULT_REGION" ]; then
 fi
 
 # Assume role
-AWS_ASSUME_ROLE=$(aws sts assume-role --role-arn arn:aws:iam::"${AWS_ACCOUNT_ID}":role/OrganizationAccountAccessRole --role-session-name ${AWS_STS_SESSION_NAME} --profile="${AWS_DEFAULT_PROFILE}")
-
-AWS_ACCESS_KEY_ID=$(echo "$AWS_ASSUME_ROLE" | jq -r '.Credentials.AccessKeyId')
-AWS_SECRET_ACCESS_KEY=$(echo "$AWS_ASSUME_ROLE" | jq -r '.Credentials.SecretAccessKey')
-AWS_SESSION_TOKEN=$(echo "$AWS_ASSUME_ROLE" | jq -r '.Credentials.SessionToken')
-
-export AWS_ACCESS_KEY_ID
-export AWS_SECRET_ACCESS_KEY
-export AWS_SESSION_TOKEN
-
-aws sts get-caller-identity
+aws sts assume-role --role-arn arn:aws:iam::"${AWS_ACCOUNT_ID}":role/OrganizationAccountAccessRole --role-session-name ${AWS_STS_SESSION_NAME} --profile="${AWS_DEFAULT_PROFILE}"

--- a/scripts/aws_assume_role_cli.sh
+++ b/scripts/aws_assume_role_cli.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+
+usage() {
+    cat <<EOF
+    usage: $0 [ OPTION ]
+    Options
+    -a         AWS Account ID (10 digit int)
+    -p         AWS Profile, leave blank for none
+    -p         AWS Region leave blank for default us-east-1
+EOF
+}
+
+if ( ! getopts ":a:p:r:h" opt); then
+    echo ""
+    echo "    $0 requries an argument!"
+    usage
+    exit 1 
+fi
+
+while getopts ":a:p:r:h" opt; do
+    case $opt in
+        a)
+            AWS_ACCOUNT_ID="$OPTARG" >&2
+            ;;
+        p)
+            AWS_DEFAULT_PROFILE="$OPTARG" >&2
+            ;;
+        r)
+            AWS_DEFAULT_REGION="$OPTARG" >&2
+            ;;
+        h)
+            echo "Invalid option: -$OPTARG" >&2
+            usage
+            exit 1
+            ;;
+        \?)
+            echo "Invalid option: -$OPTARG" >&2
+            usage
+            exit 1
+            ;;
+        :)
+            echo "$0 Requires an argument" >&2
+            usage
+            exit 1
+            ;;
+        esac
+    done
+
+
+AWS_STS_SESSION_NAME="SREAdminCreateUser"
+
+if [ -z "$AWS_ACCOUNT_ID" ]; then
+	usage
+    exit 1
+fi
+
+if [ -z "$AWS_DEFAULT_REGION" ]; then
+	AWS_DEFAULT_REGION="us-east-1"
+fi
+
+# Assume role
+AWS_ASSUME_ROLE=$(aws sts assume-role --role-arn arn:aws:iam::"${AWS_ACCOUNT_ID}":role/OrganizationAccountAccessRole --role-session-name ${AWS_STS_SESSION_NAME} --profile="${AWS_DEFAULT_PROFILE}")
+
+AWS_ACCESS_KEY_ID=$(echo "$AWS_ASSUME_ROLE" | jq -r '.Credentials.AccessKeyId')
+AWS_SECRET_ACCESS_KEY=$(echo "$AWS_ASSUME_ROLE" | jq -r '.Credentials.SecretAccessKey')
+AWS_SESSION_TOKEN=$(echo "$AWS_ASSUME_ROLE" | jq -r '.Credentials.SessionToken')
+
+export AWS_ACCESS_KEY_ID
+export AWS_SECRET_ACCESS_KEY
+export AWS_SESSION_TOKEN
+
+aws sts get-caller-identity

--- a/scripts/delete_cluster_aws_account.sh
+++ b/scripts/delete_cluster_aws_account.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+AWS_ACCOUNT_NAME=$1
+
+for acc in $(oc get accounts -n aws-account-operator --no-headers | grep "$AWS_ACCOUNT_NAME" | awk '{print $1}')
+do
+    echo "$acc"
+    oc patch account "$acc" -n aws-account-operator -p '{"metadata":{"finalizers":[]}}' --type=merge
+    oc delete account "$acc" -n aws-account-operator
+done

--- a/scripts/remove_cluster_aws_account_secrets.sh
+++ b/scripts/remove_cluster_aws_account_secrets.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+AWS_ACCOUNT_NAME=$1
+
+if [ -z "$AWS_ACCOUNT_NAME" ]; then
+    echo "No AWS account name specified"
+    echo -e "$0 <aws-account-name>\n"
+    exit 1
+fi
+
+
+for secret in $(oc get secrets -n aws-account-operator --no-headers | grep "${AWS_ACCOUNT_NAME}" | awk '{print $1}'); do
+    echo "Deleting secret $secret"
+    oc delete secret "$secret" -n aws-account-operator
+done

--- a/scripts/reset_environments.sh
+++ b/scripts/reset_environments.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+AWS_ACCOUNT_NAME=$1
+
+if [ -z "$AWS_ACCOUNT_NAME" ]; then
+    echo "No AWS account name specified"
+    echo -e "$0 <aws-account-name>\n"
+    exit 1
+fi
+
+echo "Running.."
+
+# echo "1"
+./scripts/scrub_aws_account.sh "$AWS_ACCOUNT_NAME"
+# echo "2"
+./scripts/remove_cluster_aws_account_secrets.sh "$AWS_ACCOUNT_NAME"
+# echo "3"
+./scripts/delete_cluster_aws_accounts.sh "$AWS_ACCOUNT_NAME"
+# echo "4"
+oc apply -f "$AWS_ACCOUNT_NAME".json
+# echo "5"

--- a/scripts/reset_environments.sh
+++ b/scripts/reset_environments.sh
@@ -14,7 +14,7 @@ echo "Running.."
 # echo "2"
 ./scripts/remove_cluster_aws_account_secrets.sh "$AWS_ACCOUNT_NAME"
 # echo "3"
-./scripts/delete_cluster_aws_accounts.sh "$AWS_ACCOUNT_NAME"
+./scripts/delete_cluster_aws_account.sh "$AWS_ACCOUNT_NAME"
 # echo "4"
 oc apply -f "$AWS_ACCOUNT_NAME".json
 # echo "5"

--- a/scripts/scrub_aws_account.sh
+++ b/scripts/scrub_aws_account.sh
@@ -9,7 +9,8 @@ if [ -z "$AWS_ACCOUNT_NAME" ]; then
 fi
 
 echo "Assuming role in account ${AWS_ACCOUNT_NAME}"
-AWS_ACCOUNT_CREDENTIALS=$(./scripts/aws_assume_role_cli.sh "${AWS_ACCOUNT_NAME}")
+AWS_ACCOUNT_ID=$(oc get account "${AWS_ACCOUNT_NAME}" -n aws-account-operator | jq '.spec.awsAccountID')
+AWS_ACCOUNT_CREDENTIALS=$(./scripts/aws_assume_role_cli.sh "${AWS_ACCOUNT_ID}")
 
 echo "Done"
 
@@ -20,8 +21,6 @@ AWS_SESSION_TOKEN=$(echo "${AWS_ACCOUNT_CREDENTIALS}" | jq -r '.Credentials.Sess
 export AWS_ACCESS_KEY_ID
 export AWS_SECRET_ACCESS_KEY
 export AWS_SESSION_TOKEN
-
-AWS_ACCOUNT_ID=$(aws sts get-caller-identity | jq -r '.Account')
 
 echo "Cleaning AWS account ID: $AWS_ACCOUNT_ID"
 

--- a/scripts/scrub_aws_account.sh
+++ b/scripts/scrub_aws_account.sh
@@ -9,8 +9,9 @@ if [ -z "$AWS_ACCOUNT_NAME" ]; then
 fi
 
 echo "Assuming role in account ${AWS_ACCOUNT_NAME}"
-AWS_ACCOUNT_ID=$(oc get account "${AWS_ACCOUNT_NAME}" -n aws-account-operator | jq '.spec.awsAccountID')
-AWS_ACCOUNT_CREDENTIALS=$(./scripts/aws_assume_role_cli.sh "${AWS_ACCOUNT_ID}")
+
+AWS_ACCOUNT_ID=$(oc get account "${AWS_ACCOUNT_NAME}" -n aws-account-operator -o json | jq -r '.spec.awsAccountID')
+AWS_ACCOUNT_CREDENTIALS=$(./scripts/aws_assume_role_cli.sh -a "${AWS_ACCOUNT_ID}")
 
 echo "Done"
 
@@ -43,5 +44,5 @@ for IAM_USER in $(echo "osdManagedAdmin osdManagedAdminSRE"); do
     done
 
     # Delete IAM user
-    aws iam delete-user --user-name "$IAM_USER" 
+    aws iam delete-user --user-name "$IAM_USER"
 done

--- a/scripts/scrub_aws_account.sh
+++ b/scripts/scrub_aws_account.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+
+AWS_ACCOUNT_NAME=$1
+
+if [ -z "$AWS_ACCOUNT_NAME" ]; then
+    echo "No AWS account name specified"
+    echo -e "$0 <aws-account-name>\n"
+    exit 1
+fi
+
+echo "Assuming role in account ${AWS_ACCOUNT_NAME}"
+AWS_ACCOUNT_CREDENTIALS=$(./scripts/aws_assume_role_cli.sh "${AWS_ACCOUNT_NAME}")
+
+echo "Done"
+
+AWS_ACCESS_KEY_ID=$(echo "${AWS_ACCOUNT_CREDENTIALS}" | jq -r '.Credentials.AccessKeyId')
+AWS_SECRET_ACCESS_KEY=$(echo "${AWS_ACCOUNT_CREDENTIALS}" | jq -r '.Credentials.SecretAccessKey')
+AWS_SESSION_TOKEN=$(echo "${AWS_ACCOUNT_CREDENTIALS}" | jq -r '.Credentials.SessionToken')
+
+export AWS_ACCESS_KEY_ID
+export AWS_SECRET_ACCESS_KEY
+export AWS_SESSION_TOKEN
+
+AWS_ACCOUNT_ID=$(aws sts get-caller-identity | jq -r '.Account')
+
+echo "Cleaning AWS account ID: $AWS_ACCOUNT_ID"
+
+for IAM_USER in $(echo "osdManagedAdmin osdManagedAdminSRE"); do
+    echo "Cleaning up IAM user: $IAM_USER"
+    aws iam delete-login-profile --user-name "$IAM_USER" 2> /dev/null
+    if [ $? -eq 0 ]; then
+        echo "Deleted login profile for user $IAM_USER"
+    fi
+    # Delete policy attached to IAM user
+    aws iam detach-user-policy --user-name "$IAM_USER" --policy-arn "arn:aws:iam::aws:policy/AdministratorAccess"
+    
+    # List access keys created for user
+    ADMIN_ACCESS_KEY_IDS=$(aws iam list-access-keys --user-name "$IAM_USER" | jq -r '.AccessKeyMetadata[].AccessKeyId')
+    
+    # Delete access keys created for user
+    for ID in ${ADMIN_ACCESS_KEY_IDS}; do
+      echo "Deleting ACCESS KEY $ID"
+      aws iam delete-access-key --user-name "$IAM_USER" --access-key-id "${ID}"
+    done
+
+    # Delete IAM user
+    aws iam delete-user --user-name "$IAM_USER" 
+done


### PR DESCRIPTION
This PR adds support for reusing AWS accounts, if an account CR contains a populated `spec.awsAccountID` field it will assume the account is already created and move on. The PR also contains some helper scripts to scrub the AWS env of IAM users and policies as well as reset the local ENV. 