### PR TITLE
Comments AwsLimit variable to conform with Go linting best practices

### DIFF
--- a/pkg/controller/account/account_controller.go
+++ b/pkg/controller/account/account_controller.go
@@ -35,7 +35,8 @@ import (
 
 var log = logf.Log.WithName("controller_account")
 
-const (
+const
+	// Exported and used in cmd/manager/main.go
 	AwsLimit                = 4700
 	awsCredsUserName        = "aws_user_name"
 	awsCredsSecretIDKey     = "aws_access_key_id"
@@ -376,7 +377,7 @@ func (r *ReconcileAccount) Reconcile(request reconcile.Request) (reconcile.Resul
 			}
 
 			// Case not Resolved, log info and try again in pre-defined interval
-			reqLogger.Info(fmt.Sprintf(`Case %s not resolved, 
+			reqLogger.Info(fmt.Sprintf(`Case %s not resolved,
 			trying again in %d minutes`,
 				currentAcctInstance.Status.SupportCaseID,
 				intervalBetweenChecksMinutes))

--- a/pkg/controller/account/account_controller.go
+++ b/pkg/controller/account/account_controller.go
@@ -35,8 +35,8 @@ import (
 
 var log = logf.Log.WithName("controller_account")
 
-const
-	// Exported and used in cmd/manager/main.go
+const (
+	// AwsLimit tracks the hard limit to the number of accounts; exported for use in cmd/manager/main.go
 	AwsLimit                = 4700
 	awsCredsUserName        = "aws_user_name"
 	awsCredsSecretIDKey     = "aws_access_key_id"


### PR DESCRIPTION
Adds a comment to exported variable AwsLimit to conform with Go linting best practices.

Also removes a single trailing white space.

Signed-off-by: Christopher Collins <collins.christopher@gmail.com>