### PR TITLE
Make accountpool account CR creation more verbose

### DIFF
--- a/pkg/controller/accountpool/accountpool_controller.go
+++ b/pkg/controller/accountpool/accountpool_controller.go
@@ -157,6 +157,7 @@ func (r *ReconcileAccountPool) Reconcile(request reconcile.Request) (reconcile.R
 		return reconcile.Result{}, err
 	}
 
+	reqLogger.Info(fmt.Sprintf("Creating account for accountpool. Unlaimed accounts: %d, poolsize%d", unclaimedAccountCount, poolSizeCount))
 	err = r.client.Create(context.TODO(), newAccount)
 	if err != nil {
 		return reconcile.Result{}, err


### PR DESCRIPTION
There's no a lot of clarity into when and why the accountpool controller is creating accounts. Added a logging line so we can see exactly when the controller is creating account CRs and what the unclaimed account and pool size counts are so we can easily see if there's a bug or something