### PR TITLE
[WIP] Set policy for Federation Token request

### DIFF
--- a/pkg/controller/account/credentials_rotator.go
+++ b/pkg/controller/account/credentials_rotator.go
@@ -51,7 +51,7 @@ func (r *ReconcileAccount) RotateCredentials(reqLogger logr.Logger, awsSetupClie
 
 	// Set IAM policy for Web Console login, this policy cannot grant more permissions than the IAM user has which creates it
 
-	SREConsoleLoginURL, err := RequestSigninToken(reqLogger, SREAWSClient, &SigninTokenDuration, &STSUserName, IAMPolicyDescriptors, STSCredentials)
+	SREConsoleLoginURL, err := RequestSigninToken(reqLogger, SREAWSClient, &SigninTokenDuration, &STSUserName, &IAMAdministratorPolicy, IAMPolicyDescriptors, STSCredentials)
 	if err != nil {
 		reqLogger.Error(err, "RotateCredentials: Unable to create AWS signin token")
 		return err

--- a/pkg/controller/account/iam.go
+++ b/pkg/controller/account/iam.go
@@ -3,6 +3,7 @@ package account
 import (
 	"context"
 	"encoding/json"
+
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -23,7 +24,7 @@ type awsSigninTokenResponse struct {
 }
 
 // RequestSigninToken makes a HTTP request to retrieve a Signin Token from the federation end point
-func RequestSigninToken(reqLogger logr.Logger, awsclient awsclient.Client, DurationSeconds *int64, FederatedUserName *string, PolicyArns []*sts.PolicyDescriptorType, STSCredentials *sts.AssumeRoleOutput) (string, error) {
+func RequestSigninToken(reqLogger logr.Logger, awsclient awsclient.Client, DurationSeconds *int64, FederatedUserName *string, Policy *string, PolicyArns []*sts.PolicyDescriptorType, STSCredentials *sts.AssumeRoleOutput) (string, error) {
 
 	// // URLs for building Federated Signin queries
 	federationEndPointURL := "https://signin.aws.amazon.com/federation"
@@ -33,6 +34,7 @@ func RequestSigninToken(reqLogger logr.Logger, awsclient awsclient.Client, Durat
 	GetFederationTokenInput := sts.GetFederationTokenInput{
 		DurationSeconds: DurationSeconds,
 		Name:            FederatedUserName,
+		Policy:          Policy,
 		PolicyArns:      PolicyArns,
 	}
 

--- a/pkg/controller/account/iam.go
+++ b/pkg/controller/account/iam.go
@@ -44,7 +44,7 @@ func RequestSigninToken(reqLogger logr.Logger, awsclient awsclient.Client, Durat
 	if err != nil {
 		if awsErr, ok := err.(awserr.Error); ok {
 			// Get error details
-			reqLogger.Error(err, fmt.Sprintf("Error: %s, %s", awsErr.Code(), awsErr.Message()))
+			reqLogger.Error(err, fmt.Sprintf("Error: Failed to get Federation Token %s, %s", awsErr.Code(), awsErr.Message()))
 			return "", err
 		}
 


### PR DESCRIPTION
The `GetFederationTokenInput` struct looks like this:
```
type GetFederationTokenInput struct {
    _    struct{}    `type:"structure"`
    DurationSeconds    *int64    `min:"900" type:"integer"`
    Name    *string    `min:"2" type:"string" required:"true"`
    Policy    *string    `min:"1" type:"string"`
    PolicyArns    []*PolicyDescriptorType    `type:"list"`
}
```
This PR adds that policy to the struct during creation.