### PR TITLE
Refresh web console signin token

### DIFF
--- a/deploy/crds/aws_v1alpha1_account_crd.yaml
+++ b/deploy/crds/aws_v1alpha1_account_crd.yaml
@@ -107,14 +107,13 @@ spec:
                   type:
                     description: Type is the type of the condition.
                     type: string
-                required:
-                - type
-                - status
                 type: object
               type: array
             reused:
               type: boolean
               description: 'Field will be populated by the accountclaim controller indicating the account has been reused' 
+            rotateConsoleCredentials:
+              type: boolean
             rotateCredentials:
               type: boolean
             state:
@@ -122,13 +121,6 @@ spec:
             supportCaseID:
               type: string
               description: 'Field will be populated by the account controller when the account gets in PendingVerification status'
-          required:
-          - claimed
-          - supportCaseID
-          - conditions
-          - state
-          - rotateCredentials
-          - reused
           type: object
   version: v1alpha1
   versions:

--- a/pkg/apis/aws/v1alpha1/account_types.go
+++ b/pkg/apis/aws/v1alpha1/account_types.go
@@ -52,20 +52,21 @@ type AccountStatus struct {
 	// INSERT ADDITIONAL STATUS FIELD - define observed state of cluster
 	// Important: Run "operator-sdk generate k8s" to regenerate code after modifying this file
 	// Add custom validation using kubebuilder tags: https://book.kubebuilder.io/beyond_basics/generating_crd.html
-	Claimed           bool               `json:"claimed"`
-	SupportCaseID     string             `json:"supportCaseID"`
-	Conditions        []AccountCondition `json:"conditions"`
-	State             string             `json:"state"`
-	RotateCredentials bool               `json:"rotateCredentials"`
-	Reused            bool               `json:"reused"`
+	Claimed                  bool               `json:"claimed,omitempty"`
+	SupportCaseID            string             `json:"supportCaseID,omitempty"`
+	Conditions               []AccountCondition `json:"conditions,omitempty"`
+	State                    string             `json:"state,omitempty"`
+	RotateCredentials        bool               `json:"rotateCredentials,omitempty"`
+	RotateConsoleCredentials bool               `json:"rotateConsoleCredentials,omitempty"`
+	Reused                   bool               `json:"reused,omitempty"`
 }
 
 // AccountCondition contains details for the current condition of a AWS account
 type AccountCondition struct {
 	// Type is the type of the condition.
-	Type AccountConditionType `json:"type"`
+	Type AccountConditionType `json:"type,omitempty"`
 	// Status is the status of the condition
-	Status corev1.ConditionStatus `json:"status"`
+	Status corev1.ConditionStatus `json:"status,omitempty"`
 	// LastProbeTime is the last time we probed the condition.
 	// +optional
 	LastProbeTime metav1.Time `json:"lastProbeTime,omitempty"`

--- a/pkg/apis/aws/v1alpha1/zz_generated.openapi.go
+++ b/pkg/apis/aws/v1alpha1/zz_generated.openapi.go
@@ -622,6 +622,12 @@ func schema_pkg_apis_aws_v1alpha1_AccountStatus(ref common.ReferenceCallback) co
 							Format: "",
 						},
 					},
+					"rotateConsoleCredentials": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"boolean"},
+							Format: "",
+						},
+					},
 					"reused": {
 						SchemaProps: spec.SchemaProps{
 							Type:   []string{"boolean"},
@@ -629,7 +635,6 @@ func schema_pkg_apis_aws_v1alpha1_AccountStatus(ref common.ReferenceCallback) co
 						},
 					},
 				},
-				Required: []string{"claimed", "supportCaseID", "conditions", "state", "rotateCredentials", "reused"},
 			},
 		},
 		Dependencies: []string{

--- a/pkg/controller/account/credentials_rotator.go
+++ b/pkg/controller/account/credentials_rotator.go
@@ -29,37 +29,9 @@ func (r *ReconcileAccount) RotateCredentials(reqLogger logr.Logger, awsSetupClie
 		return STSCredentialsErr
 	}
 
-	// Create new awsClient with SRE IAM credentials so we can generate STS and Federation tokens from it
-	SREAWSClient, err := awsclient.GetAWSClient(r.Client, awsclient.NewAwsClientInput{
-		SecretName: account.Name + "-" + strings.ToLower(iamUserNameSRE) + "-secret",
-		NameSpace:  awsv1alpha1.AccountCrNamespace,
-		AwsRegion:  "us-east-1",
-	})
-	if err != nil {
-		reqLogger.Error(err, "RotateCredentials: Unable to create AWS conn with IAM user creds")
-	}
-
-	STSUserName := account.Name + "-sts"
-
-	IAMAdministratorPolicy := "arn:aws:iam::aws:policy/AdministratorAccess"
-
-	IAMPolicy := sts.PolicyDescriptorType{Arn: &IAMAdministratorPolicy}
-
-	IAMPolicyDescriptors := []*sts.PolicyDescriptorType{&IAMPolicy}
-
-	SigninTokenDuration := int64(credentialwatcher.STSCredentialsDuration)
-
-	// Set IAM policy for Web Console login, this policy cannot grant more permissions than the IAM user has which creates it
-
-	SREConsoleLoginURL, err := RequestSigninToken(reqLogger, SREAWSClient, &SigninTokenDuration, &STSUserName, IAMPolicyDescriptors, STSCredentials)
-	if err != nil {
-		reqLogger.Error(err, "RotateCredentials: Unable to create AWS signin token")
-		return err
-	}
-
 	STSSecret := &corev1.Secret{}
 
-	err = r.Client.Get(context.TODO(), types.NamespacedName{Name: STSCredentialsSecretName, Namespace: awsv1alpha1.AccountCrNamespace}, STSSecret)
+	err := r.Client.Get(context.TODO(), types.NamespacedName{Name: STSCredentialsSecretName, Namespace: awsv1alpha1.AccountCrNamespace}, STSSecret)
 
 	if err != nil {
 		errMsg := fmt.Sprintf("Error retrieving secret %s", STSCredentialsSecretName)
@@ -75,12 +47,11 @@ func (r *ReconcileAccount) RotateCredentials(reqLogger logr.Logger, awsSetupClie
 	}
 
 	STSSecretInput := SRESecretInput{
-		SecretName:              account.Name,
+		SecretName:              fmt.Sprintf("%s-sre-cli-credentials", account.Name),
 		NameSpace:               STSCredentialsSecretNamespace,
 		awsCredsSecretIDKey:     *STSCredentials.Credentials.AccessKeyId,
 		awsCredsSecretAccessKey: *STSCredentials.Credentials.SecretAccessKey,
 		awsCredsSessionToken:    *STSCredentials.Credentials.SessionToken,
-		awsCredsConsoleLoginURL: SREConsoleLoginURL,
 	}
 
 	STSCredentialsSecret := SRESecretInput.newSTSSecret(STSSecretInput)
@@ -103,4 +74,90 @@ func (r *ReconcileAccount) RotateCredentials(reqLogger logr.Logger, awsSetupClie
 	reqLogger.Info(fmt.Sprintf("AWS STS and signin token rotated for account %s valid for %d", account.Name, credentialwatcher.STSCredentialsDuration-credentialwatcher.STSCredentialsThreshold))
 
 	return nil
+}
+
+func (r *ReconcileAccount) RotateConsoleCredentials(reqLogger logr.Logger, awsSetupClient awsclient.Client, account *awsv1alpha1.Account) error {
+	STSCredentialsSecretName := account.Name + credentialwatcher.STSCredentialsConsoleSuffix
+
+	// Get STS user credentials
+	STSCredentials, STSCredentialsErr := getStsCredentials(reqLogger, awsSetupClient, awsv1alpha1.AccountOperatorIAMRole, account.Spec.AwsAccountID)
+
+	if STSCredentialsErr != nil {
+		reqLogger.Info("RotateCredentials: Failed to get SRE admin STSCredentials from AWS api ", "Error", STSCredentialsErr.Error())
+		return STSCredentialsErr
+	}
+
+	STSUserName := account.Name + "-sts"
+
+	IAMAdministratorPolicy := "arn:aws:iam::aws:policy/AdministratorAccess"
+
+	IAMPolicy := sts.PolicyDescriptorType{Arn: &IAMAdministratorPolicy}
+
+	IAMPolicyDescriptors := []*sts.PolicyDescriptorType{&IAMPolicy}
+
+	SigninTokenDuration := int64(credentialwatcher.STSCredentialsDuration)
+
+	// Create new awsClient with SRE IAM credentials so we can generate STS and Federation tokens from it
+	SREAWSClient, err := awsclient.GetAWSClient(r.Client, awsclient.NewAwsClientInput{
+		SecretName: account.Name + "-" + strings.ToLower(iamUserNameSRE) + "-secret",
+		NameSpace:  awsv1alpha1.AccountCrNamespace,
+		AwsRegion:  "us-east-1",
+	})
+	if err != nil {
+		reqLogger.Error(err, "RotateCredentials: Unable to create AWS conn with IAM user creds")
+	}
+
+	SREConsoleLoginURL, err := RequestSigninToken(reqLogger, SREAWSClient, &SigninTokenDuration, &STSUserName, IAMPolicyDescriptors, STSCredentials)
+	if err != nil {
+		reqLogger.Error(err, "RotateCredentials: Unable to create AWS signin token")
+		return err
+	}
+
+	secretName := account.Name
+
+	STSConsoleInput := SREConsoleInput{
+		SecretName:              fmt.Sprintf("%s-sre-console-url", secretName),
+		NameSpace:               account.Namespace,
+		awsCredsConsoleLoginURL: SREConsoleLoginURL,
+	}
+
+	userConsoleSecret := STSConsoleInput.newConsoleSecret()
+
+	STSSecret := &corev1.Secret{}
+
+	err = r.Client.Get(context.TODO(), types.NamespacedName{Name: STSCredentialsSecretName, Namespace: awsv1alpha1.AccountCrNamespace}, STSSecret)
+
+	if err != nil {
+		errMsg := fmt.Sprintf("Error retrieving secret %s", STSCredentialsSecretName)
+		reqLogger.Error(err, errMsg)
+		return err
+	}
+
+	err = r.Client.Delete(context.TODO(), STSSecret)
+
+	if err != nil {
+		reqLogger.Error(err, fmt.Sprintf("Error deleting secret %s", STSCredentialsSecretName))
+		return err
+	}
+
+	err = r.Client.Create(context.TODO(), userConsoleSecret)
+
+	if err != nil {
+		reqLogger.Error(err, fmt.Sprintf("Unable to update secret %s", STSSecret.Name))
+		return err
+	}
+
+	// Set `status.RotateCredentials` to false now that they ahve been updated
+	account.Status.RotateConsoleCredentials = false
+
+	err = r.Client.Status().Update(context.TODO(), account)
+	if err != nil {
+		reqLogger.Error(err, fmt.Sprintf("RotateCredentials: Error updating account %s", account.Name))
+		return err
+	}
+
+	reqLogger.Info(fmt.Sprintf("AWS console URL rotated for account %s valid for %d", account.Name, credentialwatcher.STSCredentialsDuration-credentialwatcher.STSCredentialsThreshold))
+
+	return nil
+
 }

--- a/pkg/controller/account/ec2.go
+++ b/pkg/controller/account/ec2.go
@@ -10,9 +10,8 @@ import (
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/aws/aws-sdk-go/service/sts"
 	"github.com/go-logr/logr"
-	controllerutils "github.com/openshift/aws-account-operator/pkg/controller/utils"
-
 	"github.com/openshift/aws-account-operator/pkg/awsclient"
+	controllerutils "github.com/openshift/aws-account-operator/pkg/controller/utils"
 )
 
 // InitializeSupportedRegions concurrently calls InitalizeRegion to create instances in all supported regions


### PR DESCRIPTION
This PR fixes an issue where AWS console URLs are only valid for 15 minutes after creation regardless of the AWS STS session duration.

To fix this we a few things differently:
1. Remove the AWS console URL from the sre-credentials secret and rename the original secret <account-name>-sre-cli-credentials
2. Create a new secret called <account-name>-sre-console-credentials
3. We generate a new AWS console URL every 15 minutes based on the sre-console-secret creation time

This also fixes a bug where the CLI credentials could become expired.