### PR TITLE
Implement BYOC Account controller logic

### DIFF
--- a/pkg/controller/account/byoc.go
+++ b/pkg/controller/account/byoc.go
@@ -1,0 +1,60 @@
+package account
+
+import (
+	"encoding/json"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/iam"
+	"github.com/go-logr/logr"
+	awsv1alpha1 "github.com/openshift/aws-account-operator/pkg/apis/aws/v1alpha1"
+	"github.com/openshift/aws-account-operator/pkg/awsclient"
+)
+
+const (
+	byocPolicy        = "BYOCEC2Policy"
+	arnIAMPrefix      = "arn:aws:iam::"
+	byocUserArnSuffix = ":user/byocSetupUser"
+)
+
+// Create role for BYOC IAM user to assume
+func createBYOCAdminAccessRole(reqLogger logr.Logger, client awsclient.Client, userArn string, policyArn string) error {
+
+	// Lay out a basic AssumeRolePolicyDocument for BYOC
+	assumeRolePolicyDoc := struct {
+		Version   string
+		Statement []awsStatement
+	}{
+		Version: "2012-10-17",
+		Statement: []awsStatement{{
+			Effect: "Allow",
+			Action: []string{"sts:AssumeRole"},
+			Principal: &awsv1alpha1.Principal{
+				AWS: userArn,
+			},
+		}},
+	}
+
+	// Convert role to JSON
+	jsonAssumeRolePolicyDoc, err := json.Marshal(&assumeRolePolicyDoc)
+	if err != nil {
+		return err
+	}
+
+	// Create the base role
+	_, err = client.CreateRole(&iam.CreateRoleInput{
+		RoleName:                 aws.String(byocRole),
+		Description:              aws.String("AdminAccess for BYOC"),
+		AssumeRolePolicyDocument: aws.String(string(jsonAssumeRolePolicyDoc)),
+	})
+	if err != nil {
+		return err
+	}
+
+	// Attach the specified policy to the BROC role
+	_, err = client.AttachRolePolicy(&iam.AttachRolePolicyInput{
+		RoleName:  aws.String(byocRole),
+		PolicyArn: aws.String(policyArn),
+	})
+
+	return err
+}

--- a/pkg/controller/account/iam.go
+++ b/pkg/controller/account/iam.go
@@ -23,6 +23,24 @@ type awsSigninTokenResponse struct {
 	SigninToken string
 }
 
+type awsStatement struct {
+	Effect    string                 `json:"Effect"`
+	Action    []string               `json:"Action"`
+	Resource  []string               `json:"Resource,omitempty"`
+	Principal *awsv1alpha1.Principal `json:"Principal,omitempty"`
+}
+
+type PolicyDocument struct {
+	Version   string
+	Statement []StatementEntry
+}
+
+type StatementEntry struct {
+	Effect   string
+	Action   []string
+	Resource string
+}
+
 // RequestSigninToken makes a HTTP request to retrieve a Signin Token from the federation end point
 func RequestSigninToken(reqLogger logr.Logger, awsclient awsclient.Client, DurationSeconds *int64, FederatedUserName *string, PolicyArns []*sts.PolicyDescriptorType, STSCredentials *sts.AssumeRoleOutput) (string, error) {
 	// URL for building Federated Signin queries


### PR DESCRIPTION
Account Controller BYOC Logic

1. Skip creating the AWS account
2. Create new IAM access key for root credentials
3. Delete console login (??)
4. Delete original root IAM access keys that were provided
5. Assume user in this account using new root credentials (I think this and 6 are the same)
6. Following existing account setup logic
7. Skip creating support tickets for limit and enterprise support logic
8. Update status and conditions