### PR TITLE
Reorder clusterrole and clusterrolebinding

### DIFF
--- a/hack/olm-registry/olm-artifacts-template.yaml
+++ b/hack/olm-registry/olm-artifacts-template.yaml
@@ -41,21 +41,6 @@ objects:
     sourceNamespace: aws-account-operator
 
 - apiVersion: rbac.authorization.k8s.io/v1
-  kind: ClusterRoleBinding
-  metadata:
-    name: aws-account-operator-client
-  subjects:
-  - kind: ServiceAccount
-    namespace: aws-account-operator-client
-    name: aws-account-operator-client
-  - kind: Group
-    name: aws-account-operator-client
-  roleRef:
-    kind: ClusterRole
-    name: aws-account-operator-client
-    apiGroup: rbac.authorization.k8s.io
-
-- apiVersion: rbac.authorization.k8s.io/v1
   kind: ClusterRole
   metadata:
     name: aws-account-operator-client
@@ -84,3 +69,18 @@ objects:
     - get
     - create
     - update
+
+- apiVersion: rbac.authorization.k8s.io/v1
+  kind: ClusterRoleBinding
+  metadata:
+    name: aws-account-operator-client
+  subjects:
+  - kind: ServiceAccount
+    namespace: aws-account-operator-client
+    name: aws-account-operator-client
+  - kind: Group
+    name: aws-account-operator-client
+  roleRef:
+    kind: ClusterRole
+    name: aws-account-operator-client
+    apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
The template will create resources in order so the role needs to be created before the binding can use it