### PR TITLE
Only rotate STS credentials when Account CR state is Ready

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -31,7 +31,7 @@ import (
 var (
 	metricsPort                   = "8080"
 	metricsPath                   = "/metrics"
-	secretWatcherScanInterval     = time.Duration(10) * time.Minute
+	secretWatcherScanInterval     = time.Duration(1) * time.Minute
 	hours                     int = 1
 	totalWatcherInterval          = time.Duration(15) * time.Minute
 )

--- a/pkg/credentialwatcher/secretwatcher.go
+++ b/pkg/credentialwatcher/secretwatcher.go
@@ -123,6 +123,12 @@ func (s *secretWatcher) updateAccountRotateCredentialsStatus(log logr.Logger, ac
 		return
 	}
 
+	// Only rotate STS credentials if the account CR is in a Ready state
+	if accountInstance.Status.State != string(awsv1alpha1.AccountReady) {
+		log.Info(fmt.Sprintf("Account %s not in %s state, not rotating STS credentials", accountInstance.Name, awsv1alpha1.AccountReady))
+		return
+	}
+
 	if accountInstance.Status.RotateCredentials != true {
 
 		//log.Info(fmt.Sprintf("AWS credentials secret %s was created %s ago requeing to be refreshed", secret.ObjectMeta.Name, time.Since(unixTime)))


### PR DESCRIPTION
This PR should change secretwatcher to only rotate STS credentials if the Account CR is in a Ready state.

I'm also reducing the scan interval to 1 minute so that we're renewing less secrets on every run.