### PR TITLE
Implement BYOC AccountClaim logic

### DIFF
--- a/pkg/controller/accountclaim/reuse.go
+++ b/pkg/controller/accountclaim/reuse.go
@@ -52,6 +52,7 @@ func (r *ReconcileAccountClaim) resetAccountSpecStatus(reqLogger logr.Logger, re
 
 	// Reset claimlink and carry over legal entity from deleted claim
 	reusedAccount.Spec.ClaimLink = ""
+	reusedAccount.Spec.ClaimLinkNamespace = ""
 
 	// LegalEntity is being carried over here to support older accounts, that were claimed
 	// prior to the introduction of reuse (their account's legalEntity will be blank )

--- a/pkg/controller/accountpool/accountpool_controller_test.go
+++ b/pkg/controller/accountpool/accountpool_controller_test.go
@@ -8,7 +8,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/apimachinery/pkg/util/rand"
 	"k8s.io/client-go/kubernetes/scheme"
 	"reflect"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -286,58 +285,6 @@ func TestUpdateAccountPoolStatus(t *testing.T) {
 	//Expect false
 	if updateAccountPoolStatus(&testAccountPoolCR, 1, 1) {
 		t.Error("AccountPool status doesn't need updating, but function returns true")
-	}
-}
-
-func TestNewAccountForCR(t *testing.T) {
-
-	//Seed with a specific number to ensure output is predictable
-	rand.Seed(1)
-
-	//Generate CR with namespace "test"
-	testAccountCR := newAccountForCR("test")
-
-	//Create a CR with the expected output
-	expectedAccountCR := awsv1alpha1.Account{
-		ObjectMeta: metav1.ObjectMeta{
-			//The string is the expeted output of rand given the seed
-			Name:      emailID + "-xn8fgg",
-			Namespace: "test",
-		},
-		Spec: awsv1alpha1.AccountSpec{
-			AwsAccountID:  "",
-			IAMUserSecret: "",
-			ClaimLink:     "",
-		},
-	}
-
-	//Ensure the two are equal
-	if !reflect.DeepEqual(*testAccountCR, expectedAccountCR) {
-		t.Errorf("Generated Account CR does not match the expected output\n")
-		t.Errorf("\nExpected: %+v\n Actual: %+v\n", expectedAccountCR, testAccountCR)
-	}
-}
-
-func TestAddFinalizers(t *testing.T) {
-
-	//Create a CR with the expected output
-	testAccountCR := awsv1alpha1.Account{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      emailID,
-			Namespace: "test",
-		},
-		Spec: awsv1alpha1.AccountSpec{
-			AwsAccountID:  "",
-			IAMUserSecret: "",
-			ClaimLink:     "",
-		},
-	}
-
-	addFinalizer(&testAccountCR, "finalizer.aws.managed.openshift.io")
-	finalizers := testAccountCR.GetFinalizers()
-
-	if !stringInSlice("finalizer.aws.managed.openshift.io", finalizers) {
-		t.Error()
 	}
 }
 

--- a/pkg/controller/utils/utils.go
+++ b/pkg/controller/utils/utils.go
@@ -4,6 +4,13 @@ import (
 	"encoding/json"
 
 	awsv1alpha1 "github.com/openshift/aws-account-operator/pkg/apis/aws/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/rand"
+	"k8s.io/apimachinery/pkg/util/sets"
+)
+
+const (
+	EmailID = "osd-creds-mgmt"
 )
 
 func MarshalIAMPolicy(role awsv1alpha1.AWSFederatedRole) (string, error) {
@@ -37,4 +44,30 @@ func MarshalIAMPolicy(role awsv1alpha1.AWSFederatedRole) (string, error) {
 	}
 
 	return string(jsonPolicyDoc), nil
+}
+
+// GenerateAccountCR returns new account CR struct
+func GenerateAccountCR(namespace string) *awsv1alpha1.Account {
+
+	uuid := rand.String(6)
+	accountName := EmailID + "-" + uuid
+
+	return &awsv1alpha1.Account{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      accountName,
+			Namespace: namespace,
+		},
+		Spec: awsv1alpha1.AccountSpec{
+			AwsAccountID:  "",
+			IAMUserSecret: "",
+			ClaimLink:     "",
+		},
+	}
+}
+
+// AddFinalizer adds a finalizer to an object
+func AddFinalizer(object metav1.Object, finalizer string) {
+	finalizers := sets.NewString(object.GetFinalizers()...)
+	finalizers.Insert(finalizer)
+	object.SetFinalizers(finalizers.List())
 }


### PR DESCRIPTION
The AccountClaim controller will be given an AWS Account ID from OCM which it will then create an Account CR. The AccountClaim controller will then wait for this CR to be reconciled by the Account controller which will set the Account CR status to "Ready"