### PR TITLE
Remove finalizer if BYOC

### DIFF
--- a/pkg/controller/accountclaim/accountclaim_controller.go
+++ b/pkg/controller/accountclaim/accountclaim_controller.go
@@ -124,6 +124,42 @@ func (r *ReconcileAccountClaim) Reconcile(request reconcile.Request) (reconcile.
 
 		return reconcile.Result{}, nil
 	}
+	// Check if accountClaim is being deleted, this will trigger the account reuse workflow
+
+	if accountClaim.DeletionTimestamp != nil {
+		if contains(accountClaim.GetFinalizers(), accountClaimFinalizer) {
+			// Only do AWS cleanup and account reset if accountLink is not empty
+			// We will not attempt AWS cleanup if the account is BYOC since we're not going to reuse these accounts
+			if accountClaim.Spec.AccountLink != "" && accountClaim.Spec.BYOC == false {
+				err := r.finalizeAccountClaim(reqLogger, accountClaim)
+				if err != nil {
+					// If the finalize/cleanup process fails for an account we don't want to return
+					// we will flag the account with the Failed Reuse condition, and with state = Failed
+
+					// Get account claimed by deleted accountclaim
+					failedReusedAccount, accountErr := r.getClaimedAccount(accountClaim.Spec.AccountLink, awsv1alpha1.AccountCrNamespace)
+					if accountErr != nil {
+						reqLogger.Error(accountErr, "Failed to get claimed account")
+						return reconcile.Result{}, err
+					}
+					// Update account status and add "Reuse Failed" condition
+					accountErr = r.resetAccountSpecStatus(reqLogger, failedReusedAccount, accountClaim, awsv1alpha1.AccountFailed, "Failed")
+					if accountErr != nil {
+						reqLogger.Error(accountErr, "Failed updating account status for failed reuse")
+						return reconcile.Result{}, err
+					}
+				}
+			}
+
+			// Remove finalizer to unlock deletion of the accountClaim
+			err = r.removeFinalizer(reqLogger, accountClaim, accountClaimFinalizer)
+			if err != nil {
+				return reconcile.Result{}, err
+			}
+
+		}
+		return reconcile.Result{}, nil
+	}
 
 	if accountClaim.Spec.BYOC {
 
@@ -202,41 +238,6 @@ func (r *ReconcileAccountClaim) Reconcile(request reconcile.Request) (reconcile.
 
 		return reconcile.Result{}, nil
 
-	}
-
-	// Check if accountClaim is being deleted, this will trigger the account reuse workflow
-	if accountClaim.DeletionTimestamp != nil {
-		if contains(accountClaim.GetFinalizers(), accountClaimFinalizer) {
-			// Only do AWS cleanup and account reset if accountLink is not empty
-			if accountClaim.Spec.AccountLink != "" {
-				err := r.finalizeAccountClaim(reqLogger, accountClaim)
-				if err != nil {
-					// If the finalize/cleanup process fails for an account we don't want to return
-					// we will flag the account with the Failed Reuse condition, and with state = Failed
-
-					// Get account claimed by deleted accountclaim
-					failedReusedAccount, accountErr := r.getClaimedAccount(accountClaim.Spec.AccountLink, awsv1alpha1.AccountCrNamespace)
-					if accountErr != nil {
-						reqLogger.Error(accountErr, "Failed to get claimed account")
-						return reconcile.Result{}, err
-					}
-					// Update account status and add "Reuse Failed" condition
-					accountErr = r.resetAccountSpecStatus(reqLogger, failedReusedAccount, accountClaim, awsv1alpha1.AccountFailed, "Failed")
-					if accountErr != nil {
-						reqLogger.Error(accountErr, "Failed updating account status for failed reuse")
-						return reconcile.Result{}, err
-					}
-				}
-			}
-
-			// Remove finalizer to unlock deletion of the accountClaim
-			err = r.removeFinalizer(reqLogger, accountClaim, accountClaimFinalizer)
-			if err != nil {
-				return reconcile.Result{}, err
-			}
-
-		}
-		return reconcile.Result{}, nil
 	}
 
 	// Return if this claim has been satisfied


### PR DESCRIPTION
This PR ensures the finalizer for the accountClaim is removed for BYOC accountClaims when the accountClaim is deleted.