### PR TITLE
Update Federated Role CRs to include roleDisplayName

### DIFF
--- a/deploy/crds/aws_v1alpha1_awsfederatedrole_customeradmin_cr.yaml
+++ b/deploy/crds/aws_v1alpha1_awsfederatedrole_customeradmin_cr.yaml
@@ -2,7 +2,9 @@ apiVersion: aws.managed.openshift.io/v1alpha1
 kind: AWSFederatedRole
 metadata:
   name: customer-admin
+  namespace: aws-account-operator
 spec:
+  roleDisplayName: customer-admin
   roleDescription: This is the description of customer-admin
   # Custom policy definition 
   awsCustomPolicy:

--- a/deploy/crds/aws_v1alpha1_awsfederatedrole_readonly_cr.yaml
+++ b/deploy/crds/aws_v1alpha1_awsfederatedrole_readonly_cr.yaml
@@ -2,7 +2,9 @@ apiVersion: aws.managed.openshift.io/v1alpha1
 kind: AWSFederatedRole
 metadata:
   name: read-only
+  namespace: aws-account-operator
 spec:
+  roleDisplayName: read-only
   roleDescription: This is the description of read-only
   # Custom Policy definition
   awsCustomPolicy:


### PR DESCRIPTION
Both our defined Federated Roles are missing the roleDisplayName needed to apply them.