### PR TITLE
Fix for AccountClaim not registering Account CR being in an error state

### DIFF
--- a/pkg/apis/aws/v1alpha1/accountclaim_types.go
+++ b/pkg/apis/aws/v1alpha1/accountclaim_types.go
@@ -57,6 +57,8 @@ type AccountClaimConditionType string
 const (
 	// AccountClaimed is set when an Account is claimed
 	AccountClaimed AccountClaimConditionType = "Claimed"
+	// BYOCAccountClaimFailed is set when a BYOC Account Fails
+	BYOCAccountClaimFailed AccountClaimConditionType = "BYOCAccountClaimFailed"
 	// AccountUnclaimed is set when an Account is not claimed
 	AccountUnclaimed AccountClaimConditionType = "Unclaimed"
 	// BYOCAWSAccountInUse is set when a BYOC AWS Account is in use


### PR DESCRIPTION
Moved the Account CR base case handler bellow AccountReady and AccountFailed tests, the base case was being checked too early causing the AccountFailed test never being reached. https://issues.redhat.com/browse/OSD-2627