### PR TITLE
Revert "Modified Reuse metric to include ID"

### DIFF
--- a/pkg/localmetrics/localmetrics.go
+++ b/pkg/localmetrics/localmetrics.go
@@ -60,7 +60,7 @@ var (
 	}, []string{"name"})
 	MetricTotalAccountReusedAvailable = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Name: "aws_account_operator_total_aws_account_reused_available",
-		Help: "Report the number of reused accounts available for claiming grouped by legal ID",
+		Help: "Report the number of reused accounts available for claiming",
 	}, []string{"name"})
 	MetricTotalAccountReuseFailed = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Name: "aws_account_operator_total_aws_account_reused_failed",
@@ -97,14 +97,7 @@ func UpdateAccountCRMetrics(accountList *awsv1alpha1.AccountList) {
 	reuseAccountFailedCount := 0
 	pendingVerificationAccountCount := 0
 	readyAccountCount := 0
-	idMap := make(map[string]int)
 	for _, account := range accountList.Items {
-		if idMap[account.Spec.LegalEntity.ID] == 0 {
-			idMap[account.Spec.LegalEntity.ID] = 1
-		} else {
-			idMap[account.Spec.LegalEntity.ID] = idMap[account.Spec.LegalEntity.ID] + 1
-		}
-
 		if account.Status.Claimed == false {
 			// Ignore unclaimed accounts in Failed status
 			if account.Status.State != "Failed" {
@@ -143,11 +136,8 @@ func UpdateAccountCRMetrics(accountList *awsv1alpha1.AccountList) {
 	MetricTotalAccountPendingVerification.With(prometheus.Labels{"name": "aws-account-operator"}).Set(float64(pendingVerificationAccountCount))
 	MetricTotalAccountCRsFailed.With(prometheus.Labels{"name": "aws-account-operator"}).Set(float64(failedAccountCount))
 	MetricTotalAccountCRsReady.With(prometheus.Labels{"name": "aws-account-operator"}).Set(float64(readyAccountCount))
+	MetricTotalAccountReusedAvailable.With(prometheus.Labels{"name": "aws-account-operator"}).Set(float64(reusedAccountAvailableCount))
 	MetricTotalAccountReuseFailed.With(prometheus.Labels{"name": "aws-account-operator"}).Set(float64(reuseAccountFailedCount))
-	for id, val := range idMap {
-		MetricTotalAccountReusedAvailable.With(prometheus.Labels{"LegalID": id}).Set(float64(val))
-	}
-
 }
 
 // UpdateAccountClaimMetrics updates all metrics related to AccountClaim CRs


### PR DESCRIPTION
Reverts openshift/aws-account-operator#119 - This PR is causing the operator to crash, reverting until we have tested fix.