### PR TITLE
Created Go Routine to update total AWS Accounts every N hours

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -27,9 +27,10 @@ import (
 
 // Change below variables to serve metrics on different host or port.
 var (
-	metricsPort               = "8080"
-	metricsPath               = "/metrics"
-	secretWatcherScanInterval = time.Duration(10) * time.Minute
+	metricsPort                   = "8080"
+	metricsPath                   = "/metrics"
+	secretWatcherScanInterval     = time.Duration(10) * time.Minute
+	hours                     int = 1
 )
 
 var log = logf.Log.WithName("cmd")
@@ -137,6 +138,8 @@ func main() {
 
 	// Start the secret watcher
 	go credentialwatcher.SecretWatcher.Start(log, stopCh)
+
+	go localmetrics.UpdateAWSMetrics(mgr.GetClient(), hours)
 
 	log.Info("Starting the Cmd.")
 

--- a/pkg/controller/account/account_controller.go
+++ b/pkg/controller/account/account_controller.go
@@ -18,7 +18,6 @@ import (
 	awsv1alpha1 "github.com/openshift/aws-account-operator/pkg/apis/aws/v1alpha1"
 	"github.com/openshift/aws-account-operator/pkg/awsclient"
 	controllerutils "github.com/openshift/aws-account-operator/pkg/controller/utils"
-	"github.com/openshift/aws-account-operator/pkg/localmetrics"
 	corev1 "k8s.io/api/core/v1"
 	k8serr "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -42,7 +41,7 @@ const (
 	awsCredsSecretAccessKey = "aws_secret_access_key"
 	iamUserNameUHC          = "osdManagedAdmin"
 	iamUserNameSRE          = "osdManagedAdminSRE"
-	awsSecretName           = "aws-account-operator-credentials"
+	AwsSecretName           = "aws-account-operator-credentials"
 	awsAMI                  = "ami-000db10762d0c4c05"
 	awsInstanceType         = "t2.micro"
 	createPendTime          = 10 * time.Minute
@@ -244,7 +243,7 @@ func (r *ReconcileAccount) Reconcile(request reconcile.Request) (reconcile.Resul
 
 	// We expect this secret to exist in the same namespace Account CR's are created
 	awsSetupClient, err := awsclient.GetAWSClient(r.Client, awsclient.NewAwsClientInput{
-		SecretName: awsSecretName,
+		SecretName: AwsSecretName,
 		NameSpace:  awsv1alpha1.AccountCrNamespace,
 		AwsRegion:  "us-east-1",
 	})
@@ -340,8 +339,6 @@ func (r *ReconcileAccount) Reconcile(request reconcile.Request) (reconcile.Resul
 			reqLogger.Info("Failed to get AWS account total from AWS api", "Error", err.Error())
 			return reconcile.Result{}, err
 		}
-
-		localmetrics.UpdateAWSMetrics(accountTotal)
 
 		if accountTotal >= awsLimit {
 			reqLogger.Error(ErrAwsAccountLimitExceeded, "AWS Account limit reached", "Account Total", accountTotal)


### PR DESCRIPTION
Added Go routine in main.go to update the total number of AWS account every hour. Moved logic of updating this number to local metrics file so that total number is calculated in local metrics. The API call still needs to be tested however 