### PR TITLE
add permissions to uhc-cluster-role

### DIFF
--- a/deploy/uhc_cluster_role.yaml
+++ b/deploy/uhc_cluster_role.yaml
@@ -13,3 +13,16 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - create


### PR DESCRIPTION
As part of OCM migration to `controller-runtime`, we need to have permissions to create events and create and get configmaps. This is done only in a dedicated namespaces called `uhc-leadership`.