### PR TITLE
Adds consoleURL to AwsFederatedAccountAccess status

### DIFF
--- a/deploy/crds/aws_v1alpha1_awsfederatedaccountaccess_crd.yaml
+++ b/deploy/crds/aws_v1alpha1_awsfederatedaccountaccess_crd.yaml
@@ -103,11 +103,14 @@ spec:
                 - status
                 type: object
               type: array
+            consoleURL:
+              type: string
             state:
               type: string
           required:
           - conditions
           - state
+          - consoleURL
           type: object
   version: v1alpha1
   versions:

--- a/pkg/apis/aws/v1alpha1/awsfederatedaccountaccess_types.go
+++ b/pkg/apis/aws/v1alpha1/awsfederatedaccountaccess_types.go
@@ -36,8 +36,10 @@ type AWSFederatedAccountAccessSpec struct {
 type AWSFederatedAccountAccessStatus struct {
 	Conditions []AWSFederatedAccountAccessCondition `json:"conditions"`
 	State      AWSFederatedAccountAccessState       `json:"state"`
+	ConsoleURL string                               `json:"consoleURL"`
 }
 
+// AWSFederatedAccountAccessCondition defines a current condition state of the account
 type AWSFederatedAccountAccessCondition struct {
 	// Type is the type of the condition.
 	Type AWSFederatedAccountAccessConditionType `json:"type"`

--- a/pkg/apis/aws/v1alpha1/zz_generated.openapi.go
+++ b/pkg/apis/aws/v1alpha1/zz_generated.openapi.go
@@ -132,8 +132,14 @@ func schema_pkg_apis_aws_v1alpha1_AWSFederatedAccountAccessStatus(ref common.Ref
 							Format: "",
 						},
 					},
+					"consoleURL": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"string"},
+							Format: "",
+						},
+					},
 				},
-				Required: []string{"conditions", "state"},
+				Required: []string{"conditions", "state", "consoleURL"},
 			},
 		},
 		Dependencies: []string{


### PR DESCRIPTION
* Updates AwsFederatedAccountAccess status to include the consoleURL for
role assumption by provided account id
* Changes createOrUpdateIAMRole to return the role, so the ID can be used 
to construct the consoleURL

REF: [OSD-2710](https://issues.redhat.com/browse/OSD-2710)

This has been tested locally with the operator-sdk and appears to work as expected.

Signed-off-by: Christopher Collins <collins.christopher@gmail.com>