### PR TITLE
Move constants and types that could shared in the package v1alpha1

### DIFF
--- a/pkg/apis/aws/v1alpha1/shared_types.go
+++ b/pkg/apis/aws/v1alpha1/shared_types.go
@@ -1,0 +1,87 @@
+package v1alpha1
+
+import "errors"
+
+// CoveredRegions map
+var CoveredRegions = map[string]map[string]string{
+	"us-east-1": {
+		"initializationAMI": "ami-000db10762d0c4c05",
+	},
+	"us-east-2": {
+		"initializationAMI": "ami-094720ddca649952f",
+	},
+	"us-west-1": {
+		"initializationAMI": "ami-04642fc8fca1e8e67",
+	},
+	"us-west-2": {
+		"initializationAMI": "ami-0a7e1ebfee7a4570e",
+	},
+	"ca-central-1": {
+		"initializationAMI": "ami-06ca3c0058d0275b3",
+	},
+	"eu-central-1": {
+		"initializationAMI": "ami-09de4a4c670389e4b",
+	},
+	"eu-west-1": {
+		"initializationAMI": "ami-0202869bdd0fc8c75",
+	},
+	"eu-west-2": {
+		"initializationAMI": "ami-0188c0c5eddd2d032",
+	},
+	"eu-west-3": {
+		"initializationAMI": "ami-0c4224e392ec4e440",
+	},
+	"ap-northeast-1": {
+		"initializationAMI": "ami-00b95502a4d51a07e",
+	},
+	"ap-northeast-2": {
+		"initializationAMI": "ami-041b16ca28f036753",
+	},
+	"ap-south-1": {
+		"initializationAMI": "ami-0963937a03c01ecd4",
+	},
+	"ap-southeast-1": {
+		"initializationAMI": "ami-055c55112e25b1f1f",
+	},
+	"ap-southeast-2": {
+		"initializationAMI": "ami-036b423b657376f5b",
+	},
+	"sa-east-1": {
+		"initializationAMI": "ami-05c1c16cac05a7c0b",
+	},
+}
+
+// Custom errors
+
+// ErrAwsAccountLimitExceeded indicates the orgnization account limit has been reached.
+var ErrAwsAccountLimitExceeded = errors.New("AccountLimitExceeded")
+
+// ErrAwsInternalFailure indicates that there was an internal failure on the aws api
+var ErrAwsInternalFailure = errors.New("InternalFailure")
+
+// ErrAwsFailedCreateAccount indicates that an account creation failed
+var ErrAwsFailedCreateAccount = errors.New("FailedCreateAccount")
+
+// ErrAwsTooManyRequests indicates that to many requests were sent in a short period
+var ErrAwsTooManyRequests = errors.New("TooManyRequestsException")
+
+// ErrAwsCaseCreationLimitExceeded indicates that the support case limit for the account has been reached
+var ErrAwsCaseCreationLimitExceeded = errors.New("SupportCaseLimitExceeded")
+
+// ErrAwsFailedCreateSupportCase indicates that a support case creation failed
+var ErrAwsFailedCreateSupportCase = errors.New("FailedCreateSupportCase")
+
+// ErrAwsSupportCaseIDNotFound indicates that the support case ID was not found
+var ErrAwsSupportCaseIDNotFound = errors.New("SupportCaseIdNotfound")
+
+// ErrAwsFailedDescribeSupportCase indicates that the support case describe failed
+var ErrAwsFailedDescribeSupportCase = errors.New("FailedDescribeSupportCase")
+
+// ErrFederationTokenOutputNil indicates that getting a federation token from AWS failed
+var ErrFederationTokenOutputNil = errors.New("FederationTokenOutputNil")
+
+// ErrCreateEC2Instance indicates that the CreateEC2Instance function timed out
+var ErrCreateEC2Instance = errors.New("EC2CreationTimeout")
+
+// ErrFailedAWSTypecast indicates that there was a failure while typecasting to aws error
+var ErrFailedAWSTypecast = errors.New("FailedToTypecastAWSError")

--- a/pkg/controller/account/account_controller.go
+++ b/pkg/controller/account/account_controller.go
@@ -2,7 +2,6 @@ package account
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"regexp"
 	"strconv"
@@ -62,89 +61,6 @@ const (
 
 	adminAccessArn = "arn:aws:iam::aws:policy/AdministratorAccess"
 )
-
-var coveredRegions = map[string]map[string]string{
-	"us-east-1": {
-		"initializationAMI": "ami-000db10762d0c4c05",
-	},
-	"us-east-2": {
-		"initializationAMI": "ami-094720ddca649952f",
-	},
-	"us-west-1": {
-		"initializationAMI": "ami-04642fc8fca1e8e67",
-	},
-	"us-west-2": {
-		"initializationAMI": "ami-0a7e1ebfee7a4570e",
-	},
-	"ca-central-1": {
-		"initializationAMI": "ami-06ca3c0058d0275b3",
-	},
-	"eu-central-1": {
-		"initializationAMI": "ami-09de4a4c670389e4b",
-	},
-	"eu-west-1": {
-		"initializationAMI": "ami-0202869bdd0fc8c75",
-	},
-	"eu-west-2": {
-		"initializationAMI": "ami-0188c0c5eddd2d032",
-	},
-	"eu-west-3": {
-		"initializationAMI": "ami-0c4224e392ec4e440",
-	},
-	"ap-northeast-1": {
-		"initializationAMI": "ami-00b95502a4d51a07e",
-	},
-	"ap-northeast-2": {
-		"initializationAMI": "ami-041b16ca28f036753",
-	},
-	"ap-south-1": {
-		"initializationAMI": "ami-0963937a03c01ecd4",
-	},
-	"ap-southeast-1": {
-		"initializationAMI": "ami-055c55112e25b1f1f",
-	},
-	"ap-southeast-2": {
-		"initializationAMI": "ami-036b423b657376f5b",
-	},
-	"sa-east-1": {
-		"initializationAMI": "ami-05c1c16cac05a7c0b",
-	},
-}
-
-// Custom errors
-
-// ErrAwsAccountLimitExceeded indicates the orgnization account limit has been reached.
-var ErrAwsAccountLimitExceeded = errors.New("AccountLimitExceeded")
-
-// ErrAwsInternalFailure indicates that there was an internal failure on the aws api
-var ErrAwsInternalFailure = errors.New("InternalFailure")
-
-// ErrAwsFailedCreateAccount indicates that an account creation failed
-var ErrAwsFailedCreateAccount = errors.New("FailedCreateAccount")
-
-// ErrAwsTooManyRequests indicates that to many requests were sent in a short period
-var ErrAwsTooManyRequests = errors.New("TooManyRequestsException")
-
-// ErrAwsCaseCreationLimitExceeded indicates that the support case limit for the account has been reached
-var ErrAwsCaseCreationLimitExceeded = errors.New("SupportCaseLimitExceeded")
-
-// ErrAwsFailedCreateSupportCase indicates that a support case creation failed
-var ErrAwsFailedCreateSupportCase = errors.New("FailedCreateSupportCase")
-
-// ErrAwsSupportCaseIDNotFound indicates that the support case ID was not found
-var ErrAwsSupportCaseIDNotFound = errors.New("SupportCaseIdNotfound")
-
-// ErrAwsFailedDescribeSupportCase indicates that the support case describe failed
-var ErrAwsFailedDescribeSupportCase = errors.New("FailedDescribeSupportCase")
-
-// ErrFederationTokenOutputNil indicates that getting a federation token from AWS failed
-var ErrFederationTokenOutputNil = errors.New("FederationTokenOutputNil")
-
-// ErrCreateEC2Instance indicates that the CreateEC2Instance function timed out
-var ErrCreateEC2Instance = errors.New("EC2CreationTimeout")
-
-// ErrFailedAWSTypecast indicates that there was a failure while typecasting to aws error
-var ErrFailedAWSTypecast = errors.New("FailedToTypecastAWSError")
 
 /**
 * USER ACTION REQUIRED: This is a scaffold file intended for the user to modify with their own Controller
@@ -412,8 +328,8 @@ func (r *ReconcileAccount) Reconcile(request reconcile.Request) (reconcile.Resul
 
 				// before doing anything make sure we are not over the limit if we are just error
 				if totalaccountwatcher.TotalAccountWatcher.Total >= AwsLimit {
-					reqLogger.Error(ErrAwsAccountLimitExceeded, "AWS Account limit reached", "Account Total", totalaccountwatcher.TotalAccountWatcher.Total)
-					return reconcile.Result{}, ErrAwsAccountLimitExceeded
+					reqLogger.Error(awsv1alpha1.ErrAwsAccountLimitExceeded, "AWS Account limit reached", "Account Total", totalaccountwatcher.TotalAccountWatcher.Total)
+					return reconcile.Result{}, awsv1alpha1.ErrAwsAccountLimitExceeded
 				}
 
 				// Build Aws Account
@@ -563,7 +479,7 @@ func (r *ReconcileAccount) Reconcile(request reconcile.Request) (reconcile.Resul
 		}
 
 		// Initialize all supported regions by creating and terminating an instance in each
-		err = r.InitializeSupportedRegions(reqLogger, coveredRegions, creds)
+		err = r.InitializeSupportedRegions(reqLogger, awsv1alpha1.CoveredRegions, creds)
 		if err != nil {
 			r.setStatusFailed(reqLogger, currentAcctInstance, "Failed to build and destroy ec2 instances")
 			return reconcile.Result{}, err
@@ -651,16 +567,16 @@ func (r *ReconcileAccount) BuildAccount(reqLogger logr.Logger, awsClient awsclie
 	// If it was an api or a limit issue don't modify account and exit if anything else set to failed
 	if orgErr != nil {
 		switch orgErr {
-		case ErrAwsFailedCreateAccount:
+		case awsv1alpha1.ErrAwsFailedCreateAccount:
 			SetAccountStatus(reqLogger, account, "Failed to create AWS Account", awsv1alpha1.AccountFailed, AccountFailed)
 			err := r.Client.Status().Update(context.TODO(), account)
 			if err != nil {
 				return "", err
 			}
 
-			reqLogger.Error(ErrAwsFailedCreateAccount, "Failed to create AWS Account")
+			reqLogger.Error(awsv1alpha1.ErrAwsFailedCreateAccount, "Failed to create AWS Account")
 			return "", orgErr
-		case ErrAwsAccountLimitExceeded:
+		case awsv1alpha1.ErrAwsAccountLimitExceeded:
 			log.Error(orgErr, "Failed to create AWS Account limit reached")
 			return "", orgErr
 		default:
@@ -709,13 +625,13 @@ func CreateAccount(reqLogger logr.Logger, client awsclient.Client, accountName, 
 		if aerr, ok := err.(awserr.Error); ok {
 			switch aerr.Code() {
 			case organizations.ErrCodeConstraintViolationException:
-				returnErr = ErrAwsAccountLimitExceeded
+				returnErr = awsv1alpha1.ErrAwsAccountLimitExceeded
 			case organizations.ErrCodeServiceException:
-				returnErr = ErrAwsInternalFailure
+				returnErr = awsv1alpha1.ErrAwsInternalFailure
 			case organizations.ErrCodeTooManyRequestsException:
-				returnErr = ErrAwsTooManyRequests
+				returnErr = awsv1alpha1.ErrAwsTooManyRequests
 			default:
-				returnErr = ErrAwsFailedCreateAccount
+				returnErr = awsv1alpha1.ErrAwsFailedCreateAccount
 				utils.LogAwsError(reqLogger, "New AWS Error during account creation", returnErr, err)
 			}
 
@@ -741,11 +657,11 @@ func CreateAccount(reqLogger logr.Logger, client awsclient.Client, accountName, 
 			var returnErr error
 			switch *status.CreateAccountStatus.FailureReason {
 			case "ACCOUNT_LIMIT_EXCEEDED":
-				returnErr = ErrAwsAccountLimitExceeded
+				returnErr = awsv1alpha1.ErrAwsAccountLimitExceeded
 			case "INTERNAL_FAILURE":
-				returnErr = ErrAwsInternalFailure
+				returnErr = awsv1alpha1.ErrAwsInternalFailure
 			default:
-				returnErr = ErrAwsFailedCreateAccount
+				returnErr = awsv1alpha1.ErrAwsFailedCreateAccount
 			}
 
 			return &organizations.DescribeCreateAccountStatusOutput{}, returnErr

--- a/pkg/controller/account/cases.go
+++ b/pkg/controller/account/cases.go
@@ -8,6 +8,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/support"
 	"github.com/go-logr/logr"
 
+	"github.com/openshift/aws-account-operator/pkg/apis/aws/v1alpha1"
 	"github.com/openshift/aws-account-operator/pkg/awsclient"
 	controllerutils "github.com/openshift/aws-account-operator/pkg/controller/utils"
 )
@@ -50,11 +51,11 @@ func createCase(reqLogger logr.Logger, accountID string, client awsclient.Client
 		if aerr, ok := caseErr.(awserr.Error); ok {
 			switch aerr.Code() {
 			case support.ErrCodeCaseCreationLimitExceeded:
-				returnErr = ErrAwsCaseCreationLimitExceeded
+				returnErr = v1alpha1.ErrAwsCaseCreationLimitExceeded
 			case support.ErrCodeInternalServerError:
-				returnErr = ErrAwsInternalFailure
+				returnErr = v1alpha1.ErrAwsInternalFailure
 			default:
-				returnErr = ErrAwsFailedCreateSupportCase
+				returnErr = v1alpha1.ErrAwsFailedCreateSupportCase
 			}
 
 			controllerutils.LogAwsError(reqLogger, "New AWS Error while creating case", returnErr, caseErr)
@@ -82,11 +83,11 @@ func checkCaseResolution(reqLogger logr.Logger, caseID string, client awsclient.
 		if aerr, ok := caseErr.(awserr.Error); ok {
 			switch aerr.Code() {
 			case support.ErrCodeCaseIdNotFound:
-				returnErr = ErrAwsSupportCaseIDNotFound
+				returnErr = v1alpha1.ErrAwsSupportCaseIDNotFound
 			case support.ErrCodeInternalServerError:
-				returnErr = ErrAwsInternalFailure
+				returnErr = v1alpha1.ErrAwsInternalFailure
 			default:
-				returnErr = ErrAwsFailedDescribeSupportCase
+				returnErr = v1alpha1.ErrAwsFailedDescribeSupportCase
 			}
 			controllerutils.LogAwsError(reqLogger, "New AWS Error while checking case resolution", returnErr, caseErr)
 		}

--- a/pkg/controller/account/ec2.go
+++ b/pkg/controller/account/ec2.go
@@ -10,6 +10,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/aws/aws-sdk-go/service/sts"
 	"github.com/go-logr/logr"
+	"github.com/openshift/aws-account-operator/pkg/apis/aws/v1alpha1"
 	"github.com/openshift/aws-account-operator/pkg/awsclient"
 	controllerutils "github.com/openshift/aws-account-operator/pkg/controller/utils"
 )
@@ -184,7 +185,7 @@ func CreateEC2Instance(reqLogger logr.Logger, client awsclient.Client, ami strin
 					return timeoutInstanceID, runErr
 				}
 			}
-			return timeoutInstanceID, ErrFailedAWSTypecast
+			return timeoutInstanceID, v1alpha1.ErrFailedAWSTypecast
 		}
 
 		// No error was found, instance is running, return instance id
@@ -192,7 +193,7 @@ func CreateEC2Instance(reqLogger logr.Logger, client awsclient.Client, ami strin
 	}
 
 	// Timeout occurred, return instance id and timeout error
-	return timeoutInstanceID, ErrCreateEC2Instance
+	return timeoutInstanceID, v1alpha1.ErrCreateEC2Instance
 }
 
 // DescribeEC2Instances returns the InstanceState code

--- a/pkg/controller/account/iam.go
+++ b/pkg/controller/account/iam.go
@@ -101,8 +101,8 @@ func getFederationToken(reqLogger logr.Logger, awsclient awsclient.Client, Durat
 
 	if GetFederationTokenOutput == nil {
 
-		reqLogger.Error(ErrFederationTokenOutputNil, fmt.Sprintf("Federation Token Output: %+v", GetFederationTokenOutput))
-		return GetFederationTokenOutput, ErrFederationTokenOutputNil
+		reqLogger.Error(awsv1alpha1.ErrFederationTokenOutputNil, fmt.Sprintf("Federation Token Output: %+v", GetFederationTokenOutput))
+		return GetFederationTokenOutput, awsv1alpha1.ErrFederationTokenOutputNil
 
 	}
 


### PR DESCRIPTION
Ticket: https://issues.redhat.com/browse/OSD-2835



Create pkg/apis/aws/v1alpha1/shared_types.go add constants and types that could shared in the package v1alpha1

https://github.com/openshift/aws-account-operator/blob/master/pkg/controller/account/account_controller.go#L79-L138

Done criteria:
- Move types and constants that are shared between APIs to this file
- Any constants that we can reference here to keep controller files clean

Testing:
- To test you just need to apply  an account CR and check that it becomes ready without issues.

Edit: Description