### PR TITLE
Removed call to aws from totalaccountwatcher initilize

### DIFF
--- a/pkg/totalaccountwatcher/totalaccountwatcher.go
+++ b/pkg/totalaccountwatcher/totalaccountwatcher.go
@@ -49,7 +49,6 @@ func Initialize(client client.Client, watchInterval time.Duration) {
 	}
 
 	TotalAccountWatcher = NewTotalAccountWatcher(client, AwsClient, watchInterval)
-	TotalAccountWatcher.UpdateTotalAccounts(log)
 }
 
 // NewTotalAccountWatcher returns a new instance of the TotalAccountWatcher interface


### PR DESCRIPTION
On operator start we check that total number of accounts created in the AWS organization. This process holds the operator from starting until this call completes, this API call to AWS often takes 30 seconds to > 1 minute we should move it to a go routine.

This PR removes update total call from initialize function for totalaccountwatcher