### PR TITLE
Update the aws federated account access example CR

### DIFF
--- a/deploy/crds/aws_v1alpha1_awsfederatedaccountaccess_cr.yaml
+++ b/deploy/crds/aws_v1alpha1_awsfederatedaccountaccess_cr.yaml
@@ -1,10 +1,12 @@
 apiVersion: aws.managed.openshift.io/v1alpha1
 kind: AWSFederatedAccountAccess
 metadata:
-  name: clustername.customeraccountname.rolename
+  name: accountaccess-example
 spec:
-  accountReference: accountreference
-  awsCredentialSecret:
-      name: secretName
-      namespace: secretNamespace
-  awsFederatedRoleName: awsfederatedrolename
+  awsFederatedRole:
+      name: rolename
+      namespace: rolenamespace
+  externalCustomerAWSIAMARN: arn:aws:iam::AWSACCOUNTID:user/IAMUSERNAME
+  awsCustomerCredentialSecret:
+      name: secretname
+      namespace: secretnamespace


### PR DESCRIPTION
Currently, the AWS Federated Account Access example CR does not reflect the actual struct in the CRD. This PR updates the example to match the current CRD