### PR TITLE
Add missing role name to credentials rotator

### DIFF
--- a/pkg/apis/aws/v1alpha1/account_types.go
+++ b/pkg/apis/aws/v1alpha1/account_types.go
@@ -26,6 +26,8 @@ const (
 	accountStatusPendingVerification AccountStateStatus = "PendingVerification"
 	// AccountCrNamespace namespace where AWS accounts will be created
 	AccountCrNamespace = "aws-account-operator"
+	// IAM Role name for IAM user creating resources in account
+	AccountOperatorIAMRole = "OrganizationAccountAccessRole"
 )
 
 // AccountSpec defines the desired state of Account

--- a/pkg/controller/account/account_controller.go
+++ b/pkg/controller/account/account_controller.go
@@ -18,7 +18,6 @@ import (
 	"github.com/openshift/aws-account-operator/pkg/awsclient"
 	controllerutils "github.com/openshift/aws-account-operator/pkg/controller/utils"
 	totalaccountwatcher "github.com/openshift/aws-account-operator/pkg/totalaccountwatcher"
-
 	corev1 "k8s.io/api/core/v1"
 	k8serr "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -66,8 +65,6 @@ const (
 	AccountReady = "Ready"
 	// AccountPendingVerification indicates verification (of AWS limits and Enterprise Support) is pending
 	AccountPendingVerification = "PendingVerification"
-	// IAM Role name for IAM user creating resources in account
-	accountOperatorIAMRole = "OrganizationAccountAccessRole"
 )
 
 var awsAccountID string
@@ -379,7 +376,7 @@ func (r *ReconcileAccount) Reconcile(request reconcile.Request) (reconcile.Resul
 		}
 
 		// Get STS credentials so that we can create an aws client with
-		creds, credsErr := getStsCredentials(reqLogger, awsSetupClient, accountOperatorIAMRole, awsAccountID)
+		creds, credsErr := getStsCredentials(reqLogger, awsSetupClient, awsv1alpha1.AccountOperatorIAMRole, awsAccountID)
 		if credsErr != nil {
 			stsErrMsg := fmt.Sprintf("Failed to create STS Credentials for account ID %s", awsAccountID)
 			reqLogger.Info(stsErrMsg, "Error", credsErr.Error())
@@ -432,7 +429,7 @@ func (r *ReconcileAccount) Reconcile(request reconcile.Request) (reconcile.Resul
 		}
 
 		// Create STS CLI Credentials for SRE
-		_, err = r.BuildSTSUser(reqLogger, SREAWSClient, awsSetupClient, currentAcctInstance, request.Namespace, accountOperatorIAMRole)
+		_, err = r.BuildSTSUser(reqLogger, SREAWSClient, awsSetupClient, currentAcctInstance, request.Namespace, awsv1alpha1.AccountOperatorIAMRole)
 		if err != nil {
 			r.setStatusFailed(reqLogger, currentAcctInstance, fmt.Sprintf("Failed to build SRE STS credentials: %s", iamUserNameSRE))
 			return reconcile.Result{}, err

--- a/pkg/controller/account/credentials_rotator.go
+++ b/pkg/controller/account/credentials_rotator.go
@@ -22,7 +22,7 @@ func (r *ReconcileAccount) RotateCredentials(reqLogger logr.Logger, awsSetupClie
 	reqLogger.Info(fmt.Sprintf("Rotating credentials for account %s secret %s", account.Name, STSCredentialsSecretName))
 
 	// Get STS user credentials
-	STSCredentials, STSCredentialsErr := getStsCredentials(reqLogger, awsSetupClient, "", account.Spec.AwsAccountID)
+	STSCredentials, STSCredentialsErr := getStsCredentials(reqLogger, awsSetupClient, awsv1alpha1.AccountOperatorIAMRole, account.Spec.AwsAccountID)
 
 	if STSCredentialsErr != nil {
 		reqLogger.Info("RotateCredentials: Failed to get SRE admin STSCredentials from AWS api ", "Error", STSCredentialsErr.Error())


### PR DESCRIPTION
This PR fixes a missing role name when calling `getStsCredentials` in the credential rotation file. I moved the const to the API types file so it could be used in the secret watcher.