### PR TITLE
Makes the consoleURL field in AWSFederatedAccountAccessStatus optional

### DIFF
--- a/deploy/crds/aws_v1alpha1_awsfederatedaccountaccess_crd.yaml
+++ b/deploy/crds/aws_v1alpha1_awsfederatedaccountaccess_crd.yaml
@@ -110,7 +110,6 @@ spec:
           required:
           - conditions
           - state
-          - consoleURL
           type: object
   version: v1alpha1
   versions:

--- a/pkg/apis/aws/v1alpha1/awsfederatedaccountaccess_types.go
+++ b/pkg/apis/aws/v1alpha1/awsfederatedaccountaccess_types.go
@@ -36,7 +36,7 @@ type AWSFederatedAccountAccessSpec struct {
 type AWSFederatedAccountAccessStatus struct {
 	Conditions []AWSFederatedAccountAccessCondition `json:"conditions"`
 	State      AWSFederatedAccountAccessState       `json:"state"`
-	ConsoleURL string                               `json:"consoleURL"`
+	ConsoleURL string                               `json:"consoleURL,omitempty"`
 }
 
 // AWSFederatedAccountAccessCondition defines a current condition state of the account

--- a/pkg/apis/aws/v1alpha1/zz_generated.openapi.go
+++ b/pkg/apis/aws/v1alpha1/zz_generated.openapi.go
@@ -139,7 +139,7 @@ func schema_pkg_apis_aws_v1alpha1_AWSFederatedAccountAccessStatus(ref common.Ref
 						},
 					},
 				},
-				Required: []string{"conditions", "state", "consoleURL"},
+				Required: []string{"conditions", "state"},
 			},
 		},
 		Dependencies: []string{


### PR DESCRIPTION
Sets `omitempty` for the CosoleURL string in the AWSFederatedAccountAccessStatus struct in
awsfederatedaccountaccess_types.go.

Signed-off-by: Christopher Collins <collins.christopher@gmail.com>