### PR TITLE
Explicitly call out namespace in clusterrolebinding

### DIFF
--- a/deploy/cluster_role_binding.yaml
+++ b/deploy/cluster_role_binding.yaml
@@ -6,7 +6,7 @@ subjects:
 - kind: ServiceAccount
   name: aws-account-operator
   # Replace this with the namespace the operator is deployed in.
-  namespace: REPLACE_NAMESPACE
+  namespace: aws-account-operator
 roleRef:
   kind: ClusterRole
   name: aws-account-operator


### PR DESCRIPTION
Since the operator and therefore the service account is always in the `aws-account-operator` namespace by convention, I want to make this explicit as its the only bit that needs replacing when deploying the operator. 