### PR TITLE
Set ClaimLinkNamespace when Creating an Account CR

### DIFF
--- a/pkg/controller/utils/utils.go
+++ b/pkg/controller/utils/utils.go
@@ -62,9 +62,10 @@ func GenerateAccountCR(namespace string) *awsv1alpha1.Account {
 			Namespace: namespace,
 		},
 		Spec: awsv1alpha1.AccountSpec{
-			AwsAccountID:  "",
-			IAMUserSecret: "",
-			ClaimLink:     "",
+			AwsAccountID:       "",
+			IAMUserSecret:      "",
+			ClaimLink:          "",
+			ClaimLinkNamespace: "",
 		},
 	}
 }


### PR DESCRIPTION
`ClaimLinkNamespace` should be set to blank when a new account CR is generated by the AccountPool.