### PR TITLE
Register Ready metric

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -114,6 +114,7 @@ func main() {
 		WithCollectors(localmetrics.MetricTotalAccountCRsUnclaimed).
 		WithCollectors(localmetrics.MetricTotalAccountCRsClaimed).
 		WithCollectors(localmetrics.MetricTotalAccountCRsFailed).
+		WithCollectors(localmetrics.MetricTotalAccountCRsReady).
 		WithCollectors(localmetrics.MetricTotalAccountClaimCRs).
 		WithCollectors(localmetrics.MetricPoolSizeVsUnclaimed).
 		WithCollectors(localmetrics.MetricTotalAccountPendingVerification).


### PR DESCRIPTION
Regisers ready metric with the metrics endpoint builder. This was overlooked when the metric was created. A future version of operator-custom-metrics will register a list of Collectors, so eventually this will no longer be an issue