### PR TITLE
add aws-account-operator-client Group to ClusterRoleBinding

### DIFF
--- a/deploy/uhc_cluster_role_binding.yaml
+++ b/deploy/uhc_cluster_role_binding.yaml
@@ -2,8 +2,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: aws-account-operator-client
-groupNames:
-- aws-account-operator-client
 subjects:
 - kind: ServiceAccount
   namespace: aws-account-operator-client

--- a/deploy/uhc_cluster_role_binding.yaml
+++ b/deploy/uhc_cluster_role_binding.yaml
@@ -6,6 +6,8 @@ subjects:
 - kind: ServiceAccount
   namespace: aws-account-operator-client
   name: aws-account-operator-client
+- kind: Group
+  name: aws-account-operator-client
 roleRef:
   kind: ClusterRole
   name: aws-account-operator-client

--- a/deploy/uhc_cluster_role_binding.yaml
+++ b/deploy/uhc_cluster_role_binding.yaml
@@ -2,6 +2,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: aws-account-operator-client
+groupNames:
+- aws-account-operator-client
 subjects:
 - kind: ServiceAccount
   namespace: aws-account-operator-client


### PR DESCRIPTION
This PR is an attempt to solve https://jira.coreos.com/browse/APPSRE-961.
The plan is to add OCM developers to this group on the integration environment only.

Please let me know what you think.