### PR TITLE
Reduce STS credential duration until we update roles

### DIFF
--- a/pkg/credentialwatcher/secretwatcher.go
+++ b/pkg/credentialwatcher/secretwatcher.go
@@ -17,9 +17,9 @@ const (
 	// STSCredentialsSuffix is the suffix applied to account.Name to create STS Secret
 	STSCredentialsSuffix = "-sre-credentials"
 	// STSCredentialsDuration Duration of STS token and Console signin URL
-	STSCredentialsDuration = 43200
+	STSCredentialsDuration = 3600
 	// STSCredentialsThreshold Time before STS credentials are recreated
-	STSCredentialsThreshold = 7200
+	STSCredentialsThreshold = 60
 )
 
 // SecretWatcher global var for SecretWatcher


### PR DESCRIPTION
We are unable to increase the `STSCredentialDuration` to over an hour until we update the roles maximum session duration. This change will require a larger amount of work, this gets the credentials working.