### PR TITLE
Fix the port number so the route points to the right port

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -27,7 +27,7 @@ import (
 
 // Change below variables to serve metrics on different host or port.
 var (
-	metricsPort               = "9090"
+	metricsPort               = "8080"
 	metricsPath               = "/metrics"
 	secretWatcherScanInterval = time.Duration(10) * time.Minute
 )


### PR DESCRIPTION
There is a bug in operator-custom-metrics that is not allowing the route to be updated https://github.com/openshift/operator-custom-metrics/issues/4

To get around that, this PR reverts the port number for the metrics endpoint to the previously used port number, which the current route already points to. There was no obvious reason to change this port number anyway. This does not fix the bug in the vendored code, but is just a work around. 