### PR TITLE
Add roleDisplayName for OCM user interface

### DIFF
--- a/deploy/crds/aws_v1alpha1_awsfederatedrole_crd.yaml
+++ b/deploy/crds/aws_v1alpha1_awsfederatedrole_crd.yaml
@@ -84,8 +84,15 @@ spec:
                 type: string
               type: array
             roleDescription:
+              description: RoleDescription is a user friendly description of the role,
+                this discription will be displayed in the OCM user interface
+              type: string
+            roleDisplayName:
+              description: RoleDisplayName is a user friendly display name for the
+                OCM user interface
               type: string
           required:
+          - roleDisplayName
           - roleDescription
           type: object
         status:

--- a/pkg/apis/aws/v1alpha1/awsfederatedrole_types.go
+++ b/pkg/apis/aws/v1alpha1/awsfederatedrole_types.go
@@ -23,6 +23,9 @@ const (
 // AWSFederatedRoleSpec defines the desired state of AWSFederatedRole
 // +k8s:openapi-gen=true
 type AWSFederatedRoleSpec struct {
+	// RoleDisplayName is a user friendly display name for the OCM user interface
+	RoleDisplayName string `json:"roleDisplayName"`
+	// RoleDescription is a user friendly description of the role, this discription will be displayed in the OCM user interface
 	RoleDescription string `json:"roleDescription"`
 	// AWSCustomPolicy is the defenition of a custom aws permission policy that will be associated with this role
 	// +optional

--- a/pkg/apis/aws/v1alpha1/zz_generated.openapi.go
+++ b/pkg/apis/aws/v1alpha1/zz_generated.openapi.go
@@ -191,10 +191,18 @@ func schema_pkg_apis_aws_v1alpha1_AWSFederatedRoleSpec(ref common.ReferenceCallb
 			SchemaProps: spec.SchemaProps{
 				Description: "AWSFederatedRoleSpec defines the desired state of AWSFederatedRole",
 				Properties: map[string]spec.Schema{
+					"roleDisplayName": {
+						SchemaProps: spec.SchemaProps{
+							Description: "RoleDisplayName is a user friendly display name for the OCM user interface",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 					"roleDescription": {
 						SchemaProps: spec.SchemaProps{
-							Type:   []string{"string"},
-							Format: "",
+							Description: "RoleDescription is a user friendly description of the role, this discription will be displayed in the OCM user interface",
+							Type:        []string{"string"},
+							Format:      "",
 						},
 					},
 					"awsCustomPolicy": {
@@ -218,7 +226,7 @@ func schema_pkg_apis_aws_v1alpha1_AWSFederatedRoleSpec(ref common.ReferenceCallb
 						},
 					},
 				},
-				Required: []string{"roleDescription"},
+				Required: []string{"roleDisplayName", "roleDescription"},
 			},
 		},
 		Dependencies: []string{


### PR DESCRIPTION
OCM requires a way to dynamically display a user friendly role name, along with the description we've added a display name to the spec.