### PR TITLE
Reintroduce credential refresh to account reuse

### DIFF
--- a/pkg/controller/accountclaim/reuse.go
+++ b/pkg/controller/accountclaim/reuse.go
@@ -67,6 +67,11 @@ func (r *ReconcileAccountClaim) resetAccountSpecStatus(reqLogger logr.Logger, re
 		return err
 	}
 
+	reqLogger.Info(fmt.Sprintf(
+		"Setting RotateCredentials and RotateConsoleCredentials for account %s", reusedAccount.Spec.AwsAccountID))
+	reusedAccount.Status.RotateConsoleCredentials = true
+	reusedAccount.Status.RotateCredentials = true
+
 	// Update account status and add conditions indicating account reuse
 	reusedAccount.Status.State = conditionStatus
 	reusedAccount.Status.Claimed = false


### PR DESCRIPTION
https://github.com/openshift/aws-account-operator/pull/277 reverted
credential refreshes from the account reuse as part of the
mitigation of OSD-2800.

This commit moves the credential refresh to `resetAccountSpecStatus`,
to take advantage of the existing status update there, and ensuring
a status update occurs just once, reducing the chance of conflict
with other updates.

REF: [OSD-2827](https://issues.redhat.com/browse/OSD-2827)

Signed-off-by: Christopher Collins <collins.christopher@gmail.com>