### PR TITLE
Added missing return

### DIFF
--- a/pkg/controller/account/credentials_rotator.go
+++ b/pkg/controller/account/credentials_rotator.go
@@ -132,6 +132,7 @@ func (r *ReconcileAccount) RotateConsoleCredentials(reqLogger logr.Logger, awsSe
 	})
 	if err != nil {
 		reqLogger.Error(err, "RotateCredentials: Unable to create AWS conn with IAM user creds")
+		return err
 	}
 
 	SREConsoleLoginURL, err := RequestSigninToken(reqLogger, SREAWSClient, &SigninTokenDuration, &STSUserName, IAMPolicyDescriptors, STSCredentials)


### PR DESCRIPTION
Fixes a bug where the awsclient is a nil pointer and causing  panics.