### PR TITLE
Revert "Ensure we have a timestamp as lastTransitionTime"

### DIFF
--- a/pkg/controller/utils/conditions.go
+++ b/pkg/controller/utils/conditions.go
@@ -128,10 +128,6 @@ func SetAccountCondition(
 			if existingCondition.Status != status {
 				existingCondition.LastTransitionTime = now
 			}
-
-			if existingCondition.LastTransitionTime != (metav1.Time{}) {
-				existingCondition.LastTransitionTime = existingCondition.LastProbeTime
-			}
 			existingCondition.Status = status
 			existingCondition.Reason = reason
 			existingCondition.Message = message


### PR DESCRIPTION
Reverts openshift/aws-account-operator#206

No longer required with #207 