### PR TITLE
Deletes BYOCAdminAccess role and recreate if it exists

### DIFF
--- a/pkg/awsclient/client.go
+++ b/pkg/awsclient/client.go
@@ -72,7 +72,10 @@ type Client interface {
 	CreatePolicy(*iam.CreatePolicyInput) (*iam.CreatePolicyOutput, error)
 	DeletePolicy(input *iam.DeletePolicyInput) (*iam.DeletePolicyOutput, error)
 	AttachRolePolicy(*iam.AttachRolePolicyInput) (*iam.AttachRolePolicyOutput, error)
+	DetachRolePolicy(*iam.DetachRolePolicyInput) (*iam.DetachRolePolicyOutput, error)
+	ListAttachedRolePolicies(*iam.ListAttachedRolePoliciesInput) (*iam.ListAttachedRolePoliciesOutput, error)
 	CreateRole(*iam.CreateRoleInput) (*iam.CreateRoleOutput, error)
+	GetRole(*iam.GetRoleInput) (*iam.GetRoleOutput, error)
 	DeleteRole(*iam.DeleteRoleInput) (*iam.DeleteRoleOutput, error)
 
 	//Organizations
@@ -198,8 +201,20 @@ func (c *awsClient) AttachRolePolicy(input *iam.AttachRolePolicyInput) (*iam.Att
 	return c.iamClient.AttachRolePolicy(input)
 }
 
+func (c *awsClient) DetachRolePolicy(input *iam.DetachRolePolicyInput) (*iam.DetachRolePolicyOutput, error) {
+	return c.iamClient.DetachRolePolicy(input)
+}
+
+func (c *awsClient) ListAttachedRolePolicies(input *iam.ListAttachedRolePoliciesInput) (*iam.ListAttachedRolePoliciesOutput, error) {
+	return c.iamClient.ListAttachedRolePolicies(input)
+}
+
 func (c *awsClient) CreateRole(input *iam.CreateRoleInput) (*iam.CreateRoleOutput, error) {
 	return c.iamClient.CreateRole(input)
+}
+
+func (c *awsClient) GetRole(input *iam.GetRoleInput) (*iam.GetRoleOutput, error) {
+	return c.iamClient.GetRole(input)
 }
 
 func (c *awsClient) DeleteRole(input *iam.DeleteRoleInput) (*iam.DeleteRoleOutput, error) {

--- a/pkg/awsclient/mock/mock_client.go
+++ b/pkg/awsclient/mock/mock_client.go
@@ -353,6 +353,36 @@ func (mr *MockClientMockRecorder) AttachRolePolicy(arg0 interface{}) *gomock.Cal
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AttachRolePolicy", reflect.TypeOf((*MockClient)(nil).AttachRolePolicy), arg0)
 }
 
+// DetachRolePolicy mocks base method
+func (m *MockClient) DetachRolePolicy(arg0 *iam.DetachRolePolicyInput) (*iam.DetachRolePolicyOutput, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DetachRolePolicy", arg0)
+	ret0, _ := ret[0].(*iam.DetachRolePolicyOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DetachRolePolicy indicates an expected call of DetachRolePolicy
+func (mr *MockClientMockRecorder) DetachRolePolicy(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DetachRolePolicy", reflect.TypeOf((*MockClient)(nil).DetachRolePolicy), arg0)
+}
+
+// ListAttachedRolePolicies mocks base method
+func (m *MockClient) ListAttachedRolePolicies(arg0 *iam.ListAttachedRolePoliciesInput) (*iam.ListAttachedRolePoliciesOutput, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListAttachedRolePolicies", arg0)
+	ret0, _ := ret[0].(*iam.ListAttachedRolePoliciesOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListAttachedRolePolicies indicates an expected call of ListAttachedRolePolicies
+func (mr *MockClientMockRecorder) ListAttachedRolePolicies(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListAttachedRolePolicies", reflect.TypeOf((*MockClient)(nil).ListAttachedRolePolicies), arg0)
+}
+
 // CreateRole mocks base method
 func (m *MockClient) CreateRole(arg0 *iam.CreateRoleInput) (*iam.CreateRoleOutput, error) {
 	m.ctrl.T.Helper()
@@ -366,6 +396,21 @@ func (m *MockClient) CreateRole(arg0 *iam.CreateRoleInput) (*iam.CreateRoleOutpu
 func (mr *MockClientMockRecorder) CreateRole(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateRole", reflect.TypeOf((*MockClient)(nil).CreateRole), arg0)
+}
+
+// GetRole mocks base method
+func (m *MockClient) GetRole(arg0 *iam.GetRoleInput) (*iam.GetRoleOutput, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetRole", arg0)
+	ret0, _ := ret[0].(*iam.GetRoleOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetRole indicates an expected call of GetRole
+func (mr *MockClientMockRecorder) GetRole(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRole", reflect.TypeOf((*MockClient)(nil).GetRole), arg0)
 }
 
 // DeleteRole mocks base method

--- a/pkg/controller/account/account_controller_test.go
+++ b/pkg/controller/account/account_controller_test.go
@@ -1,0 +1,81 @@
+package account
+
+import (
+	"fmt"
+	"testing"
+)
+
+type substringTestPair struct {
+	roleID string
+	role   string
+}
+
+var matchPairs = []substringTestPair{
+	{
+		"AROA3SYAY5EP3KG4G2FIR",
+		"AROA3SYAY5EP3KG4G2FIR:awsAccountOperator",
+	},
+	{
+		"AROA3SYABCEDRKG4G2FIR",
+		"AROA3SYABCEDRKG4G2FIR:awsAccountOperator",
+	},
+	{
+		"AROABIGORGOHOME4G2FIR",
+		"AROABIGORGOHOME4G2FIR:awsAccountOperator",
+	},
+}
+
+var noMatchPairs = []substringTestPair{
+	{
+		"IHEHRHSHY5EP3KG4G2FIR",
+		"AROA3SYAY5EP3KG4G2FIR:awsAccountOperator",
+	},
+	{
+		"AROA3SYAEHAIRHHALKBCDERKG422FIR",
+		"AROA3SYABCEDRKG4G2FIR:awsAccountOperator",
+	},
+	{
+		"A test string",
+		"AROA3SYAY5EP3KG4G2FIR:awsAccountOperator",
+	},
+}
+
+func TestMatchSubstring(t *testing.T) {
+	for _, pair := range matchPairs {
+		result, err := matchSubstring(pair.roleID, pair.role)
+		if result != true {
+			t.Error(
+				"For", fmt.Sprintf("%s - %s", pair.roleID, pair.role),
+				"expected", true,
+				"got", result,
+			)
+		}
+		if err != nil {
+			t.Error(
+				"For", fmt.Sprintf("%s - %s", pair.roleID, pair.role),
+				"expected", nil,
+				"got", err,
+			)
+		}
+	}
+}
+
+func TestNoMatchSubstring(t *testing.T) {
+	for _, pair := range noMatchPairs {
+		result, err := matchSubstring(pair.roleID, pair.role)
+		if result != false {
+			t.Error(
+				"For", fmt.Sprintf("%s - %s", pair.roleID, pair.role),
+				"expected", false,
+				"got", result,
+			)
+		}
+		if err != nil {
+			t.Error(
+				"For", fmt.Sprintf("%s - %s", pair.roleID, pair.role),
+				"expected", nil,
+				"got", err,
+			)
+		}
+	}
+}

--- a/pkg/controller/account/byoc.go
+++ b/pkg/controller/account/byoc.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/iam"
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
@@ -24,16 +25,22 @@ const (
 	byocUserArnSuffix = ":user/byocSetupUser"
 )
 
+// ErrBYOCAccountIDMissing is an error for missing Account ID
 var ErrBYOCAccountIDMissing = errors.New("BYOCAccountIDMissing")
+
+// ErrBYOCSecretRefMissing is an error for missing Secret References
 var ErrBYOCSecretRefMissing = errors.New("BYOCSecretRefMissing")
 
+// Placeholder for the unique role id created by createRole
+var roleID = ""
+
 // Create role for BYOC IAM user to assume
-func createBYOCAdminAccessRole(reqLogger logr.Logger, awsSetupClient awsclient.Client, byocAWSClient awsclient.Client, policyArn string) error {
+func createBYOCAdminAccessRole(reqLogger logr.Logger, awsSetupClient awsclient.Client, byocAWSClient awsclient.Client, policyArn string) (roleID string, err error) {
 
 	getUserOutput, err := awsSetupClient.GetUser(&iam.GetUserInput{})
 	if err != nil {
 		reqLogger.Error(err, "Failed to get non-BYOC IAM User info")
-		return err
+		return roleID, err
 	}
 
 	// Lay out a basic AssumeRolePolicyDocument for BYOC
@@ -54,26 +61,158 @@ func createBYOCAdminAccessRole(reqLogger logr.Logger, awsSetupClient awsclient.C
 	// Convert role to JSON
 	jsonAssumeRolePolicyDoc, err := json.Marshal(&assumeRolePolicyDoc)
 	if err != nil {
-		return err
+		return roleID, err
+	}
+
+	// Check if Role already exists
+	existingRole, err := byocAWSClient.GetRole(&iam.GetRoleInput{
+		RoleName: aws.String(byocRole),
+	})
+
+	if err != nil {
+		if aerr, ok := err.(awserr.Error); ok {
+			switch aerr.Code() {
+			case iam.ErrCodeNoSuchEntityException:
+				// This is OK and to be expected if the role hasn't been created yet
+				reqLogger.Info(fmt.Sprintf("%s role does not yet exist", byocRole))
+			case iam.ErrCodeServiceFailureException:
+				reqLogger.Error(
+					aerr,
+					fmt.Sprintf("AWS Internal Server Error (%s) checking for %s role existence: %s", aerr.Code(), byocRole, aerr.Message()),
+				)
+				return roleID, err
+			default:
+				// Currently only two errors returned by AWS.  This is a catch-all for any that may appear in the future.
+				reqLogger.Error(
+					aerr,
+					fmt.Sprintf("Unknown error (%s) checking for %s role existence: %s", aerr.Code(), byocRole, aerr.Message()),
+				)
+				return roleID, err
+			}
+		} else {
+			return roleID, err
+		}
+	}
+
+	if (*existingRole != iam.GetRoleOutput{}) {
+		reqLogger.Info(fmt.Sprintf("Found pre-existing role: %s", byocRole))
+		// existingRole is not empty
+		listRoleInput := &iam.ListAttachedRolePoliciesInput{
+			RoleName: aws.String(byocRole),
+		}
+		policyList, listErr := byocAWSClient.ListAttachedRolePolicies(listRoleInput)
+		if listErr != nil {
+			if aerr, ok := listErr.(awserr.Error); ok {
+				switch aerr.Code() {
+				default:
+					reqLogger.Error(
+						aerr,
+						fmt.Sprintf(aerr.Error()),
+					)
+					return roleID, err
+				}
+			} else {
+				return roleID, err
+			}
+		}
+
+		for _, policy := range policyList.AttachedPolicies {
+			reqLogger.Info(fmt.Sprintf("Detaching Policy %s from role %s", *policy.PolicyName, byocRole))
+			// Must detach the RolePolicy before it can be deleted
+			_, err := byocAWSClient.DetachRolePolicy(&iam.DetachRolePolicyInput{
+				RoleName:  aws.String(byocRole),
+				PolicyArn: aws.String(*policy.PolicyArn),
+			})
+			if err != nil {
+				if aerr, ok := err.(awserr.Error); ok {
+					switch aerr.Code() {
+					default:
+						reqLogger.Error(
+							aerr,
+							fmt.Sprintf(aerr.Error()),
+						)
+						reqLogger.Error(err, fmt.Sprintf("%v", err))
+						return roleID, err
+					}
+				}
+			}
+		}
+
+		reqLogger.Info(fmt.Sprintf("Deleting Role: %s", byocRole))
+		_, delErr := byocAWSClient.DeleteRole(&iam.DeleteRoleInput{
+			RoleName: aws.String(byocRole),
+		})
+
+		// Delete the existing role
+		if delErr != nil {
+			if aerr, ok := delErr.(awserr.Error); ok {
+				switch aerr.Code() {
+				default:
+					reqLogger.Error(
+						aerr,
+						fmt.Sprintf(aerr.Error()),
+					)
+					reqLogger.Error(err, fmt.Sprintf("%v", err))
+					return roleID, err
+				}
+			}
+		}
 	}
 
 	// Create the base role
-	_, err = byocAWSClient.CreateRole(&iam.CreateRoleInput{
+	reqLogger.Info(fmt.Sprintf("Creating role: %s", byocRole))
+	createRoleOutput, err := byocAWSClient.CreateRole(&iam.CreateRoleInput{
 		RoleName:                 aws.String(byocRole),
 		Description:              aws.String("AdminAccess for BYOC"),
 		AssumeRolePolicyDocument: aws.String(string(jsonAssumeRolePolicyDoc)),
 	})
 	if err != nil {
-		return err
+		return roleID, err
 	}
 
+	// Successfully created role gets a unique identifier
+	roleID = *createRoleOutput.Role.RoleId
+	reqLogger.Info(fmt.Sprintf("New RoleID: %s", roleID))
+
+	reqLogger.Info(fmt.Sprintf("Attaching policy %s to role %s", policyArn, byocRole))
 	// Attach the specified policy to the BYOC role
 	_, err = byocAWSClient.AttachRolePolicy(&iam.AttachRolePolicyInput{
 		RoleName:  aws.String(byocRole),
 		PolicyArn: aws.String(policyArn),
 	})
 
-	return err
+	reqLogger.Info(fmt.Sprintf("Checking if policy %s has been attached", policyArn))
+	// Attaching the policy suffers from an eventual consistency problem
+	listRoleInput := &iam.ListAttachedRolePoliciesInput{
+		RoleName: aws.String(byocRole),
+	}
+	policyList, listErr := byocAWSClient.ListAttachedRolePolicies(listRoleInput)
+	if listErr != nil {
+		if aerr, ok := listErr.(awserr.Error); ok {
+			switch aerr.Code() {
+			default:
+				reqLogger.Error(
+					aerr,
+					fmt.Sprintf(aerr.Error()),
+				)
+				return roleID, err
+			}
+		} else {
+			return roleID, err
+		}
+	}
+
+	for _, policy := range policyList.AttachedPolicies {
+		if *policy.PolicyArn == policyArn {
+			reqLogger.Info(fmt.Sprintf("Found attached policy %s", *policy.PolicyArn))
+			break
+		} else {
+			err = fmt.Errorf("Policy %s never attached to role %s", policyArn, byocRole)
+			return roleID, err
+		}
+	}
+
+	return roleID, err
 }
 
 func (r *ReconcileAccount) getBYOCClient(currentAcct *awsv1alpha1.Account) (awsclient.Client, *awsv1alpha1.AccountClaim, error) {


### PR DESCRIPTION
Checks for the existence of the BYOC AdminAccess role before attempting to
create it.  If it exists (ie: the returned struct is not empty), then lists
the attached role policies, and detaches them, and then deletes the role.
(The role cannot be deleted with attached policies.)

After deleting the role, the contoller then continues to create the role fresh.

REF: [OSD-2582](https://issues.redhat.com/browse/OSD-2582)