### PR TITLE
Added credential refresh to reuse

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,5 +73,7 @@ Session.vim
 tags
 ### VisualStudioCode ###
 .vscode/*
+### Goland ###
+.idea/*
 .history
 # End of https://www.gitignore.io/api/go,vim,emacs,visualstudiocode


### PR DESCRIPTION
This PR adds Boolean rotateConsoleCredentials and RotateCredentials to true after account clean up so that credentials are refreshed when doing an account reuse. 