### PR TITLE
Handle and log errors in localmetrics

### DIFF
--- a/pkg/controller/account/account_controller.go
+++ b/pkg/controller/account/account_controller.go
@@ -817,7 +817,11 @@ func TotalAwsAccounts(client awsclient.Client) (int, error) {
 	for {
 		awsAccountList, err := client.ListAccounts(&organizations.ListAccountsInput{NextToken: nextToken})
 		if err != nil {
-			return 0, errors.New("Error getting a list of accounts")
+			errMsg := "Error getting a list of accounts"
+			if aerr, ok := err.(awserr.Error); ok {
+				errMsg = fmt.Sprintf("Failed to get account list with error code %s", aerr.Message())
+			}
+			return 0, errors.New(errMsg)
 		}
 		awsAccounts = append(awsAccounts, awsAccountList.Accounts...)
 		if awsAccountList.NextToken != nil {


### PR DESCRIPTION
The aws-account-operator total number of AWS account metric is showing 0 occasionally, I suspect this is due to the API returning the "TooManyRequestsException" error (which we've experienced before) and then returning 0

Maybe we want to parse the returning API error?

https://github.com/openshift/aws-account-operator/blob/master/pkg/controller/account/account_controller.go#L820

This only merged in staging, we want to resolve this before our next prod push

https://jira.coreos.com/browse/SREP-2108

Along with this, I updated the other error handing case in metrics. 