### PR TITLE
 SREP-1950 - Fix for CI clusters burning accounts

### DIFF
--- a/pkg/controller/accountclaim/accountclaim_controller.go
+++ b/pkg/controller/accountclaim/accountclaim_controller.go
@@ -145,6 +145,7 @@ func (r *ReconcileAccountClaim) Reconcile(request reconcile.Request) (reconcile.
 			}
 
 		}
+		return reconcile.Result{}, nil
 	}
 
 	// Return if this claim has been satisfied


### PR DESCRIPTION
Fix for bug that was causing ci clusters to burn accounts, because their accountClaim was being created and deleted too fast (before an account could be assigned).

At the end of the finalizer block, there was a missing return, making the operator claim an account right after deleting the accountClaim, leaving an orphaned account behind.