### PR TITLE
Update to operator-custom-metrics v0.2.1

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -80,6 +80,7 @@
     "service/organizations/organizationsiface",
     "service/s3",
     "service/s3/s3iface",
+    "service/s3/s3manager",
     "service/sts",
     "service/sts/stsiface",
     "service/support",
@@ -390,12 +391,12 @@
   version = "v3.9.0"
 
 [[projects]]
-  branch = "master"
-  digest = "1:eb16e059ec17378bcab2d67bff2dbe95dec98f151e496f4a29a6a34d25060129"
+  digest = "1:c67dd573eb0c047dc1036884e264e69dd44b9b07bab1482ea1cd7cb760e91599"
   name = "github.com/openshift/operator-custom-metrics"
   packages = ["pkg/metrics"]
   pruneopts = "NT"
-  revision = "b20490a1cf8bda14d129cfea17c1cf6781d9c3e6"
+  revision = "6a7c3bd8b210d68dac10a3130c19f64d40eb8556"
+  version = "v0.2.1"
 
 [[projects]]
   digest = "1:df8e741cd0f86087367f3bcfeb1cf237e96fada71194b6d4cee9412d221ec763"
@@ -1030,6 +1031,7 @@
     "github.com/aws/aws-sdk-go/service/organizations/organizationsiface",
     "github.com/aws/aws-sdk-go/service/s3",
     "github.com/aws/aws-sdk-go/service/s3/s3iface",
+    "github.com/aws/aws-sdk-go/service/s3/s3manager",
     "github.com/aws/aws-sdk-go/service/sts",
     "github.com/aws/aws-sdk-go/service/sts/stsiface",
     "github.com/aws/aws-sdk-go/service/support",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -56,6 +56,10 @@ required = [
   name = "sigs.k8s.io/controller-runtime"
   version = "=v0.1.10"
 
+[[override]]
+  name = "github.com/openshift/operator-custom-metrics"
+  version = "=v0.2.1"
+
 [[constraint]]
   name = "github.com/operator-framework/operator-sdk"
   # The version rule is used for a specific release and the master branch for in between releases.

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -110,22 +110,14 @@ func main() {
 
 	//Create metrics endpoint and register metrics
 	metricsServer := metrics.NewBuilder().WithPort(metricsPort).WithPath(metricsPath).
-		WithCollectors(localmetrics.MetricTotalAWSAccounts).
-		WithCollectors(localmetrics.MetricTotalAccountCRs).
-		WithCollectors(localmetrics.MetricTotalAccountCRsUnclaimed).
-		WithCollectors(localmetrics.MetricTotalAccountCRsClaimed).
-		WithCollectors(localmetrics.MetricTotalAccountCRsFailed).
-		WithCollectors(localmetrics.MetricTotalAccountCRsReady).
-		WithCollectors(localmetrics.MetricTotalAccountClaimCRs).
-		WithCollectors(localmetrics.MetricPoolSizeVsUnclaimed).
-		WithCollectors(localmetrics.MetricTotalAccountPendingVerification).
-		WithCollectors(localmetrics.MetricTotalAccountReusedAvailable).
-		WithCollectors(localmetrics.MetricTotalAccountReuseFailed).
+		WithCollectors(localmetrics.MetricsList).
+		WithRoute().
 		GetConfig()
 
 	// Configure metrics if it errors log the error but continue
 	if err := metrics.ConfigureMetrics(context.TODO(), *metricsServer); err != nil {
 		log.Error(err, "Failed to configure Metrics")
+		os.Exit(1)
 	}
 
 	// Define stopCh which we'll use to notify the secretWatcher (any any other routine)

--- a/vendor/github.com/openshift/operator-custom-metrics/pkg/metrics/builder.go
+++ b/vendor/github.com/openshift/operator-custom-metrics/pkg/metrics/builder.go
@@ -6,6 +6,7 @@ import "github.com/prometheus/client_golang/prometheus"
 const (
 	defaultMetricsPath = "/customMetrics"
 	defaultMetricsPort = "8089"
+	defaultServiceName = "operator-metrics"
 )
 
 // metricsConfigBuilder builds a new metricsConfig object.
@@ -13,17 +14,14 @@ type metricsConfigBuilder struct {
 	config metricsConfig
 }
 
-// convertmetrics is a user-defined function, indicating how the metrics are collected.
-type convertMetrics func()
-
 // NewBuilder sets the default values to the metricsConfig object.
 func NewBuilder() *metricsConfigBuilder {
 	return &metricsConfigBuilder{
 		config: metricsConfig{
-			metricsPath:           defaultMetricsPath,
-			metricsPort:           defaultMetricsPort,
-			collectorList:         nil,
-			recordMetricsFunction: nil,
+			metricsPath:   defaultMetricsPath,
+			metricsPort:   defaultMetricsPort,
+			serviceName:   defaultServiceName,
+			collectorList: nil,
 		},
 	}
 }
@@ -45,8 +43,14 @@ func (b *metricsConfigBuilder) WithPath(path string) *metricsConfigBuilder {
 	return b
 }
 
-// WithCollectors appends the prometheus-collector provided by the user to a list of Collectors.
-func (b *metricsConfigBuilder) WithCollectors(collector prometheus.Collector) *metricsConfigBuilder {
+//WithName specifies the name of the service
+func (b *metricsConfigBuilder) WithServiceName(name string) *metricsConfigBuilder {
+	b.config.serviceName = name
+	return b
+}
+
+// WithCollector appends the prometheus-collector provided by the user to a list of Collectors.
+func (b *metricsConfigBuilder) WithCollector(collector prometheus.Collector) *metricsConfigBuilder {
 	if b.config.collectorList == nil {
 		b.config.collectorList = make([]prometheus.Collector, 0)
 	}
@@ -54,8 +58,18 @@ func (b *metricsConfigBuilder) WithCollectors(collector prometheus.Collector) *m
 	return b
 }
 
-// WithMetricsFunction updates the configuration with the user-defined function to update the metrics.
-func (b *metricsConfigBuilder) WithMetricsFunction(recordMetricsFunction convertMetrics) *metricsConfigBuilder {
-	b.config.recordMetricsFunction = recordMetricsFunction
+// WithCollectors updates the collectorList to the list of collectors provided by the user.
+func (b *metricsConfigBuilder) WithCollectors(collectors []prometheus.Collector) *metricsConfigBuilder {
+	b.config.collectorList = collectors
+	return b
+}
+
+func (b *metricsConfigBuilder) WithRoute() *metricsConfigBuilder {
+	b.config.withRoute = true
+	return b
+}
+
+func (b *metricsConfigBuilder) WithServiceMonitor() *metricsConfigBuilder {
+	b.config.withServiceMonitor = true
 	return b
 }

--- a/vendor/github.com/openshift/operator-custom-metrics/pkg/metrics/metrics.go
+++ b/vendor/github.com/openshift/operator-custom-metrics/pkg/metrics/metrics.go
@@ -15,6 +15,7 @@
 package metrics
 
 import (
+	"fmt"
 	"net/http"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -27,13 +28,8 @@ func StartMetrics(config metricsConfig) {
 		RegisterMetrics(config.collectorList)
 	}
 
-	// Execute recordMetricsFunction if provided by the user
-	if config.recordMetricsFunction != nil {
-		config.recordMetricsFunction()
-	}
-
 	http.Handle(config.metricsPath, prometheus.Handler())
-	log.Info("Port: %v", config.metricsPort)
+	log.Info(fmt.Sprintf("Port: %s", config.metricsPort))
 	metricsPort := ":" + (config.metricsPort)
 	go http.ListenAndServe(metricsPort, nil)
 }

--- a/vendor/github.com/openshift/operator-custom-metrics/pkg/metrics/metricsconfig.go
+++ b/vendor/github.com/openshift/operator-custom-metrics/pkg/metrics/metricsconfig.go
@@ -4,8 +4,10 @@ import "github.com/prometheus/client_golang/prometheus"
 
 // metricsConfig allows user to specify how to send information to the prometheus instance.
 type metricsConfig struct {
-	metricsPath           string
-	metricsPort           string
-	collectorList         []prometheus.Collector
-	recordMetricsFunction convertMetrics
+	metricsPath        string
+	metricsPort        string
+	serviceName        string
+	collectorList      []prometheus.Collector
+	withRoute          bool
+	withServiceMonitor bool
 }

--- a/vendor/github.com/openshift/operator-custom-metrics/pkg/metrics/service.go
+++ b/vendor/github.com/openshift/operator-custom-metrics/pkg/metrics/service.go
@@ -16,6 +16,7 @@ package metrics
 
 import (
 	"context"
+	"fmt"
 	"strconv"
 
 	monitoringv1 "github.com/coreos/prometheus-operator/pkg/apis/monitoring/v1"
@@ -36,7 +37,7 @@ var (
 )
 
 // GenerateService returns the static service at specified port
-func GenerateService(port int32, portName string) (*v1.Service, error) {
+func GenerateService(port int32, portName string, serviceName string) (*v1.Service, error) {
 	operatorName, err := k8sutil.GetOperatorName()
 	if err != nil {
 		return nil, err
@@ -48,7 +49,7 @@ func GenerateService(port int32, portName string) (*v1.Service, error) {
 
 	service := &v1.Service{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      operatorName,
+			Name:      serviceName,
 			Namespace: namespace,
 			Labels:    map[string]string{"name": operatorName},
 		},
@@ -152,8 +153,9 @@ func ConfigureMetrics(ctx context.Context, userMetricsConfig metricsConfig) erro
 	if err != nil {
 		return err
 	}
+
 	res := int32(p)
-	s, svcerr := GenerateService(res, "metrics")
+	s, svcerr := GenerateService(res, "metrics", userMetricsConfig.serviceName)
 	if svcerr != nil {
 		log.Info("Error generating metrics service object.", "Error", svcerr.Error())
 		return svcerr
@@ -166,18 +168,34 @@ func ConfigureMetrics(ctx context.Context, userMetricsConfig metricsConfig) erro
 		log.Info("Error getting current metrics service", "Error", err.Error())
 		return err
 	}
-
 	log.Info("Created Service")
-	// Generate Route Object
-	r := GenerateRoute(s, userMetricsConfig.metricsPath)
-	log.Info("Generated metrics route object")
 
-	// Create or Update route
-	_, err = createOrUpdateRoute(ctx, client, r)
-	if err != nil {
-		log.Info("Error creating route", "Error", err.Error())
-		return err
+	// Generate Route Object
+	if userMetricsConfig.withRoute {
+		r := GenerateRoute(s, userMetricsConfig.metricsPath)
+		log.Info("Generated metrics route object")
+
+		// Create or Update route
+		_, err = createOrUpdateRoute(ctx, client, r)
+		if err != nil {
+			log.Info("Error creating route", "Error", err.Error())
+			return err
+		}
 	}
+
+	//Generate Service Monitor Object
+	if userMetricsConfig.withServiceMonitor {
+		sm := GenerateServiceMonitor(s)
+		log.Info("Generated metrics service monitor object")
+
+		// Create or Update Service Monitor
+		_, err = createOrUpdateServiceMonitor(ctx, client, sm)
+		if err != nil {
+			log.Info("Error creating Service Monitor", "Error", err.Error())
+			return err
+		}
+	}
+
 	return nil
 }
 
@@ -205,33 +223,69 @@ func createOrUpdateService(ctx context.Context, client client.Client, s *v1.Serv
 			log.Info("Error creating service object", "Error", err)
 			return nil, err
 		}
-		log.Info("Metrics Service object updated Service.Name %v and Service.Namespace %v", s.Name, s.Namespace)
+		log.Info(fmt.Sprintf("Metrics Service object updated Service.Name %v and Service.Namespace %v", s.Name, s.Namespace))
 		return existingService, nil
 	}
 
-	log.Info("Metrics Service object created Service.Name %v and Service.Namespace %v", s.Name, s.Namespace)
+	log.Info(fmt.Sprintf("Metrics Service object created Service.Name %v and Service.Namespace %v", s.Name, s.Namespace))
 	return s, nil
 }
 
 //createOrUpdateRoute is a function which creates or updates the route for the service object.
 func createOrUpdateRoute(ctx context.Context, client client.Client, r *routev1.Route) (*routev1.Route, error) {
-	err := client.Create(ctx, r)
-	if err != nil {
-		if k8serr.IsAlreadyExists(err) {
-			// update the Route
-			if rUpdateErr := client.Update(ctx, r); rUpdateErr != nil {
-				log.Info("Error creating metrics route", "Error", rUpdateErr.Error())
-				return nil, rUpdateErr
+	if err := client.Create(ctx, r); err != nil {
+		if err != nil {
+			if !k8serr.IsAlreadyExists(err) {
+				return nil, err
 			}
-			log.Info("Metrics route object updated", "Route.Name", r.Name, "Route.Namespace", r.Namespace)
-			return nil, nil
+
+			existingRoute := &routev1.Route{}
+			err := client.Get(ctx, types.NamespacedName{
+				Name:      r.Name,
+				Namespace: r.Namespace,
+			}, existingRoute)
+			// update the Route
+			r.ResourceVersion = existingRoute.ResourceVersion
+			if err = client.Update(ctx, r); err != nil {
+				log.Info("Error creating metrics route", "Error", err.Error())
+				return nil, err
+			}
+			log.Info(fmt.Sprintf("Metrics Route object updated Route.Name %v and Route.Namespace %v", r.Name, r.Namespace))
+			return existingRoute, nil
 		}
-		log.Info("Error creating metrics route", "Error", err.Error())
-		return nil, err
 
 	}
 	log.Info("Metrics Route object Created", "Route.Name", r.Name, "Route.Namespace", r.Namespace)
 	return r, nil
+
+}
+
+//createOrUpdateServiceMonitor is a function which creates or updates the service monitor for the servicemonitor object.
+func createOrUpdateServiceMonitor(ctx context.Context, client client.Client, sm *monitoringv1.ServiceMonitor) (*monitoringv1.ServiceMonitor, error) {
+	if err := client.Create(ctx, sm); err != nil {
+		if err != nil {
+			if !k8serr.IsAlreadyExists(err) {
+				return nil, err
+			}
+
+			existingServiceMonitor := &monitoringv1.ServiceMonitor{}
+			err := client.Get(ctx, types.NamespacedName{
+				Name:      sm.Name,
+				Namespace: sm.Namespace,
+			}, existingServiceMonitor)
+			// update the Service Monitor
+			sm.ResourceVersion = existingServiceMonitor.ResourceVersion
+			if err = client.Update(ctx, sm); err != nil {
+				log.Info("Error creating metrics route", "Error", err.Error())
+				return nil, err
+			}
+			log.Info("Metrics Service Monitor object updated ServiceMonitor.Name %v and ServiceMonitor.Namespace %v", sm.Name, sm.Namespace)
+			return existingServiceMonitor, nil
+		}
+
+	}
+	log.Info("Metrics Service Monitor object Created", "ServiceMonitor.Name", sm.Name, "ServiceMonitor.Namespace", sm.Namespace)
+	return sm, nil
 
 }
 


### PR DESCRIPTION
Simplify metrics setup by upgrading to v0.2.1 of the operator custom metrics library. This change makes the operator exit on startup if the metrics stack does not come up correctly.