### PR TITLE
Log AWS CreateAccessKey error

### DIFF
--- a/pkg/controller/account/account_controller.go
+++ b/pkg/controller/account/account_controller.go
@@ -812,11 +812,8 @@ func CreateUserAccessKey(reqLogger logr.Logger, client awsclient.Client, userNam
 
 	result, err := client.CreateAccessKey(input)
 	if err != nil {
-		return &iam.CreateAccessKeyOutput{}, errors.New("Error creating access key")
-	}
-
-	if err != nil {
 		controllerutils.LogAwsError(reqLogger, "New AWS Error while creating user access key", nil, err)
+		return &iam.CreateAccessKeyOutput{}, fmt.Errorf("Error creating access key: %v", err)
 	}
 
 	return result, nil


### PR DESCRIPTION
If access key creation fails there isn't enough information to identify the problem. The error has been added to the log.

Log  entry before the change:
```
{"level":"error","ts":1575976761.5593326,"logger":"kubebuilder.controller","msg":"Reconciler error","controller":"account-controller","request":"aws-account-operator/osd-creds-mgmt-xf7cn8","error":"Error creating access key","stacktrace":"github.com/openshift/aws-account-operator/vendor/github.com/go-logr/zapr.(*zapLogger).Error\n\tsrc/github.com/openshift/aws-account-operator/vendor/github.com/go-logr/zapr/zapr.go:128\ngithub.com/openshift/aws-account-operator/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem\n\tsrc/github.com/openshift/aws-account-operator/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:217\ngithub.com/openshift/aws-account-operator/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func1\n\tsrc/github.com/openshift/aws-account-operator/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:158\ngithub.com/openshift/aws-account-operator/vendor/k8s.io/apimachinery/pkg/util/wait.JitterUntil.func1\n\tsrc/github.com/openshift/aws-account-operator/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:133\ngithub.com/openshift/aws-account-operator/vendor/k8s.io/apimachinery/pkg/util/wait.JitterUntil\n\tsrc/github.com/openshift/aws-account-operator/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:134\ngithub.com/openshift/aws-account-operator/vendor/k8s.io/apimachinery/pkg/util/wait.Until\n\tsrc/github.com/openshift/aws-account-operator/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:88"}
```