### PR TITLE
Add claimLinkNamespace field to Account CR

### DIFF
--- a/deploy/crds/aws_v1alpha1_account_crd.yaml
+++ b/deploy/crds/aws_v1alpha1_account_crd.yaml
@@ -52,6 +52,8 @@ spec:
               type: boolean
             claimLink:
               type: string
+            claimLinkNamespace:
+              type: string
             iamUserSecret:
               type: string
             legalEntity:
@@ -69,6 +71,7 @@ spec:
           - awsAccountID
           - iamUserSecret
           - claimLink
+          - claimLinkNamespace
           - legalEntity
           type: object
         status:

--- a/deploy/crds/aws_v1alpha1_account_crd.yaml
+++ b/deploy/crds/aws_v1alpha1_account_crd.yaml
@@ -71,7 +71,6 @@ spec:
           - awsAccountID
           - iamUserSecret
           - claimLink
-          - claimLinkNamespace
           - legalEntity
           type: object
         status:

--- a/pkg/apis/aws/v1alpha1/account_types.go
+++ b/pkg/apis/aws/v1alpha1/account_types.go
@@ -40,7 +40,7 @@ type AccountSpec struct {
 	// +optional
 	ClaimLink string `json:"claimLink"`
 	// +optional
-	ClaimLinkNamespace string      `json:"claimLinkNamespace"`
+	ClaimLinkNamespace string      `json:"claimLinkNamespace,omitempty"`
 	LegalEntity        LegalEntity `json:"legalEntity"`
 }
 

--- a/pkg/apis/aws/v1alpha1/account_types.go
+++ b/pkg/apis/aws/v1alpha1/account_types.go
@@ -38,8 +38,10 @@ type AccountSpec struct {
 	IAMUserSecret string `json:"iamUserSecret"`
 	BYOC          bool   `json:"byoc,omitempty"`
 	// +optional
-	ClaimLink   string      `json:"claimLink"`
-	LegalEntity LegalEntity `json:"legalEntity"`
+	ClaimLink string `json:"claimLink"`
+	// +optional
+	ClaimLinkNamespace string      `json:"claimLinkNamespace"`
+	LegalEntity        LegalEntity `json:"legalEntity"`
 }
 
 // AccountStatus defines the observed state of Account

--- a/pkg/apis/aws/v1alpha1/zz_generated.openapi.go
+++ b/pkg/apis/aws/v1alpha1/zz_generated.openapi.go
@@ -559,6 +559,12 @@ func schema_pkg_apis_aws_v1alpha1_AccountSpec(ref common.ReferenceCallback) comm
 							Format: "",
 						},
 					},
+					"claimLinkNamespace": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"string"},
+							Format: "",
+						},
+					},
 					"legalEntity": {
 						SchemaProps: spec.SchemaProps{
 							Ref: ref("github.com/openshift/aws-account-operator/pkg/apis/aws/v1alpha1.LegalEntity"),


### PR DESCRIPTION
Currently, an account CR only has a reference to the name of an accountClaim. However, these names are not unique. In order to ensure the Account knows the accountClaim its linked to, the namespace of the accountClaim should also be referenced in its spec.