### PR TITLE
Removes support cases functions to own file

### DIFF
--- a/pkg/controller/account/account_controller.go
+++ b/pkg/controller/account/account_controller.go
@@ -14,7 +14,6 @@ import (
 	"github.com/aws/aws-sdk-go/service/iam"
 	"github.com/aws/aws-sdk-go/service/organizations"
 	"github.com/aws/aws-sdk-go/service/sts"
-	"github.com/aws/aws-sdk-go/service/support"
 	"github.com/go-logr/logr"
 	"github.com/openshift/aws-account-operator/pkg/controller/utils"
 	corev1 "k8s.io/api/core/v1"
@@ -793,10 +792,10 @@ func (r *ReconcileAccount) BuildIAMUser(reqLogger logr.Logger, awsClient awsclie
 		}
 
 		return userSecret.ObjectMeta.Name, nil
-	} else {
-		//Secret already exists
-		return fmt.Sprintf("%s-secret", secretName), nil
 	}
+
+	//Secret already exists
+	return fmt.Sprintf("%s-secret", secretName), nil
 }
 
 func (r *ReconcileAccount) setStatusFailed(reqLogger logr.Logger, awsAccount *awsv1alpha1.Account, message string) error {
@@ -1108,86 +1107,7 @@ func (r *ReconcileAccount) statusUpdate(reqLogger logr.Logger, account *awsv1alp
 	return err
 }
 
-func createCase(reqLogger logr.Logger, accountID string, client awsclient.Client) (string, error) {
-	// Initialize basic communication body and case subject
-	caseCommunicationBody := fmt.Sprintf("Hello AWS,\n\nPlease enable Enterprise Support on AWS account %s\n\nOnce this has been completed and the default EC2 limits are ready for use, please resolve this support case. Please do not set the case to Pending Customer Action\n\nThanks", accountID)
-	caseSubject := fmt.Sprintf("Add account %s to Enterprise Support", accountID)
-
-	createCaseInput := support.CreateCaseInput{
-		CategoryCode:      aws.String(caseCategoryCode),
-		ServiceCode:       aws.String(caseServiceCode),
-		IssueType:         aws.String(caseIssueType),
-		CommunicationBody: aws.String(caseCommunicationBody),
-		Subject:           aws.String(caseSubject),
-		SeverityCode:      aws.String(caseSeverity),
-		Language:          aws.String(caseLanguage),
-	}
-
-	reqLogger.Info("Creating the case", "CaseInput", createCaseInput)
-
-	caseResult, caseErr := client.CreateCase(&createCaseInput)
-	if caseErr != nil {
-		var returnErr error
-		if aerr, ok := caseErr.(awserr.Error); ok {
-			switch aerr.Code() {
-			case support.ErrCodeCaseCreationLimitExceeded:
-				returnErr = ErrAwsCaseCreationLimitExceeded
-			case support.ErrCodeInternalServerError:
-				returnErr = ErrAwsInternalFailure
-			default:
-				returnErr = ErrAwsFailedCreateSupportCase
-			}
-
-			controllerutils.LogAwsError(reqLogger, "New AWS Error while creating case", returnErr, caseErr)
-		}
-		return "", returnErr
-	}
-
-	reqLogger.Info("Support case created", "AccountID", accountID, "CaseID", caseResult.CaseId)
-
-	return *caseResult.CaseId, nil
-}
-
-func checkCaseResolution(reqLogger logr.Logger, caseID string, client awsclient.Client) (bool, error) {
-	// Look for the case using the unique ID provided
-	describeCasesInput := support.DescribeCasesInput{
-		CaseIdList: []*string{
-			aws.String(caseID),
-		},
-	}
-
-	caseResult, caseErr := client.DescribeCases(&describeCasesInput)
-	if caseErr != nil {
-
-		var returnErr error
-		if aerr, ok := caseErr.(awserr.Error); ok {
-			switch aerr.Code() {
-			case support.ErrCodeCaseIdNotFound:
-				returnErr = ErrAwsSupportCaseIDNotFound
-			case support.ErrCodeInternalServerError:
-				returnErr = ErrAwsInternalFailure
-			default:
-				returnErr = ErrAwsFailedDescribeSupportCase
-			}
-			controllerutils.LogAwsError(reqLogger, "New AWS Error while checking case resolution", returnErr, caseErr)
-		}
-
-		return false, returnErr
-	}
-
-	// Since we are describing cases based on the unique ID, this list will have only 1 element
-	if *caseResult.Cases[0].Status == caseStatusResolved {
-		reqLogger.Info(fmt.Sprintf("Case Resolved: %s", caseID))
-		return true, nil
-	}
-
-	// reqLogger.Info(fmt.Sprintf("Case [%s] not yet Resolved, waiting. Current Status: %s", caseID, *caseResult.Cases[0].Status))
-	return false, nil
-
-}
-
 func matchSubstring(roleID, role string) (bool, error) {
 	matched, err := regexp.MatchString(roleID, role)
 	return matched, err
-
 }

--- a/pkg/controller/account/cases.go
+++ b/pkg/controller/account/cases.go
@@ -1,0 +1,93 @@
+package account
+
+import (
+	"fmt"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/service/support"
+	"github.com/go-logr/logr"
+
+	"github.com/openshift/aws-account-operator/pkg/awsclient"
+	controllerutils "github.com/openshift/aws-account-operator/pkg/controller/utils"
+)
+
+func createCase(reqLogger logr.Logger, accountID string, client awsclient.Client) (string, error) {
+	// Initialize basic communication body and case subject
+	caseCommunicationBody := fmt.Sprintf(
+		"Hello AWS,\n\nPlease enable Enterprise Support on AWS account %s.\n\nOnce this has been completed and the default EC2 limits are ready for use, please resolve this support case. Please do not set the case to Pending Customer Action.\n\nThanks.", accountID,
+	)
+
+	caseSubject := fmt.Sprintf("Add account %s to Enterprise Support", accountID)
+
+	createCaseInput := support.CreateCaseInput{
+		CategoryCode:      aws.String(caseCategoryCode),
+		ServiceCode:       aws.String(caseServiceCode),
+		IssueType:         aws.String(caseIssueType),
+		CommunicationBody: aws.String(caseCommunicationBody),
+		Subject:           aws.String(caseSubject),
+		SeverityCode:      aws.String(caseSeverity),
+		Language:          aws.String(caseLanguage),
+	}
+
+	reqLogger.Info("Creating the case", "CaseInput", createCaseInput)
+
+	caseResult, caseErr := client.CreateCase(&createCaseInput)
+	if caseErr != nil {
+		var returnErr error
+		if aerr, ok := caseErr.(awserr.Error); ok {
+			switch aerr.Code() {
+			case support.ErrCodeCaseCreationLimitExceeded:
+				returnErr = ErrAwsCaseCreationLimitExceeded
+			case support.ErrCodeInternalServerError:
+				returnErr = ErrAwsInternalFailure
+			default:
+				returnErr = ErrAwsFailedCreateSupportCase
+			}
+
+			controllerutils.LogAwsError(reqLogger, "New AWS Error while creating case", returnErr, caseErr)
+		}
+		return "", returnErr
+	}
+
+	reqLogger.Info("Support case created", "AccountID", accountID, "CaseID", caseResult.CaseId)
+
+	return *caseResult.CaseId, nil
+}
+
+func checkCaseResolution(reqLogger logr.Logger, caseID string, client awsclient.Client) (bool, error) {
+	// Look for the case using the unique ID provided
+	describeCasesInput := support.DescribeCasesInput{
+		CaseIdList: []*string{
+			aws.String(caseID),
+		},
+	}
+
+	caseResult, caseErr := client.DescribeCases(&describeCasesInput)
+	if caseErr != nil {
+
+		var returnErr error
+		if aerr, ok := caseErr.(awserr.Error); ok {
+			switch aerr.Code() {
+			case support.ErrCodeCaseIdNotFound:
+				returnErr = ErrAwsSupportCaseIDNotFound
+			case support.ErrCodeInternalServerError:
+				returnErr = ErrAwsInternalFailure
+			default:
+				returnErr = ErrAwsFailedDescribeSupportCase
+			}
+			controllerutils.LogAwsError(reqLogger, "New AWS Error while checking case resolution", returnErr, caseErr)
+		}
+
+		return false, returnErr
+	}
+
+	// Since we are describing cases based on the unique ID, this list will have only 1 element
+	if *caseResult.Cases[0].Status == caseStatusResolved {
+		reqLogger.Info(fmt.Sprintf("Case Resolved: %s", caseID))
+		return true, nil
+	}
+
+	// reqLogger.Info(fmt.Sprintf("Case [%s] not yet Resolved, waiting. Current Status: %s", caseID, *caseResult.Cases[0].Status))
+	return false, nil
+}


### PR DESCRIPTION
This PR moves functions for AWS support cases-related code to their own file.  This is the first of several to reduce the length and complexity of the accounts_controller.go file.

REF: [OSD-1937 "aws-account-operator breakout functions from account_controller.go"](https://issues.redhat.com/browse/OSD-1937)