### PR TITLE
Adds handling of unexpected AWS API errors

### DIFF
--- a/pkg/controller/awsfederatedaccountaccess/awsfederatedaccountaccess_controller.go
+++ b/pkg/controller/awsfederatedaccountaccess/awsfederatedaccountaccess_controller.go
@@ -439,18 +439,22 @@ func (r *ReconcileAWSFederatedAccountAccess) createOrUpdateIAMRole(awsClient aws
 		if aerr, ok := err.(awserr.Error); ok {
 			if aerr.Code() == "EntityAlreadyExists" {
 				_, err := awsClient.DeleteRole(&iam.DeleteRoleInput{RoleName: aws.String(roleName)})
+
 				if err != nil {
 					return nil, err
 				}
+
 				role, err := r.createIAMRole(awsClient, afr, afaa)
+
 				if err != nil {
 					return nil, err
-				}
-				if role == nil {
-					return nil, errors.New("Create Role Output is nil")
 				}
 
 				return role, nil
+
+			} else {
+				// Handle unexpected AWS API errors
+				return nil, errors.New(aerr.Code())
 			}
 		}
 	}


### PR DESCRIPTION
Currently, if there is an error creating the role, and the error is an AWS API error (awserr.Error), only "EntityAlreadyExists" is handled, and all other errors are slilently dropped on the floor.  This adds an `else` case to return the awserr.Error.Code() string as an error if it isn't the EntityAlreadyExists error.

REF: panics[1] due to role being nil, ultimately tracked down to unhandled "MalformedPolicyDocument" errors returned by AWS that were being ignored by the code.

[1] https://github.com/openshift/aws-account-operator/pull/300#pullrequestreview-369920242