### PR TITLE
Support arbitrary role in getStsCredentials and BuildSTSUser

### DIFF
--- a/pkg/controller/account/account_controller.go
+++ b/pkg/controller/account/account_controller.go
@@ -439,7 +439,7 @@ func (r *ReconcileAccount) Reconcile(request reconcile.Request) (reconcile.Resul
 		}
 
 		// Create STS CLI Credentials for SRE
-		_, err = r.BuildSTSUser(reqLogger, SREAWSClient, awsSetupClient, currentAcctInstance, request.Namespace, "OrganizationAccountAccessRole")
+		_, err = r.BuildSTSUser(reqLogger, SREAWSClient, awsSetupClient, currentAcctInstance, request.Namespace, accountOperatorIAMRole)
 		if err != nil {
 			r.setStatusFailed(reqLogger, currentAcctInstance, fmt.Sprintf("Failed to build SRE STS credentials: %s", iamUserNameSRE))
 			return reconcile.Result{}, err

--- a/pkg/controller/account/account_controller.go
+++ b/pkg/controller/account/account_controller.go
@@ -12,7 +12,6 @@ import (
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/iam"
 	"github.com/aws/aws-sdk-go/service/organizations"
-	"github.com/aws/aws-sdk-go/service/sts"
 	"github.com/aws/aws-sdk-go/service/support"
 	"github.com/go-logr/logr"
 	awsv1alpha1 "github.com/openshift/aws-account-operator/pkg/apis/aws/v1alpha1"
@@ -766,50 +765,6 @@ func CreateUserAccessKey(reqLogger logr.Logger, client awsclient.Client, userNam
 	}
 
 	return result, nil
-}
-
-// getStsCredentials returns sts credentials for the specified account ARN
-func getStsCredentials(reqLogger logr.Logger, client awsclient.Client, iamRoleName string, awsAccountID string) (*sts.AssumeRoleOutput, error) {
-	// Use the role session name to uniquely identify a session when the same role
-	// is assumed by different principals or for different reasons.
-	var roleSessionName = "awsAccountOperator"
-	// Default duration in seconds of the session token 3600. We need to have the roles policy
-	// changed if we want it to be longer than 3600 seconds
-	var roleSessionDuration int64 = 3600
-	// The role ARN made up of the account number and the role which is the default role name
-	// created in child accounts
-	var roleArn = fmt.Sprintf("arn:aws:iam::%s:role/%s", awsAccountID, iamRoleName)
-	reqLogger.Info(fmt.Sprintf("Creating STS credentials for AWS ARN: %s", roleArn))
-	// Build input for AssumeRole
-	assumeRoleInput := sts.AssumeRoleInput{
-		DurationSeconds: &roleSessionDuration,
-		RoleArn:         &roleArn,
-		RoleSessionName: &roleSessionName,
-	}
-
-	assumeRoleOutput := &sts.AssumeRoleOutput{}
-	var err error
-	for i := 0; i < 100; i++ {
-		time.Sleep(500 * time.Millisecond)
-		assumeRoleOutput, err = client.AssumeRole(&assumeRoleInput)
-		if err == nil {
-			break
-		}
-	}
-	if err != nil {
-		// Log AWS error
-		if aerr, ok := err.(awserr.Error); ok {
-			reqLogger.Error(aerr,
-				fmt.Sprintf(`New AWS Error while getting STS credentials, 
-					AWS Error Code: %s, 
-					AWS Error Message: %s`,
-					aerr.Code(),
-					aerr.Message()))
-		}
-		return &sts.AssumeRoleOutput{}, err
-	}
-
-	return assumeRoleOutput, nil
 }
 
 func (input SRESecretInput) newSTSSecret() *corev1.Secret {

--- a/pkg/controller/account/account_controller.go
+++ b/pkg/controller/account/account_controller.go
@@ -440,7 +440,7 @@ func (r *ReconcileAccount) Reconcile(request reconcile.Request) (reconcile.Resul
 		}
 
 		// Create STS CLI Credentials for SRE
-		_, err = r.BuildSTSUser(reqLogger, SREAWSClient, awsSetupClient, currentAcctInstance, request.Namespace)
+		_, err = r.BuildSTSUser(reqLogger, SREAWSClient, awsSetupClient, currentAcctInstance, request.Namespace, "OrganizationAccountAccessRole")
 		if err != nil {
 			r.setStatusFailed(reqLogger, currentAcctInstance, fmt.Sprintf("Failed to build SRE STS credentials: %s", iamUserNameSRE))
 			return reconcile.Result{}, err
@@ -778,7 +778,7 @@ func getStsCredentials(reqLogger logr.Logger, client awsclient.Client, iamRoleNa
 	var roleSessionDuration int64 = 3600
 	// The role ARN made up of the account number and the role which is the default role name
 	// created in child accounts
-	var roleArn = fmt.Sprintf("arn:aws:iam::%s:role/OrganizationAccountAccessRole", awsAccountID)
+	var roleArn = fmt.Sprintf("arn:aws:iam::%s:role/%s", awsAccountID, iamRoleName)
 	reqLogger.Info(fmt.Sprintf("Creating STS credentials for AWS ARN: %s", roleArn))
 	// Build input for AssumeRole
 	assumeRoleInput := sts.AssumeRoleInput{

--- a/pkg/controller/account/iam.go
+++ b/pkg/controller/account/iam.go
@@ -191,3 +191,47 @@ func (r *ReconcileAccount) BuildSTSUser(reqLogger logr.Logger, awsSetupClient aw
 	reqLogger.Info("Created IAM STS User")
 	return userSecret.ObjectMeta.Name, nil
 }
+
+// getStsCredentials returns sts credentials for the specified account ARN
+func getStsCredentials(reqLogger logr.Logger, client awsclient.Client, iamRoleName string, awsAccountID string) (*sts.AssumeRoleOutput, error) {
+	// Use the role session name to uniquely identify a session when the same role
+	// is assumed by different principals or for different reasons.
+	var roleSessionName = "awsAccountOperator"
+	// Default duration in seconds of the session token 3600. We need to have the roles policy
+	// changed if we want it to be longer than 3600 seconds
+	var roleSessionDuration int64 = 3600
+	// The role ARN made up of the account number and the role which is the default role name
+	// created in child accounts
+	var roleArn = fmt.Sprintf("arn:aws:iam::%s:role/%s", awsAccountID, iamRoleName)
+	reqLogger.Info(fmt.Sprintf("Creating STS credentials for AWS ARN: %s", roleArn))
+	// Build input for AssumeRole
+	assumeRoleInput := sts.AssumeRoleInput{
+		DurationSeconds: &roleSessionDuration,
+		RoleArn:         &roleArn,
+		RoleSessionName: &roleSessionName,
+	}
+
+	assumeRoleOutput := &sts.AssumeRoleOutput{}
+	var err error
+	for i := 0; i < 100; i++ {
+		time.Sleep(500 * time.Millisecond)
+		assumeRoleOutput, err = client.AssumeRole(&assumeRoleInput)
+		if err == nil {
+			break
+		}
+	}
+	if err != nil {
+		// Log AWS error
+		if aerr, ok := err.(awserr.Error); ok {
+			reqLogger.Error(aerr,
+				fmt.Sprintf(`New AWS Error while getting STS credentials, 
+					AWS Error Code: %s, 
+					AWS Error Message: %s`,
+					aerr.Code(),
+					aerr.Message()))
+		}
+		return &sts.AssumeRoleOutput{}, err
+	}
+
+	return assumeRoleOutput, nil
+}

--- a/pkg/controller/account/iam.go
+++ b/pkg/controller/account/iam.go
@@ -135,7 +135,7 @@ func RequestSigninToken(reqLogger logr.Logger, awsclient awsclient.Client, Durat
 }
 
 // BuildSTSUser takes all parameters required to create a user, user secret
-func (r *ReconcileAccount) BuildSTSUser(reqLogger logr.Logger, awsSetupClient awsclient.Client, awsClient awsclient.Client, account *awsv1alpha1.Account, nameSpace string) (string, error) {
+func (r *ReconcileAccount) BuildSTSUser(reqLogger logr.Logger, awsSetupClient awsclient.Client, awsClient awsclient.Client, account *awsv1alpha1.Account, nameSpace string, iamRole string) (string, error) {
 	reqLogger.Info("Creating IAM STS User")
 
 	// If IAM user was just created we cannot immediately create STS credentials due to an issue
@@ -143,7 +143,7 @@ func (r *ReconcileAccount) BuildSTSUser(reqLogger logr.Logger, awsSetupClient aw
 	time.Sleep(10 * time.Second)
 
 	// Create STS user for SRE admins
-	STSCredentials, STSCredentialsErr := getStsCredentials(reqLogger, awsClient, "", account.Spec.AwsAccountID)
+	STSCredentials, STSCredentialsErr := getStsCredentials(reqLogger, awsClient, iamRole, account.Spec.AwsAccountID)
 	if STSCredentialsErr != nil {
 		reqLogger.Info("Failed to get SRE admin STSCredentials from AWS api ", "Error", STSCredentialsErr.Error())
 		return "", STSCredentialsErr


### PR DESCRIPTION
`getStsCredentials` has an `iamRoleName` parameter but is unused. This PR leverage this to enable arbitrary roles for `getStsCredentials` and `BuildSTSUser` 