### PR TITLE
Ensure we update the status on the accountclaim

### DIFF
--- a/pkg/controller/account/credentials_rotator.go
+++ b/pkg/controller/account/credentials_rotator.go
@@ -22,8 +22,17 @@ func (r *ReconcileAccount) RotateCredentials(reqLogger logr.Logger, awsSetupClie
 
 	reqLogger.Info(fmt.Sprintf("Rotating credentials for account %s secret %s", account.Name, STSCredentialsSecretName))
 
+	//var awsAssumedRoleClient awsclient.Client
+	var roleToAssume string
+
+	if account.Spec.BYOC {
+		roleToAssume = byocRole
+	} else {
+		roleToAssume = awsv1alpha1.AccountOperatorIAMRole
+	}
+
 	// Get STS user credentials
-	STSCredentials, STSCredentialsErr := getStsCredentials(reqLogger, awsSetupClient, awsv1alpha1.AccountOperatorIAMRole, account.Spec.AwsAccountID)
+	STSCredentials, STSCredentialsErr := getStsCredentials(reqLogger, awsSetupClient, roleToAssume, account.Spec.AwsAccountID)
 
 	if STSCredentialsErr != nil {
 		reqLogger.Info("RotateCredentials: Failed to get SRE admin STSCredentials from AWS api ", "Error", STSCredentialsErr.Error())
@@ -86,8 +95,17 @@ func (r *ReconcileAccount) RotateCredentials(reqLogger logr.Logger, awsSetupClie
 func (r *ReconcileAccount) RotateConsoleCredentials(reqLogger logr.Logger, awsSetupClient awsclient.Client, account *awsv1alpha1.Account) error {
 	STSCredentialsSecretName := account.Name + credentialwatcher.STSCredentialsConsoleSuffix
 
+	//var awsAssumedRoleClient awsclient.Client
+	var roleToAssume string
+
+	if account.Spec.BYOC {
+		roleToAssume = byocRole
+	} else {
+		roleToAssume = awsv1alpha1.AccountOperatorIAMRole
+	}
+
 	// Get STS user credentials
-	STSCredentials, STSCredentialsErr := getStsCredentials(reqLogger, awsSetupClient, awsv1alpha1.AccountOperatorIAMRole, account.Spec.AwsAccountID)
+	STSCredentials, STSCredentialsErr := getStsCredentials(reqLogger, awsSetupClient, roleToAssume, account.Spec.AwsAccountID)
 
 	if STSCredentialsErr != nil {
 		reqLogger.Info("RotateCredentials: Failed to get SRE admin STSCredentials from AWS api ", "Error", STSCredentialsErr.Error())

--- a/pkg/controller/account/iam.go
+++ b/pkg/controller/account/iam.go
@@ -237,6 +237,9 @@ func getStsCredentials(reqLogger logr.Logger, client awsclient.Client, iamRoleNa
 		if err == nil {
 			break
 		}
+		if i == 99 {
+			reqLogger.Info(fmt.Sprintf("Timed out while assuming role %s", roleArn))
+		}
 	}
 	if err != nil {
 		// Log AWS error


### PR DESCRIPTION
This PR fixes a few bugs with BYOC and also attempts to handle inconsistencies of the AWS API when working with STS tokens

There are two main problems its fixing:

- The AccountClaims status was never updated to Ready (For a few reasons)
- The AWS API seems to be returning "InvalidClientTokenId" or "AccessDenied" inconsistently with the STS tokens, I've implemented some retries.