### PR TITLE
CreateIAMUser fix

### DIFF
--- a/pkg/controller/account/account_controller.go
+++ b/pkg/controller/account/account_controller.go
@@ -696,6 +696,8 @@ func CreateIAMUser(reqLogger logr.Logger, client awsclient.Client, userName stri
 					return &iam.CreateUserOutput{}, err
 				}
 				createUserOutput = createResult
+				return createUserOutput, nil
+
 			default:
 				// Log new AWS error
 				reqLogger.Error(aerr,
@@ -709,7 +711,6 @@ func CreateIAMUser(reqLogger logr.Logger, client awsclient.Client, userName stri
 		} else {
 			return &iam.CreateUserOutput{}, err
 		}
-		return createUserOutput, errors.New("Failed to cast AWS error")
 	}
 	return createUserOutput, nil
 }


### PR DESCRIPTION
Currently CreateIAMUser will return an error even it succeeds in creating a new user. This commit changes CreateIAMUser to handle the case of a new account properly.