### PR TITLE
BYOC does not supporting multiple clusters

### DIFF
--- a/pkg/apis/aws/v1alpha1/accountclaim_types.go
+++ b/pkg/apis/aws/v1alpha1/accountclaim_types.go
@@ -59,6 +59,8 @@ const (
 	AccountClaimed AccountClaimConditionType = "Claimed"
 	// AccountUnclaimed is set when an Account is not claimed
 	AccountUnclaimed AccountClaimConditionType = "Unclaimed"
+	// BYOCAWSAccountInUse is set when a BYOC AWS Account is in use
+	BYOCAWSAccountInUse AccountClaimConditionType = "BYOCAWSAccountInUse"
 )
 
 // ClaimStatus is a valid value from AccountClaim.Status

--- a/pkg/controller/utils/conditions.go
+++ b/pkg/controller/utils/conditions.go
@@ -1,6 +1,9 @@
 package utils
 
 import (
+	"fmt"
+
+	"github.com/go-logr/logr"
 	awsv1alpha1 "github.com/openshift/aws-account-operator/pkg/apis/aws/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -259,3 +262,17 @@ func FindAWSFederatedAccountAccessCondition(conditions []awsv1alpha1.AWSFederate
 const (
 	AwsSecretName = "aws-account-operator-credentials"
 )
+
+// SetBYOCAccountClaimStatusAWSAccountInUse Sets the Status.State and appends an account Status.Condition
+func SetBYOCAccountClaimStatusAWSAccountInUse(reqLogger logr.Logger, accountClaim *awsv1alpha1.AccountClaim) {
+	message := fmt.Sprintf("AWS Account %s already in use", accountClaim.Spec.BYOCAWSAccountID)
+	accountClaim.Status.Conditions = SetAccountClaimCondition(
+		accountClaim.Status.Conditions,
+		awsv1alpha1.BYOCAWSAccountInUse,
+		corev1.ConditionTrue,
+		string(awsv1alpha1.BYOCAWSAccountInUse),
+		message,
+		UpdateConditionNever)
+	accountClaim.Status.State = awsv1alpha1.ClaimStatusError
+	reqLogger.Info(fmt.Sprintf("AccountClaim %s condition status updated", accountClaim.Name))
+}


### PR DESCRIPTION
This PR prevents a BYOC customer from installing multiple clusters in a single AWS account