### PR TITLE
Move check for awslimit outside of reconcile.

### DIFF
--- a/pkg/controller/utils/conditions.go
+++ b/pkg/controller/utils/conditions.go
@@ -255,3 +255,7 @@ func FindAWSFederatedAccountAccessCondition(conditions []awsv1alpha1.AWSFederate
 	}
 	return nil
 }
+
+const (
+	AwsSecretName = "aws-account-operator-credentials"
+)

--- a/pkg/localmetrics/localmetrics.go
+++ b/pkg/localmetrics/localmetrics.go
@@ -15,16 +15,11 @@
 package localmetrics
 
 import (
-	"fmt"
 	"math"
 	"sync"
-	"time"
 
 	awsv1alpha1 "github.com/openshift/aws-account-operator/pkg/apis/aws/v1alpha1"
-	"github.com/openshift/aws-account-operator/pkg/awsclient"
-	"github.com/openshift/aws-account-operator/pkg/controller/account"
 	"github.com/prometheus/client_golang/prometheus"
-	kubeclientpkg "sigs.k8s.io/controller-runtime/pkg/client"
 	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
 )
 
@@ -91,33 +86,6 @@ var (
 		MetricTotalAccountReuseFailed,
 	}
 )
-
-// UpdateAWSMetrics updates the total AWS Accounts metric every N hours
-func UpdateAWSMetrics(kubeClient kubeclientpkg.Client, hour int) {
-	metricLogger := log.WithValues("Namespace", "aws-account-operator-operator")
-
-	awsClient, err := awsclient.GetAWSClient(kubeClient, awsclient.NewAwsClientInput{
-		SecretName: account.AwsSecretName,
-		NameSpace:  awsv1alpha1.AccountCrNamespace,
-		AwsRegion:  "us-east-1",
-	})
-
-	if err != nil {
-		metricLogger.Error(err, "Failed to get awsClient")
-		return
-	}
-
-	d := time.Duration(hour) * time.Hour
-	for range time.Tick(d) {
-		accountTotal, err := account.TotalAwsAccounts(awsClient)
-
-		if err != nil {
-			metricLogger.Error(err, fmt.Sprintf("Failed to get total number of AWS accounts: %s", err))
-		} else {
-			MetricTotalAWSAccounts.With(prometheus.Labels{"name": "aws-account-operator"}).Set(float64(accountTotal))
-		}
-	}
-}
 
 // UpdateAccountCRUnclaimedMetric updates the unclaimed account metric
 func UpdateAccountCRUnclaimedMetric(accountList awsv1alpha1.AccountList, wg *sync.WaitGroup) {

--- a/pkg/totalaccountwatcher/totalaccountwatcher.go
+++ b/pkg/totalaccountwatcher/totalaccountwatcher.go
@@ -1,0 +1,125 @@
+package totalaccountwatcher
+
+import (
+	"errors"
+	"fmt"
+	"time"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
+
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/service/organizations"
+	"github.com/go-logr/logr"
+	awsv1alpha1 "github.com/openshift/aws-account-operator/pkg/apis/aws/v1alpha1"
+	"github.com/openshift/aws-account-operator/pkg/awsclient"
+	controllerutils "github.com/openshift/aws-account-operator/pkg/controller/utils"
+	"github.com/openshift/aws-account-operator/pkg/localmetrics"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// ErrAwsAccountLimitExceeded indicates the orgnization account limit has been reached.
+var ErrAwsAccountLimitExceeded = errors.New("AccountLimitExceeded")
+
+// TotalAccountWatcher global var for TotalAccountWatcher
+var TotalAccountWatcher *totalAccountWatcher
+
+var log = logf.Log.WithName("aws-account-operator")
+
+type totalAccountWatcher struct {
+	watchInterval time.Duration
+	AwsClient     awsclient.Client
+	client        client.Client
+	Total         int
+}
+
+// Initialize creates a global instance of the TotalAccountWatcher
+func Initialize(client client.Client, watchInterval time.Duration) {
+	log.Info("Initializing the totalAccountWatcher")
+
+	AwsClient, err := awsclient.GetAWSClient(client, awsclient.NewAwsClientInput{
+		SecretName: controllerutils.AwsSecretName,
+		NameSpace:  awsv1alpha1.AccountCrNamespace,
+		AwsRegion:  "us-east-1",
+	})
+
+	if err != nil {
+		log.Error(err, "Failed to get AwsClient")
+		return
+	}
+
+	TotalAccountWatcher = NewTotalAccountWatcher(client, AwsClient, watchInterval)
+	TotalAccountWatcher.UpdateTotalAccounts(log)
+}
+
+// NewTotalAccountWatcher returns a new instance of the TotalAccountWatcher interface
+func NewTotalAccountWatcher(client client.Client, AwsClient awsclient.Client, watchInterval time.Duration) *totalAccountWatcher {
+	return &totalAccountWatcher{
+		watchInterval: watchInterval,
+		AwsClient:     AwsClient,
+		client:        client,
+	}
+}
+
+// TotalAccountWatcher will trigger AwsLimitUpdate every `scanInternal` and only stop if the operator is killed or a
+// message is sent on the stopCh
+func (s *totalAccountWatcher) Start(log logr.Logger, stopCh <-chan struct{}) {
+	log.Info("Starting the totalAccountWatcher")
+	for {
+		select {
+		case <-time.After(s.watchInterval):
+			err := s.UpdateTotalAccounts(log)
+			if err != nil {
+				log.Error(err, "totalAccountWatcher not started, awsLimit won't be updated")
+			}
+		case <-stopCh:
+			log.Info("Stopping the totalAccountWatcher")
+			break
+		}
+	}
+}
+
+// UpdateTotalAccounts will update the TotalAccountWatcher's total field
+func (s *totalAccountWatcher) UpdateTotalAccounts(log logr.Logger) error {
+
+	accountTotal, err := TotalAwsAccounts()
+	if err != nil {
+		log.Error(err, "Failed to get account list with error code %s")
+	}
+
+	localmetrics.MetricTotalAWSAccounts.With(prometheus.Labels{"name": "aws-account-operator"}).Set(float64(accountTotal))
+
+	if accountTotal != TotalAccountWatcher.Total {
+		log.Info(fmt.Sprintf("Updating total from %d to %d", TotalAccountWatcher.Total, accountTotal))
+		TotalAccountWatcher.Total = accountTotal
+	}
+
+	return nil
+}
+
+// TotalAwsAccounts returns the total number of aws accounts in the aws org
+func TotalAwsAccounts() (int, error) {
+	var nextToken *string
+
+	accountTotal := 0
+	// Ensure we paginate through the account list
+	for {
+		awsAccountList, err := TotalAccountWatcher.AwsClient.ListAccounts(&organizations.ListAccountsInput{NextToken: nextToken})
+		if err != nil {
+			errMsg := "Error getting a list of accounts"
+			if aerr, ok := err.(awserr.Error); ok {
+				errMsg = aerr.Message()
+			}
+			return TotalAccountWatcher.Total, errors.New(errMsg)
+		}
+		accountTotal += len(awsAccountList.Accounts)
+
+		if awsAccountList.NextToken != nil {
+			nextToken = awsAccountList.NextToken
+		} else {
+			break
+		}
+	}
+
+	return accountTotal, nil
+}

--- a/pkg/totalaccountwatcher/totalaccountwatcher_test.go
+++ b/pkg/totalaccountwatcher/totalaccountwatcher_test.go
@@ -1,9 +1,10 @@
-package account
+package totalaccountwatcher
 
 import (
 	"errors"
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 
 	"github.com/aws/aws-sdk-go/service/organizations"
 
@@ -12,6 +13,7 @@ import (
 	mockAWS "github.com/openshift/aws-account-operator/pkg/awsclient/mock"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
 	fakekubeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
@@ -111,7 +113,9 @@ func TestTotalAwsAccounts(t *testing.T) {
 			defer mocks.mockCtrl.Finish()
 
 			// Act
-			total, err := TotalAwsAccounts(mocks.mockAWSClient)
+			TotalAccountWatcher = NewTotalAccountWatcher(mocks.fakeKubeClient, mocks.mockAWSClient, 10)
+			TotalAccountWatcher.AwsClient = mocks.mockAWSClient
+			total, err := TotalAwsAccounts()
 
 			// Assert
 			if test.errorExpected {
@@ -130,12 +134,3 @@ func TestTotalAwsAccounts(t *testing.T) {
 		})
 	}
 }
-
-// used to create the reconcile
-// raws := &ReconcileAccount{
-// 	Client: mocks.fakeKubeClient,
-// 	scheme: scheme.Scheme,
-// 	awsClientBuilder: func(string, string, string, string) (awsclient.Client, error) {
-// 		return mocks.mockAWSClient, nil
-// 	},
-// }


### PR DESCRIPTION
https://jira.coreos.com/browse/SREP-2163
Currently the aws-account-operator will check the total number of created accounts when an account CR has `.status.state` as "" and `.status.claimed` as false.

We should do this independently of the reconcile loop and run it on a timer since we consistently hit API errors from AWS blocking the controller as well as blocking the refreshing of already created accounts. We would do this similar to the way we're updating the localmetics in main.go.

The problem is that we need to check this against the awsLimit var so that we don't create too many accounts. Should we create an internal counter too that is refreshed on every update from AWS?

Done criteria:
- Checking of total number of AWS accounts is done outside the loop
- We need to observe awsLimit until we implement some rate limiting when creating accounts