### PR TITLE
remove dep for createBYOCAdminAccessRole

### DIFF
--- a/pkg/controller/account/account_controller.go
+++ b/pkg/controller/account/account_controller.go
@@ -322,7 +322,7 @@ func (r *ReconcileAccount) Reconcile(request reconcile.Request) (reconcile.Resul
 				}
 
 				// Create BYOC role to assume
-				byocRoleID, err = createBYOCAdminAccessRole(reqLogger, awsSetupClient, byocAWSClient, adminAccessArn)
+				byocRoleID, err = createBYOCAdminAccessRole(reqLogger, byocAWSClient, adminAccessArn)
 				if err != nil {
 					reqLogger.Error(err, "Failed to create BYOC role")
 					r.accountClaimBYOCError(reqLogger, accountClaim, err)

--- a/pkg/controller/account/byoc.go
+++ b/pkg/controller/account/byoc.go
@@ -35,9 +35,9 @@ var ErrBYOCSecretRefMissing = errors.New("BYOCSecretRefMissing")
 var roleID = ""
 
 // Create role for BYOC IAM user to assume
-func createBYOCAdminAccessRole(reqLogger logr.Logger, awsSetupClient awsclient.Client, byocAWSClient awsclient.Client, policyArn string) (roleID string, err error) {
+func createBYOCAdminAccessRole(reqLogger logr.Logger, byocAWSClient awsclient.Client, policyArn string) (roleID string, err error) {
 
-	getUserOutput, err := awsSetupClient.GetUser(&iam.GetUserInput{})
+	getUserOutput, err := byocAWSClient.GetUser(&iam.GetUserInput{})
 	if err != nil {
 		reqLogger.Error(err, "Failed to get non-BYOC IAM User info")
 		return roleID, err


### PR DESCRIPTION
This change removes a dependency on the aws-account-operator-credentials
details when processing a BYOC account claim. This enables BYOC to run
completely independent. For example, aws-account-operator-credentials
can be for an AWS Global account while being able to process BYOC for
AWS China.