### PR TITLE
Change AWS Id to  AWS arn

### DIFF
--- a/deploy/crds/aws_v1alpha1_awsfederatedaccountaccess_cr.yaml
+++ b/deploy/crds/aws_v1alpha1_awsfederatedaccountaccess_cr.yaml
@@ -3,6 +3,6 @@ kind: AWSFederatedAccountAccess
 metadata:
   name: clustername.customeraccountname.rolename
 spec:
-  AccountReference: accountreference
-  ExternalCustomerAWSAccountID: externalcustomerawsaccountid
+  accountReference: accountreference
+  externalCustomerAWSIAMARN: externalCustomerAWSIAMARN
   awsFederatedRoleName: awsfederatedrolename

--- a/deploy/crds/aws_v1alpha1_awsfederatedaccountaccess_crd.yaml
+++ b/deploy/crds/aws_v1alpha1_awsfederatedaccountaccess_crd.yaml
@@ -46,12 +46,11 @@ spec:
               description: FederatedRoleName must be the name of a federatedrole cr
                 that currently exists
               type: string
-            externalCustomerAWSAccountID:
-              description: ExternalCustomerAwsAccountID holds the external AWS account
-                ID
+            externalCustomerAWSIAMARN:
+              description: externalCustomerAWSIAMARN holds the external AWS IAM ARN
               type: string
           required:
-          - externalCustomerAWSAccountID
+          - externalCustomerAWSIAMARN
           - accountReference
           - awsFederatedRoleName
           type: object

--- a/pkg/apis/aws/v1alpha1/awsfederatedaccountaccess_types.go
+++ b/pkg/apis/aws/v1alpha1/awsfederatedaccountaccess_types.go
@@ -23,8 +23,8 @@ const (
 // AWSFederatedAccountAccessSpec defines the desired state of AWSFederatedAccountAccess
 // +k8s:openapi-gen=true
 type AWSFederatedAccountAccessSpec struct {
-	// ExternalCustomerAwsAccountID holds the external AWS account ID
-	ExternalCustomerAWSAccountID string `json:"externalCustomerAWSAccountID"`
+	// ExternalCustomerAWSARN holds the external AWS IAM ARN
+	ExternalCustomerAWSIAMARN string `json:"externalCustomerAWSIAMARN"`
 	// AccountReference holds the name of the associated Account CR to use
 	AccountReference string `json:"accountReference"`
 	// FederatedRoleName must be the name of a federatedrole cr that currently exists

--- a/pkg/apis/aws/v1alpha1/zz_generated.openapi.go
+++ b/pkg/apis/aws/v1alpha1/zz_generated.openapi.go
@@ -80,9 +80,9 @@ func schema_pkg_apis_aws_v1alpha1_AWSFederatedAccountAccessSpec(ref common.Refer
 			SchemaProps: spec.SchemaProps{
 				Description: "AWSFederatedAccountAccessSpec defines the desired state of AWSFederatedAccountAccess",
 				Properties: map[string]spec.Schema{
-					"externalCustomerAWSAccountID": {
+					"externalCustomerAWSIAMARN": {
 						SchemaProps: spec.SchemaProps{
-							Description: "ExternalCustomerAwsAccountID holds the external AWS account ID",
+							Description: "externalCustomerAWSIAMARN holds the external AWS IAM ARN",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -102,7 +102,7 @@ func schema_pkg_apis_aws_v1alpha1_AWSFederatedAccountAccessSpec(ref common.Refer
 						},
 					},
 				},
-				Required: []string{"externalCustomerAWSAccountID", "accountReference", "awsFederatedRoleName"},
+				Required: []string{"externalCustomerAWSIAMARN", "accountReference", "awsFederatedRoleName"},
 			},
 		},
 		Dependencies: []string{},

--- a/pkg/controller/awsfederatedaccountaccess/awsfederatedaccountaccess_controller.go
+++ b/pkg/controller/awsfederatedaccountaccess/awsfederatedaccountaccess_controller.go
@@ -286,7 +286,7 @@ func (r *ReconcileAWSFederatedAccountAccess) createIAMRole(awsClient awsclient.C
 			Effect: "Allow",
 			Action: []string{"sts:AssumeRole"},
 			Principal: &awsv1alpha1.Principal{
-				AWS: afaa.Spec.ExternalCustomerAWSAccountID,
+				AWS: afaa.Spec.ExternalCustomerAWSIAMARN,
 			},
 		}},
 	}


### PR DESCRIPTION
https://jira.coreos.com/browse/SREP-2328

Formerly the AssumeRolePolicyDocument took an AWS-ID and defaulted to the root user. This PR changes the AWS-ID to an ARN. 