### PR TITLE
Increase creation timeout

### DIFF
--- a/pkg/controller/account/account_controller.go
+++ b/pkg/controller/account/account_controller.go
@@ -48,7 +48,7 @@ const (
 	iamUserNameSRE          = "osdManagedAdminSRE"
 	awsAMI                  = "ami-000db10762d0c4c05"
 	awsInstanceType         = "t2.micro"
-	createPendTime          = 10 * time.Minute
+	createPendTime          = 30 * time.Minute
 	// Fields used to create/monitor AWS case
 	caseCategoryCode              = "other-account-issues"
 	caseServiceCode               = "customer-account"


### PR DESCRIPTION
Currently resetting accounts is not working due to a short time out. This is a hotfix to get accounts reuse working again. 