### PR TITLE
Implement Route53 hosted zone cleanup for reuse

### DIFF
--- a/pkg/awsclient/client.go
+++ b/pkg/awsclient/client.go
@@ -17,6 +17,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/aws/aws-sdk-go/service/route53/route53iface"
 	"github.com/aws/aws-sdk-go/service/s3/s3manager"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -28,6 +29,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/iam/iamiface"
 	"github.com/aws/aws-sdk-go/service/organizations"
 	"github.com/aws/aws-sdk-go/service/organizations/organizationsiface"
+	"github.com/aws/aws-sdk-go/service/route53"
 	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/aws/aws-sdk-go/service/s3/s3iface"
 	"github.com/aws/aws-sdk-go/service/sts"
@@ -97,6 +99,12 @@ type Client interface {
 	DeleteBucket(*s3.DeleteBucketInput) (*s3.DeleteBucketOutput, error)
 	BatchDeleteBucketObjects(bucketName *string) error
 	ListObjectsV2(*s3.ListObjectsV2Input) (*s3.ListObjectsV2Output, error)
+
+	// Route53
+	ListHostedZones(*route53.ListHostedZonesInput) (*route53.ListHostedZonesOutput, error)
+	DeleteHostedZone(*route53.DeleteHostedZoneInput) (*route53.DeleteHostedZoneOutput, error)
+	ListResourceRecordSets(*route53.ListResourceRecordSetsInput) (*route53.ListResourceRecordSetsOutput, error)
+	ChangeResourceRecordSets(*route53.ChangeResourceRecordSetsInput) (*route53.ChangeResourceRecordSetsOutput, error)
 }
 
 type awsClient struct {
@@ -106,6 +114,7 @@ type awsClient struct {
 	stsClient     stsiface.STSAPI
 	supportClient supportiface.SupportAPI
 	s3Client      s3iface.S3API
+	route53client route53iface.Route53API
 }
 
 // NewAwsClientInput input for new aws client
@@ -279,6 +288,22 @@ func (c *awsClient) BatchDeleteBucketObjects(bucketName *string) error {
 	return s3manager.NewBatchDeleteWithClient(c.s3Client).Delete(aws.BackgroundContext(), iter)
 }
 
+func (c *awsClient) ListHostedZones(input *route53.ListHostedZonesInput) (*route53.ListHostedZonesOutput, error) {
+	return c.route53client.ListHostedZones(input)
+}
+
+func (c *awsClient) DeleteHostedZone(input *route53.DeleteHostedZoneInput) (*route53.DeleteHostedZoneOutput, error) {
+	return c.route53client.DeleteHostedZone(input)
+}
+
+func (c *awsClient) ListResourceRecordSets(input *route53.ListResourceRecordSetsInput) (*route53.ListResourceRecordSetsOutput, error) {
+	return c.route53client.ListResourceRecordSets(input)
+}
+
+func (c *awsClient) ChangeResourceRecordSets(input *route53.ChangeResourceRecordSetsInput) (*route53.ChangeResourceRecordSetsOutput, error) {
+	return c.route53client.ChangeResourceRecordSets(input)
+}
+
 // NewClient creates our client wrapper object for the actual AWS clients we use.
 func NewClient(awsAccessID, awsAccessSecret, token, region string) (Client, error) {
 	awsConfig := &aws.Config{Region: aws.String(region)}
@@ -297,6 +322,7 @@ func NewClient(awsAccessID, awsAccessSecret, token, region string) (Client, erro
 		stsClient:     sts.New(s),
 		supportClient: support.New(s),
 		s3Client:      s3.New(s),
+		route53client: route53.New(s),
 	}, nil
 }
 

--- a/pkg/awsclient/mock/mock_client.go
+++ b/pkg/awsclient/mock/mock_client.go
@@ -8,6 +8,7 @@ import (
 	ec2 "github.com/aws/aws-sdk-go/service/ec2"
 	iam "github.com/aws/aws-sdk-go/service/iam"
 	organizations "github.com/aws/aws-sdk-go/service/organizations"
+	route53 "github.com/aws/aws-sdk-go/service/route53"
 	s3 "github.com/aws/aws-sdk-go/service/s3"
 	sts "github.com/aws/aws-sdk-go/service/sts"
 	support "github.com/aws/aws-sdk-go/service/support"
@@ -605,4 +606,64 @@ func (m *MockClient) ListObjectsV2(arg0 *s3.ListObjectsV2Input) (*s3.ListObjects
 func (mr *MockClientMockRecorder) ListObjectsV2(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListObjectsV2", reflect.TypeOf((*MockClient)(nil).ListObjectsV2), arg0)
+}
+
+// ListHostedZones mocks base method
+func (m *MockClient) ListHostedZones(arg0 *route53.ListHostedZonesInput) (*route53.ListHostedZonesOutput, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListHostedZones", arg0)
+	ret0, _ := ret[0].(*route53.ListHostedZonesOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListHostedZones indicates an expected call of ListHostedZones
+func (mr *MockClientMockRecorder) ListHostedZones(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListHostedZones", reflect.TypeOf((*MockClient)(nil).ListHostedZones), arg0)
+}
+
+// DeleteHostedZone mocks base method
+func (m *MockClient) DeleteHostedZone(arg0 *route53.DeleteHostedZoneInput) (*route53.DeleteHostedZoneOutput, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteHostedZone", arg0)
+	ret0, _ := ret[0].(*route53.DeleteHostedZoneOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DeleteHostedZone indicates an expected call of DeleteHostedZone
+func (mr *MockClientMockRecorder) DeleteHostedZone(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteHostedZone", reflect.TypeOf((*MockClient)(nil).DeleteHostedZone), arg0)
+}
+
+// ListResourceRecordSets mocks base method
+func (m *MockClient) ListResourceRecordSets(arg0 *route53.ListResourceRecordSetsInput) (*route53.ListResourceRecordSetsOutput, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListResourceRecordSets", arg0)
+	ret0, _ := ret[0].(*route53.ListResourceRecordSetsOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListResourceRecordSets indicates an expected call of ListResourceRecordSets
+func (mr *MockClientMockRecorder) ListResourceRecordSets(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListResourceRecordSets", reflect.TypeOf((*MockClient)(nil).ListResourceRecordSets), arg0)
+}
+
+// ChangeResourceRecordSets mocks base method
+func (m *MockClient) ChangeResourceRecordSets(arg0 *route53.ChangeResourceRecordSetsInput) (*route53.ChangeResourceRecordSetsOutput, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ChangeResourceRecordSets", arg0)
+	ret0, _ := ret[0].(*route53.ChangeResourceRecordSetsOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ChangeResourceRecordSets indicates an expected call of ChangeResourceRecordSets
+func (mr *MockClientMockRecorder) ChangeResourceRecordSets(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ChangeResourceRecordSets", reflect.TypeOf((*MockClient)(nil).ChangeResourceRecordSets), arg0)
 }

--- a/pkg/controller/accountclaim/reuse.go
+++ b/pkg/controller/accountclaim/reuse.go
@@ -299,7 +299,7 @@ func (r *ReconcileAccountClaim) cleanUpAwsRoute53(reqLogger logr.Logger, awsClie
 					// Build ChangeBatch
 					// https://docs.aws.amazon.com/sdk-for-go/api/service/route53/#ChangeBatch
 					//https://docs.aws.amazon.com/sdk-for-go/api/service/route53/#Change
-					if *record.Type == "TXT" {
+					if *record.Type != "NS" && *record.Type != "SOA" {
 						changeBatch.Changes = append(changeBatch.Changes, &route53.Change{
 							Action:            aws.String("DELETE"),
 							ResourceRecordSet: record,


### PR DESCRIPTION
This PR cleans up route53 hosted zones during the reuse cleanup code. A hosted zone can only be deleted if all record sets, except for the SOA and NS records, are deleted. Certman operator uses TXT records for certificate setup, so included in this cleanup is the deletion of TXT records within the hosted zone before the deletion is called. 