### PR TITLE
Revert 246 "Added credential refresh to reuse" 

### DIFF
--- a/pkg/controller/accountclaim/reuse.go
+++ b/pkg/controller/accountclaim/reuse.go
@@ -44,22 +44,6 @@ func (r *ReconcileAccountClaim) finalizeAccountClaim(reqLogger logr.Logger, acco
 		return err
 	}
 
-	// Get latest version of the account
-	reusedAccount, err = r.getClaimedAccount(accountClaim.Spec.AccountLink, awsv1alpha1.AccountCrNamespace)
-	if err != nil {
-		reqLogger.Error(err, "Failed to get claimed account")
-		return err
-	}
-
-	reqLogger.Info(fmt.Sprintf("Setting RotateCredentials and RotateConsoleCredentials for account %s", reusedAccount.Spec.AwsAccountID))
-	reusedAccount.Status.RotateConsoleCredentials = true
-	reusedAccount.Status.RotateCredentials = true
-	err = r.accountStatusUpdate(reqLogger, reusedAccount)
-	if err != nil {
-		reqLogger.Error(err, "Failed to update account status for reuse")
-		return err
-	}
-
 	reqLogger.Info("Successfully finalized AccountClaim")
 	return nil
 }


### PR DESCRIPTION
This commit reverts #246, 5fab2a348bf6a687af331c204bb82d3384b71d06,
"Added credential refresh to reuse", to address multiple reconcile
attempts on the account.  This addresses the failed accounts created
by the account reuse, [OSD-2800](https://issues.redhat.com/browse/OSD-2800).

Signed-off-by: Christopher Collins <collins.christopher@gmail.com>