### PR TITLE
Fix removal of subresouces in CRD

### DIFF
--- a/deploy/crds/aws_v1alpha1_account_crd.yaml
+++ b/deploy/crds/aws_v1alpha1_account_crd.yaml
@@ -23,6 +23,8 @@ spec:
     plural: accounts
     singular: account
   scope: Namespaced
+  subresources:
+    status: {}
   validation:
     openAPIV3Schema:
       properties:

--- a/deploy/crds/aws_v1alpha1_accountclaim_crd.yaml
+++ b/deploy/crds/aws_v1alpha1_accountclaim_crd.yaml
@@ -20,6 +20,8 @@ spec:
     plural: accountclaims
     singular: accountclaim
   scope: Namespaced
+  subresources:
+    status: {}
   validation:
     openAPIV3Schema:
       properties:

--- a/deploy/crds/aws_v1alpha1_accountpool_crd.yaml
+++ b/deploy/crds/aws_v1alpha1_accountpool_crd.yaml
@@ -20,6 +20,8 @@ spec:
     plural: accountpools
     singular: accountpool
   scope: Namespaced
+  subresources:
+    status: {}
   validation:
     openAPIV3Schema:
       properties:

--- a/pkg/apis/aws/v1alpha1/account_types.go
+++ b/pkg/apis/aws/v1alpha1/account_types.go
@@ -98,6 +98,7 @@ const (
 
 // Account is the Schema for the accounts API
 // +k8s:openapi-gen=true
+// +kubebuilder:subresource:status
 type Account struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/pkg/apis/aws/v1alpha1/accountclaim_types.go
+++ b/pkg/apis/aws/v1alpha1/accountclaim_types.go
@@ -75,6 +75,7 @@ const (
 
 // AccountClaim is the Schema for the accountclaims API
 // +k8s:openapi-gen=true
+// +kubebuilder:subresource:status
 type AccountClaim struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/pkg/apis/aws/v1alpha1/accountpool_types.go
+++ b/pkg/apis/aws/v1alpha1/accountpool_types.go
@@ -32,6 +32,7 @@ type AccountPoolStatus struct {
 
 // AccountPool is the Schema for the accountpools API
 // +k8s:openapi-gen=true
+// +kubebuilder:subresource:status
 type AccountPool struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`


### PR DESCRIPTION
The subresouces section of the CRDs were removed after a regen in this commit:
https://github.com/openshift/aws-account-operator/commit/a7f123f83ceb78bff2a7441add844c56fbb8821e#diff-85bc3ddf6b56ff3826c09f368b0f6293

However, this removal causes bugs in the operator. A similar issue was found here: https://github.com/kubernetes-sigs/kubebuilder/issues/751

What likely happened was operator-sdk enabled that option (`+kubebuilder:subresource:status`) behind the scenes before but with a new updated disabled it. So when the CRDs were generated with a newer version, the subresources field was removed. The fix is to explicitly add that option to the CRD types in Go and regenerate the CRDs