### PR TITLE
Remove conditions check for invalid lasttransitiontime

### DIFF
--- a/pkg/controller/account/account_controller.go
+++ b/pkg/controller/account/account_controller.go
@@ -257,11 +257,6 @@ func (r *ReconcileAccount) Reconcile(request reconcile.Request) (reconcile.Resul
 		return reconcile.Result{}, err
 	}
 
-	// If conditions have LastTransitionTime as null update them
-	if controllerutils.CheckAccountConditions(currentAcctInstance) {
-		return reconcile.Result{}, r.statusUpdate(reqLogger, currentAcctInstance)
-	}
-
 	// We expect this secret to exist in the same namespace Account CR's are created
 	awsSetupClient, err := awsclient.GetAWSClient(r.Client, awsclient.NewAwsClientInput{
 		SecretName: controllerutils.AwsSecretName,

--- a/pkg/controller/utils/conditions.go
+++ b/pkg/controller/utils/conditions.go
@@ -94,18 +94,6 @@ func FindAccountClaimCondition(conditions []awsv1alpha1.AccountClaimCondition, c
 	return nil
 }
 
-// CheckAccountConditions checks all conditions and resets LastTransitionTime to LastProbeTime if null
-func CheckAccountConditions(account *awsv1alpha1.Account) bool {
-	updated := false
-	for i, condition := range account.Status.Conditions {
-		if condition.LastTransitionTime == (metav1.Time{}) {
-			account.Status.Conditions[i].LastTransitionTime = condition.LastProbeTime
-			updated = true
-		}
-	}
-	return updated
-}
-
 // SetAccountCondition sets a condition on a Account resource's status
 func SetAccountCondition(
 	conditions []awsv1alpha1.AccountCondition,


### PR DESCRIPTION
This PR removes a fix that was put in place to specifically fix `.status.conditions[].lastTransitionTime` this has been merged to prod and all accounts reconciled.

cc/ @wshearn @fahlmant 