### PR TITLE
Make legalEntity optional again

### DIFF
--- a/deploy/crds/aws_v1alpha1_account_crd.yaml
+++ b/deploy/crds/aws_v1alpha1_account_crd.yaml
@@ -74,7 +74,6 @@ spec:
           - awsAccountID
           - iamUserSecret
           - claimLink
-          - legalEntity
           type: object
         status:
           properties:

--- a/pkg/apis/aws/v1alpha1/account_types.go
+++ b/pkg/apis/aws/v1alpha1/account_types.go
@@ -43,7 +43,7 @@ type AccountSpec struct {
 	ClaimLink string `json:"claimLink"`
 	// +optional
 	ClaimLinkNamespace string      `json:"claimLinkNamespace,omitempty"`
-	LegalEntity        LegalEntity `json:"legalEntity"`
+	LegalEntity        LegalEntity `json:"legalEntity,omitempty"`
 }
 
 // AccountStatus defines the observed state of Account

--- a/pkg/apis/aws/v1alpha1/zz_generated.openapi.go
+++ b/pkg/apis/aws/v1alpha1/zz_generated.openapi.go
@@ -571,7 +571,7 @@ func schema_pkg_apis_aws_v1alpha1_AccountSpec(ref common.ReferenceCallback) comm
 						},
 					},
 				},
-				Required: []string{"awsAccountID", "iamUserSecret", "legalEntity"},
+				Required: []string{"awsAccountID", "iamUserSecret"},
 			},
 		},
 		Dependencies: []string{


### PR DESCRIPTION
This CR sets `.spec.legalEntity` to omitempty again.