### PR TITLE
Add clusterrolebinding to oc template

### DIFF
--- a/hack/olm-registry/olm-artifacts-template.yaml
+++ b/hack/olm-registry/olm-artifacts-template.yaml
@@ -39,3 +39,48 @@ objects:
     name: aws-account-operator
     source: aws-account-operator-catalog
     sourceNamespace: aws-account-operator
+
+- apiVersion: rbac.authorization.k8s.io/v1
+  kind: ClusterRoleBinding
+  metadata:
+    name: aws-account-operator-client
+  subjects:
+  - kind: ServiceAccount
+    namespace: aws-account-operator-client
+    name: aws-account-operator-client
+  - kind: Group
+    name: aws-account-operator-client
+  roleRef:
+    kind: ClusterRole
+    name: aws-account-operator-client
+    apiGroup: rbac.authorization.k8s.io
+
+- apiVersion: rbac.authorization.k8s.io/v1
+  kind: ClusterRole
+  metadata:
+    name: aws-account-operator-client
+  rules:
+  - apiGroups:
+    - "aws.managed.openshift.io"
+    resources:
+    - accountclaims
+    verbs:
+    - create
+    - delete
+    - get
+    - list
+    - watch
+  - apiGroups:
+    - ""
+    resources:
+    - events
+    verbs:
+    - create
+  - apiGroups:
+    - ""
+    resources:
+    - configmaps
+    verbs:
+    - get
+    - create
+    - update


### PR DESCRIPTION
This PR adds the clusterrolebinding for the aws-acconut-operator-client ServiceAccount to the oc template that is applied on deployment.

Currently that template is not generated automatically as part of the deployment and probably should be if we are going to include things such as this clusterrolebinding. At the moment I don't see an easier way to apply the additional subject to the clusterrolebinding which is managed by OLM and at this time OLM does not support modifying or customizing the ciusterrolebinding it creates for service accounts listed in the CSV.

This clusterrolebinding is not going to have the same name as the one created by OLM but that shouldn't be an issue for the moment.

cc/ @maorfr @jewzaam @rogbas 