### PR TITLE
Explicitly support * on accountpools

### DIFF
--- a/deploy/cluster_role.yaml
+++ b/deploy/cluster_role.yaml
@@ -44,6 +44,7 @@ rules:
   - '*'
   - accountclaims
   - accounts
+  - accountpools
   verbs:
   - '*'
 - apiGroups:


### PR DESCRIPTION
I don't think this is required, but being explicit with RBAC is probably a safer bet. 