### PR TITLE
Ensure we have a timestamp as lastTransitionTime

### DIFF
--- a/pkg/controller/utils/conditions.go
+++ b/pkg/controller/utils/conditions.go
@@ -128,6 +128,10 @@ func SetAccountCondition(
 			if existingCondition.Status != status {
 				existingCondition.LastTransitionTime = now
 			}
+
+			if existingCondition.LastTransitionTime != (metav1.Time{}) {
+				existingCondition.LastTransitionTime = existingCondition.LastProbeTime
+			}
 			existingCondition.Status = status
 			existingCondition.Reason = reason
 			existingCondition.Message = message


### PR DESCRIPTION
This PR fixes an issue where the `status.conditions[].lastTransitionTime` is `null` due to a CRD change here #129 

This should set the lastTransitionTime to LastProbeTime if its not of type `metav1.Time`