### PR TITLE
Add update the UHC rbac policy for ConfigMaps

### DIFF
--- a/deploy/uhc_cluster_role.yaml
+++ b/deploy/uhc_cluster_role.yaml
@@ -26,3 +26,4 @@ rules:
   verbs:
   - get
   - create
+  - update


### PR DESCRIPTION
This PR attempts to fix an issue where the UHC service account cannot update ConfigMaps.

```
User "system:serviceaccount:aws-account-operator:aws-account-operator-client" cannot update configmaps in the namespace "uhc-leadership": no RBAC policy matched.
```