### PR TITLE
APPSRE-745 - Lower severity for support cases to urgent

### DIFF
--- a/pkg/controller/account/account_controller.go
+++ b/pkg/controller/account/account_controller.go
@@ -50,7 +50,7 @@ const (
 	caseCategoryCode              = "other-account-issues"
 	caseServiceCode               = "customer-account"
 	caseIssueType                 = "customer-service"
-	caseSeverity                  = "critical"
+	caseSeverity                  = "urgent"
 	caseDesiredInstanceLimit      = 25
 	caseStatusResolved            = "resolved"
 	intervalAfterCaseCreationSecs = 30


### PR DESCRIPTION
Per discussion with AWS, changing the support case severity to urgent. Since it wouldn't impact the resolution times and AWS was afraid the critical ones would cause problems in their end during the weekend

