### PR TITLE
[WIP] Remove initialize totalaccountwatcher's update call

### DIFF
--- a/pkg/controller/account/account_controller.go
+++ b/pkg/controller/account/account_controller.go
@@ -338,6 +338,10 @@ func (r *ReconcileAccount) Reconcile(request reconcile.Request) (reconcile.Resul
 
 		if currentAcctInstance.Spec.AwsAccountID == "" {
 			// before doing anything make sure we are not over the limit if we are just error
+			if totalaccountwatcher.TotalAccountWatcher.Total == 0 {
+				totalaccountwatcher.TotalAccountWatcher.UpdateTotalAccounts(log)
+			}
+
 			if totalaccountwatcher.TotalAccountWatcher.Total >= AwsLimit {
 				reqLogger.Error(ErrAwsAccountLimitExceeded, "AWS Account limit reached", "Account Total", totalaccountwatcher.TotalAccountWatcher.Total)
 				return reconcile.Result{}, ErrAwsAccountLimitExceeded

--- a/pkg/totalaccountwatcher/totalaccountwatcher.go
+++ b/pkg/totalaccountwatcher/totalaccountwatcher.go
@@ -49,7 +49,6 @@ func Initialize(client client.Client, watchInterval time.Duration) {
 	}
 
 	TotalAccountWatcher = NewTotalAccountWatcher(client, AwsClient, watchInterval)
-	TotalAccountWatcher.UpdateTotalAccounts(log)
 }
 
 // NewTotalAccountWatcher returns a new instance of the TotalAccountWatcher interface


### PR DESCRIPTION
https://jira.coreos.com/browse/SREP-2369

Currently the initialization of totalaccountwatcher calls the update total function. This function often fails (as the aws call it wraps often does). Which will result in unnecessary failed starts. So the update call within initialize is being removed. The update total function is still called within a goroutine. 