### PR TITLE
Rotate credentials by accounts that are in Ready state

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,7 +73,6 @@ Session.vim
 tags
 ### VisualStudioCode ###
 .vscode/*
-### Goland ###
 .idea/*
 .history
 # End of https://www.gitignore.io/api/go,vim,emacs,visualstudiocode

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -29,11 +29,11 @@ import (
 
 // Change below variables to serve metrics on different host or port.
 var (
-	metricsPort                   = "8080"
-	metricsPath                   = "/metrics"
-	secretWatcherScanInterval     = time.Duration(10) * time.Minute
-	hours                     int = 1
-	totalWatcherInterval          = time.Duration(15) * time.Minute
+	metricsPort               = "8080"
+	metricsPath               = "/metrics"
+	secretWatcherScanInterval = time.Duration(10) * time.Minute
+	hours                     = 1
+	totalWatcherInterval      = time.Duration(15) * time.Minute
 )
 
 var log = logf.Log.WithName("cmd")
@@ -129,15 +129,15 @@ func main() {
 	// work
 	stopCh := signals.SetupSignalHandler()
 
-	accountWatcherClient, err := client.New(cfg, client.Options{})
+	goRoutineClient, err := client.New(cfg, client.Options{})
 	if err != nil {
 		log.Error(err, "")
 	}
 
 	// Initialize the SecretWatcher
-	credentialwatcher.Initialize(mgr.GetClient(), secretWatcherScanInterval)
+	credentialwatcher.Initialize(goRoutineClient, secretWatcherScanInterval)
 
-	totalaccountwatcher.Initialize(accountWatcherClient, totalWatcherInterval)
+	totalaccountwatcher.Initialize(goRoutineClient, totalWatcherInterval)
 
 	// Start the secret watcher
 	go credentialwatcher.SecretWatcher.Start(log, stopCh)

--- a/pkg/controller/account/credentials_rotator.go
+++ b/pkg/controller/account/credentials_rotator.go
@@ -78,7 +78,7 @@ func (r *ReconcileAccount) RotateCredentials(reqLogger logr.Logger, awsSetupClie
 		return err
 	}
 
-	// Set `status.RotateCredentials` to false now that they ahve been updated
+	// Set `status.RotateCredentials` to false now that they have been updated
 	account.Status.RotateCredentials = false
 
 	err = r.Client.Status().Update(context.TODO(), account)
@@ -94,6 +94,8 @@ func (r *ReconcileAccount) RotateCredentials(reqLogger logr.Logger, awsSetupClie
 
 func (r *ReconcileAccount) RotateConsoleCredentials(reqLogger logr.Logger, awsSetupClient awsclient.Client, account *awsv1alpha1.Account) error {
 	STSCredentialsSecretName := account.Name + credentialwatcher.STSCredentialsConsoleSuffix
+
+	reqLogger.Info(fmt.Sprintf("Rotating consolde credentials for account %s secret %s", account.Name, STSCredentialsSecretName))
 
 	//var awsAssumedRoleClient awsclient.Client
 	var roleToAssume string
@@ -178,12 +180,12 @@ func (r *ReconcileAccount) RotateConsoleCredentials(reqLogger logr.Logger, awsSe
 		return err
 	}
 
-	// Set `status.RotateCredentials` to false now that they ahve been updated
+	// Set `status.RotateCredentials` to false now that they have been updated
 	account.Status.RotateConsoleCredentials = false
 
 	err = r.Client.Status().Update(context.TODO(), account)
 	if err != nil {
-		reqLogger.Error(err, fmt.Sprintf("RotateCredentials: Error updating account %s", account.Name))
+		reqLogger.Error(err, fmt.Sprintf("RotateConsoleCredentials: Error updating account %s", account.Name))
 		return err
 	}
 


### PR DESCRIPTION
This PR updates the RotateConsoleCredentials and RotateCredentials functions so that they pull that lastest account CR data before updating.