### PR TITLE
Handle error for BYOC aws client setup

### DIFF
--- a/pkg/controller/account/byoc.go
+++ b/pkg/controller/account/byoc.go
@@ -91,6 +91,9 @@ func (r *ReconcileAccount) getBYOCClient(currentAcct *awsv1alpha1.Account) (awsc
 		NameSpace:  accountClaim.Spec.BYOCSecretRef.Namespace,
 		AwsRegion:  "us-east-1",
 	})
+	if err != nil {
+		return nil, nil, err
+	}
 
 	return byocAWSClient, accountClaim, nil
 }


### PR DESCRIPTION
This PR ensures that if the BYOC AWS client does not get initialized correctly, the error is returned. 