### PR TITLE
Explicitly check conditions LastTransitionTime

### DIFF
--- a/pkg/controller/account/account_controller.go
+++ b/pkg/controller/account/account_controller.go
@@ -264,6 +264,11 @@ func (r *ReconcileAccount) Reconcile(request reconcile.Request) (reconcile.Resul
 		return reconcile.Result{}, err
 	}
 
+	// If conditions have LastTransitionTime as null update them
+	if controllerutils.CheckAccountConditions(currentAcctInstance) {
+		return reconcile.Result{}, r.statusUpdate(reqLogger, currentAcctInstance)
+	}
+
 	// Test PendingVerification state creating support case and checking for case status
 	if currentAcctInstance.Status.State == AccountPendingVerification {
 		// reqLogger.Info("Account in PendingVerification state", "AccountID", currentAcctInstance.Spec.AwsAccountID)

--- a/pkg/controller/utils/conditions.go
+++ b/pkg/controller/utils/conditions.go
@@ -94,6 +94,18 @@ func FindAccountClaimCondition(conditions []awsv1alpha1.AccountClaimCondition, c
 	return nil
 }
 
+// CheckAccountConditions checks all conditions and resets LastTransitionTime to LastProbeTime if null
+func CheckAccountConditions(account *awsv1alpha1.Account) bool {
+	updated := false
+	for i, condition := range account.Status.Conditions {
+		if condition.LastTransitionTime == (metav1.Time{}) {
+			account.Status.Conditions[i].LastTransitionTime = condition.LastProbeTime
+			updated = true
+		}
+	}
+	return updated
+}
+
 // SetAccountCondition sets a condition on a Account resource's status
 func SetAccountCondition(
 	conditions []awsv1alpha1.AccountCondition,


### PR DESCRIPTION
In this PR we are explicitly checking `status.conditions[].LastTransitionTime` to see if its an empty struct and update it to `LastProbeTime`