### PR TITLE
Add permissive option to image registry initializer

### DIFF
--- a/hack/app_sre_create_image_catalog.sh
+++ b/hack/app_sre_create_image_catalog.sh
@@ -94,7 +94,7 @@ cat <<EOF > $DOCKERFILE_REGISTRY
 FROM quay.io/openshift/origin-operator-registry:latest
 
 COPY $SAAS_OPERATOR_DIR manifests
-RUN initializer
+RUN initializer --permissive
 
 CMD ["registry-server", "-t", "/tmp/terminate.log"]
 EOF


### PR DESCRIPTION
This PR adds the `--permissive` flag to the image registry docker build to ignore errors when loading and initializing the OLM bundles restoring the behavior the image registry initializer had before this PR https://github.com/operator-framework/operator-registry/pull/74

This option should be removed once https://github.com/operator-framework/operator-registry/pull/76 is merged which fixes the initial issue where the initalizer attempts to parse any file as JSON or YAML.

This should be considered temporary to fix our Jenkins builds until the above is complete.