### PR TITLE
Return when account can't be found by secretwatcher to prevent segfault

### DIFF
--- a/pkg/credentialwatcher/secretwatcher.go
+++ b/pkg/credentialwatcher/secretwatcher.go
@@ -120,6 +120,7 @@ func (s *secretWatcher) updateAccountRotateCredentialsStatus(log logr.Logger, ac
 	if err != nil {
 		getAccountErrMsg := fmt.Sprintf("Unable to retrieve account CR %s", accountName)
 		log.Error(err, getAccountErrMsg)
+		return
 	}
 
 	if accountInstance.Status.RotateCredentials != true {


### PR DESCRIPTION
Currently if there's an error when getting the associated account during a secret watch, the code continues and tries to use the secret, resulting in a segfault. Adding a return out of the function solves this issue. 