### PR TITLE
Correct service name to match whats on cluster and in monitoring

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -112,6 +112,7 @@ func main() {
 	metricsServer := metrics.NewBuilder().WithPort(metricsPort).WithPath(metricsPath).
 		WithCollectors(localmetrics.MetricsList).
 		WithRoute().
+		WithServiceName("aws-account-operator").
 		GetConfig()
 
 	// Configure metrics if it errors log the error but continue


### PR DESCRIPTION
Before, the service name defaulted to the name of the operator, which the route creation used for the route name. However, other services may already be created with the name name, so a default name was built in to the library. This PR explicitly uses the name of the operator for the service to match the service/route names our current monitoring set up expects.

tl;dr
We use this route:
aws-account-operator-aws-account-operator.example.com

After #175, the operator creates this route:
operator-metrics-aws-account-operator.example.com

This PR ensures that the first one is created/updated, not the second one.