### PR TITLE
Revert "InitializeSupportedRegions takes an AWS Client instead of a set of credentials"

### DIFF
--- a/pkg/controller/account/account_controller.go
+++ b/pkg/controller/account/account_controller.go
@@ -439,7 +439,7 @@ func (r *ReconcileAccount) Reconcile(request reconcile.Request) (reconcile.Resul
 		}
 
 		// Initialize all supported regions by creating and terminating an instance in each
-		err = r.InitializeSupportedRegions(reqLogger, coveredRegions, awsAssumedRoleClient)
+		err = r.InitializeSupportedRegions(reqLogger, coveredRegions, creds)
 		if err != nil {
 			r.setStatusFailed(reqLogger, currentAcctInstance, "Failed to build and destroy ec2 instances")
 			return reconcile.Result{}, err


### PR DESCRIPTION
Reverts openshift/aws-account-operator#192

This PR is being reverted as it introduced an error when initializing accounts.

We create a new AWS client within the `InitializeRegion` function because we need to connect to the specific region to use the AMI and start/terminate the AWS EC2 instance.

Error from the account_controller:

`{"level":"error","ts":1573654676.9214592,"logger":"controller_account","msg":"Failed while trying to create EC2 instance,\n\t\t\t\tAWS Error 
Code: InvalidAMIID.NotFound, \n\t\t\t\tAWS Error Message: The image id '[ami-04642fc8fca1e8e67]' does not exist","Request.Namespace":"aws-acc
ount-operator","Request.Name":"osd-creds-mgmt-vrb5t7","error":"InvalidAMIID.NotFound: The image id '[ami-04642fc8fca1e8e67]' does not exist`