### PR TITLE
Fix formatting and spelling

### DIFF
--- a/pkg/controller/account/credentials_rotator.go
+++ b/pkg/controller/account/credentials_rotator.go
@@ -62,7 +62,8 @@ func (r *ReconcileAccount) RotateCredentials(reqLogger logr.Logger, awsSetupClie
 	err = r.Client.Get(context.TODO(), types.NamespacedName{Name: STSCredentialsSecretName, Namespace: awsv1alpha1.AccountCrNamespace}, STSSecret)
 
 	if err != nil {
-		reqLogger.Error(err, "Error retriving secret %s", STSCredentialsSecretName)
+		errMsg := fmt.Sprintf("Error retrieving secret %s", STSCredentialsSecretName)
+		reqLogger.Error(err, errMsg)
 		return err
 	}
 


### PR DESCRIPTION
https://jira.coreos.com/browse/SREP-2034

The following error statement in account controller is not correctly formatted and has a typo

https://github.com/openshift/aws-account-operator/blob/master/pkg/controller/account/credentials_rotator.go#L65