### PR TITLE
SREP-1792: Add extra protections to aws client

### DIFF
--- a/pkg/awsclient/client.go
+++ b/pkg/awsclient/client.go
@@ -201,7 +201,11 @@ func (c *awsClient) GetCallerIdentity(input *sts.GetCallerIdentityInput) (*sts.G
 }
 
 func (c *awsClient) GetFederationToken(input *sts.GetFederationTokenInput) (*sts.GetFederationTokenOutput, error) {
-	return c.stsClient.GetFederationToken(input)
+	GetFederationTokenOutput, err := c.stsClient.GetFederationToken(input)
+	if GetFederationTokenOutput != nil {
+		return GetFederationTokenOutput, err
+	}
+	return &sts.GetFederationTokenOutput{}, err
 }
 
 func (c *awsClient) ListBuckets(input *s3.ListBucketsInput) (*s3.ListBucketsOutput, error) {


### PR DESCRIPTION
Extra checks to make sure that aws-acccount-operator code never uses a nil pointer. If a segfault still happens, then we can assume its coming from the aws library code. 