### PR TITLE
InitializeSupportedRegions takes an AWS Client instead of a set of credentials

### DIFF
--- a/pkg/controller/account/account_controller.go
+++ b/pkg/controller/account/account_controller.go
@@ -442,7 +442,7 @@ func (r *ReconcileAccount) Reconcile(request reconcile.Request) (reconcile.Resul
 		}
 
 		// Initialize all supported regions by creating and terminating an instance in each
-		err = r.InitializeSupportedRegions(reqLogger, coveredRegions, creds)
+		err = r.InitializeSupportedRegions(reqLogger, coveredRegions, awsAssumedRoleClient)
 		if err != nil {
 			r.setStatusFailed(reqLogger, currentAcctInstance, "Failed to build and destroy ec2 instances")
 			return reconcile.Result{}, err

--- a/pkg/controller/account/ec2.go
+++ b/pkg/controller/account/ec2.go
@@ -8,14 +8,13 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/ec2"
-	"github.com/aws/aws-sdk-go/service/sts"
 	"github.com/go-logr/logr"
 	"github.com/openshift/aws-account-operator/pkg/awsclient"
 )
 
 // InitializeSupportedRegions concurrently calls InitalizeRegion to create instances in all supported regions
 // This should ensure we don't see any AWS API "PendingVerification" errors when launching instances
-func (r *ReconcileAccount) InitializeSupportedRegions(reqLogger logr.Logger, regions map[string]map[string]string, creds *sts.AssumeRoleOutput) error {
+func (r *ReconcileAccount) InitializeSupportedRegions(reqLogger logr.Logger, regions map[string]map[string]string, awsClient awsclient.Client) error {
 	// Create some channels to listen and error on when creating EC2 instances in all supported regions
 	ec2Notifications, ec2Errors := make(chan string), make(chan string)
 
@@ -25,7 +24,7 @@ func (r *ReconcileAccount) InitializeSupportedRegions(reqLogger logr.Logger, reg
 
 	// Create go routines to initialize regions in parallel
 	for region := range regions {
-		go r.InitializeRegion(reqLogger, region, regions[region]["initializationAMI"], ec2Notifications, ec2Errors, creds)
+		go r.InitializeRegion(reqLogger, region, regions[region]["initializationAMI"], ec2Notifications, ec2Errors, awsClient)
 	}
 
 	// Wait for all go routines to send a message or error to notify that the region initialization has finished
@@ -44,25 +43,10 @@ func (r *ReconcileAccount) InitializeSupportedRegions(reqLogger logr.Logger, reg
 }
 
 // InitializeRegion sets up a connection to the AWS `region` and then creates and terminates an EC2 instance
-func (r *ReconcileAccount) InitializeRegion(reqLogger logr.Logger, region string, ami string, ec2Notifications chan string, ec2Errors chan string, creds *sts.AssumeRoleOutput) error {
+func (r *ReconcileAccount) InitializeRegion(reqLogger logr.Logger, region string, ami string, ec2Notifications chan string, ec2Errors chan string, awsClient awsclient.Client) error {
 	reqLogger.Info(fmt.Sprintf("Initializing region: %s", region))
 
-	awsClient, err := awsclient.GetAWSClient(r.Client, awsclient.NewAwsClientInput{
-		AwsCredsSecretIDKey:     *creds.Credentials.AccessKeyId,
-		AwsCredsSecretAccessKey: *creds.Credentials.SecretAccessKey,
-		AwsToken:                *creds.Credentials.SessionToken,
-		AwsRegion:               region,
-	})
-	if err != nil {
-		connErr := fmt.Sprintf("Unable to connect to region: %s when attempting to initialize it", region)
-		reqLogger.Error(err, connErr)
-		// Notify Error channel that this region has errored and to move on
-		ec2Errors <- connErr
-
-		return err
-	}
-
-	err = r.BuildandDestroyEC2Instances(reqLogger, awsClient, ami)
+	err := r.BuildandDestroyEC2Instances(reqLogger, awsClient, ami)
 
 	if err != nil {
 		createErr := fmt.Sprintf("Unable to create instance in region: %s", region)


### PR DESCRIPTION
Currently, `InitializeSupportedRegions` take a set of credentials returned from `StsAssumeRole`. These creds go on to be used to build an AWS client in `InitializeRegion`. However, these credentials are already used to create an AWS Client before `InitializeSupportedRegions` is called. To make the function more flexible and to reduce complexity, this PR changes `InitializeSupportedRegions` to take an AWS client instead. 