### PR TITLE
CreateOrUpdate logic for Self-service IAM Roles and Policies

### DIFF
--- a/pkg/awsclient/client.go
+++ b/pkg/awsclient/client.go
@@ -73,6 +73,7 @@ type Client interface {
 	DeletePolicy(input *iam.DeletePolicyInput) (*iam.DeletePolicyOutput, error)
 	AttachRolePolicy(*iam.AttachRolePolicyInput) (*iam.AttachRolePolicyOutput, error)
 	CreateRole(*iam.CreateRoleInput) (*iam.CreateRoleOutput, error)
+	DeleteRole(*iam.DeleteRoleInput) (*iam.DeleteRoleOutput, error)
 
 	//Organizations
 	ListAccounts(*organizations.ListAccountsInput) (*organizations.ListAccountsOutput, error)
@@ -199,6 +200,10 @@ func (c *awsClient) AttachRolePolicy(input *iam.AttachRolePolicyInput) (*iam.Att
 
 func (c *awsClient) CreateRole(input *iam.CreateRoleInput) (*iam.CreateRoleOutput, error) {
 	return c.iamClient.CreateRole(input)
+}
+
+func (c *awsClient) DeleteRole(input *iam.DeleteRoleInput) (*iam.DeleteRoleOutput, error) {
+	return c.iamClient.DeleteRole(input)
 }
 
 func (c *awsClient) ListAccounts(input *organizations.ListAccountsInput) (*organizations.ListAccountsOutput, error) {

--- a/pkg/awsclient/mock/mock_client.go
+++ b/pkg/awsclient/mock/mock_client.go
@@ -368,6 +368,21 @@ func (mr *MockClientMockRecorder) CreateRole(arg0 interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateRole", reflect.TypeOf((*MockClient)(nil).CreateRole), arg0)
 }
 
+// DeleteRole mocks base method
+func (m *MockClient) DeleteRole(arg0 *iam.DeleteRoleInput) (*iam.DeleteRoleOutput, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteRole", arg0)
+	ret0, _ := ret[0].(*iam.DeleteRoleOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DeleteRole indicates an expected call of DeleteRole
+func (mr *MockClientMockRecorder) DeleteRole(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteRole", reflect.TypeOf((*MockClient)(nil).DeleteRole), arg0)
+}
+
 // ListAccounts mocks base method
 func (m *MockClient) ListAccounts(arg0 *organizations.ListAccountsInput) (*organizations.ListAccountsOutput, error) {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
Right now, the controller blindly tries to `Create` both IAM Roles and Policies. However, if they already exist in the AWS account, and the CR has been updated with new permissions, they will not be applied as the `Create` will fail with `EntityAlreadyExists`. This PR adds `CreateOrUpdate` logic to delete and recreate Roles and Policies when they already exist in an AWS account to ensure they are always up to date. 