### PR TITLE
Ensure finalizer is added and handled for AWS Federated Roles

### DIFF
--- a/pkg/controller/awsfederatedrole/finalizer.go
+++ b/pkg/controller/awsfederatedrole/finalizer.go
@@ -1,0 +1,77 @@
+package awsfederatedrole
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+
+	"github.com/go-logr/logr"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	awsv1alpha1 "github.com/openshift/aws-account-operator/pkg/apis/aws/v1alpha1"
+	"github.com/openshift/aws-account-operator/pkg/controller/utils"
+)
+
+func (r *ReconcileAWSFederatedRole) addFinalizer(reqLogger logr.Logger, awsFederatedRole *awsv1alpha1.AWSFederatedRole) error {
+	reqLogger.Info("Adding Finalizer for the AccountClaim")
+	awsFederatedRole.SetFinalizers(append(awsFederatedRole.GetFinalizers(), utils.Finalizer))
+
+	// Update CR
+	err := r.client.Update(context.TODO(), awsFederatedRole)
+	if err != nil {
+		reqLogger.Error(err, "Failed to update AccountClaim with finalizer")
+		return err
+	}
+	return nil
+}
+
+func (r *ReconcileAWSFederatedRole) removeFinalizer(reqLogger logr.Logger, awsFederatedRole *awsv1alpha1.AWSFederatedRole, finalizerName string) error {
+	reqLogger.Info("Removing Finalizer for the AWSFederatedRole")
+	awsFederatedRole.SetFinalizers(utils.Remove(awsFederatedRole.GetFinalizers(), finalizerName))
+
+	// Update CR
+	err := r.client.Update(context.TODO(), awsFederatedRole)
+	if err != nil {
+		reqLogger.Error(err, "Failed to remove AWSFederatedAccountAccess finalizer")
+		return err
+	}
+	return nil
+}
+
+func (r *ReconcileAWSFederatedRole) finalizeFederateRole(reqLogger logr.Logger, awsFederatedRole *awsv1alpha1.AWSFederatedRole) error {
+
+	// Get all FederatedAccountAccesses
+	awsFederatedAccountAccessList := &awsv1alpha1.AWSFederatedAccountAccessList{}
+
+	listOps := &client.ListOptions{}
+	if err := r.client.List(context.TODO(), listOps, awsFederatedAccountAccessList); err != nil {
+		reqLogger.Error(err, "unable to list AWS Federated Account Accesses")
+		return err
+	}
+
+	for _, item := range awsFederatedAccountAccessList.Items {
+		if isFederatedRoleReferenced(&item, awsFederatedRole) {
+			deleteAccessErr := r.client.Delete(context.TODO(), &item)
+			if deleteAccessErr != nil {
+				reqLogger.Error(deleteAccessErr, fmt.Sprintf("unable to delete AWS Federated Account Accesses %s\n", item.Name))
+				return deleteAccessErr
+			}
+		}
+
+	}
+
+	return nil
+}
+
+func isFederatedRoleReferenced(awsFederatedAccountAccess *awsv1alpha1.AWSFederatedAccountAccess, awsFederatedRole *awsv1alpha1.AWSFederatedRole) bool {
+
+	referencedRoleNamespacedName := types.NamespacedName{Name: awsFederatedAccountAccess.Spec.AWSFederatedRole.Name, Namespace: awsFederatedAccountAccess.Spec.AWSFederatedRole.Namespace}
+	roleNamespacedName := types.NamespacedName{Name: awsFederatedRole.Name, Namespace: awsFederatedRole.Namespace}
+
+	if reflect.DeepEqual(referencedRoleNamespacedName, roleNamespacedName) {
+		return true
+	}
+
+	return false
+}


### PR DESCRIPTION
This PR adds a finalizer to all Federated Roles that don't have it, as well as handles cleanup during deletion of the Role. If the Federated Role is referenced by a Federated Account Access, then the Federated Account Access is deleted, which triggers its own finalizer cleanup. 