### PR TITLE
New fix for adding LegalID to Reuse Metric

### DIFF
--- a/pkg/localmetrics/localmetrics.go
+++ b/pkg/localmetrics/localmetrics.go
@@ -59,9 +59,10 @@ var (
 		Help: "Report the number of accounts waiting for enterprise support and EC2 limit increases in AWS",
 	}, []string{"name"})
 	MetricTotalAccountReusedAvailable = prometheus.NewGaugeVec(prometheus.GaugeOpts{
-		Name: "aws_account_operator_total_aws_account_reused_available",
-		Help: "Report the number of reused accounts available for claiming",
-	}, []string{"name"})
+		Name:        "aws_account_operator_total_aws_account_reused_available",
+		Help:        "Report the number of reused accounts available for claiming grouped by legal ID",
+		ConstLabels: prometheus.Labels{"name": "aws-account-operator"},
+	}, []string{"LegalID"})
 	MetricTotalAccountReuseFailed = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Name: "aws_account_operator_total_aws_account_reused_failed",
 		Help: "Report the number of accounts that failed during account reuse",
@@ -97,7 +98,13 @@ func UpdateAccountCRMetrics(accountList *awsv1alpha1.AccountList) {
 	reuseAccountFailedCount := 0
 	pendingVerificationAccountCount := 0
 	readyAccountCount := 0
+	idMap := make(map[string]int)
 	for _, account := range accountList.Items {
+		if idMap[account.Spec.LegalEntity.ID] == 0 {
+			idMap[account.Spec.LegalEntity.ID] = 1
+		} else {
+			idMap[account.Spec.LegalEntity.ID] = idMap[account.Spec.LegalEntity.ID] + 1
+		}
 		if account.Status.Claimed == false {
 			// Ignore unclaimed accounts in Failed status
 			if account.Status.State != "Failed" {
@@ -136,8 +143,10 @@ func UpdateAccountCRMetrics(accountList *awsv1alpha1.AccountList) {
 	MetricTotalAccountPendingVerification.With(prometheus.Labels{"name": "aws-account-operator"}).Set(float64(pendingVerificationAccountCount))
 	MetricTotalAccountCRsFailed.With(prometheus.Labels{"name": "aws-account-operator"}).Set(float64(failedAccountCount))
 	MetricTotalAccountCRsReady.With(prometheus.Labels{"name": "aws-account-operator"}).Set(float64(readyAccountCount))
-	MetricTotalAccountReusedAvailable.With(prometheus.Labels{"name": "aws-account-operator"}).Set(float64(reusedAccountAvailableCount))
 	MetricTotalAccountReuseFailed.With(prometheus.Labels{"name": "aws-account-operator"}).Set(float64(reuseAccountFailedCount))
+	for id, val := range idMap {
+		MetricTotalAccountReusedAvailable.With(prometheus.Labels{"LegalID": id}).Set(float64(val))
+	}
 }
 
 // UpdateAccountClaimMetrics updates all metrics related to AccountClaim CRs


### PR DESCRIPTION
Added legalID to reuse metric so that the number of available reused accounts are grouped by ID. Also fixed label issues that were causing problems in other PR. There is now a label for the LegalID in the metric itself, and the name label is just a const label in the metric definition. 