### PR TITLE
Remove finalizer from the Account CR if BYOC

### DIFF
--- a/pkg/apis/aws/v1alpha1/account_types.go
+++ b/pkg/apis/aws/v1alpha1/account_types.go
@@ -28,6 +28,8 @@ const (
 	AccountCrNamespace = "aws-account-operator"
 	// IAM Role name for IAM user creating resources in account
 	AccountOperatorIAMRole = "OrganizationAccountAccessRole"
+	// AccountFinalizer is the string finalizer name
+	AccountFinalizer = "finalizer.aws.managed.openshift.io"
 )
 
 // AccountSpec defines the desired state of Account

--- a/pkg/controller/accountpool/accountpool_controller.go
+++ b/pkg/controller/accountpool/accountpool_controller.go
@@ -144,7 +144,7 @@ func (r *ReconcileAccountPool) Reconcile(request reconcile.Request) (reconcile.R
 
 	// Create Account CR
 	newAccount := utils.GenerateAccountCR(awsv1alpha1.AccountCrNamespace)
-	utils.AddFinalizer(newAccount, "finalizer.aws.managed.openshift.io")
+	utils.AddFinalizer(newAccount, awsv1alpha1.AccountFinalizer)
 
 	// Set AccountPool instance as the owner and controller
 	if err := controllerutil.SetControllerReference(currentAccountPool, newAccount, r.scheme); err != nil {


### PR DESCRIPTION
Currently when an accountClaim CR is deleted and the AccountClaim was BYOC it will attempt to delete the Account CR because the accountClaim is set as an owner reference. This will fail because the finalizer on the account CR is never removed.

It fixes this error where we attempt to get the `.Spec.claimLink` in the reconcile loop instead of deleting the account and exiting the reconcile.

`"level":"error","ts":1576783019.8541033,"logger":"kubebuilder.controller","msg":"Reconciler error","controller":"account-controller","request":"aws-account-operator/osd-creds-mgmt-vqnml2","error":"AccountClaim.aws.managed.openshift.io \"jamesh-corp\" not found"`