### PR TITLE
Removes support ticket related code from account_controller.go

### DIFF
--- a/pkg/controller/account/account_controller.go
+++ b/pkg/controller/account/account_controller.go
@@ -47,16 +47,6 @@ const (
 	awsAMI                  = "ami-000db10762d0c4c05"
 	awsInstanceType         = "t2.micro"
 	createPendTime          = utils.WaitTime * time.Minute
-	// Fields used to create/monitor AWS case
-	caseCategoryCode              = "other-account-issues"
-	caseServiceCode               = "customer-account"
-	caseIssueType                 = "customer-service"
-	caseSeverity                  = "urgent"
-	caseDesiredInstanceLimit      = 25
-	caseStatusResolved            = "resolved"
-	caseLanguage                  = "en"
-	intervalAfterCaseCreationSecs = 30
-	intervalBetweenChecksMinutes  = 10
 
 	// AccountPending indicates an account is pending
 	AccountPending = "Pending"
@@ -119,19 +109,6 @@ var coveredRegions = map[string]map[string]string{
 	"sa-east-1": {
 		"initializationAMI": "ami-05c1c16cac05a7c0b",
 	},
-}
-
-// Instance types UHC supports
-var coveredInstanceTypes = []string{
-	"c5.xlarge",
-	"c5.2xlarge",
-	"c5.4xlarge",
-	"m5.xlarge",
-	"m5.2xlarge",
-	"m5.4xlarge",
-	"r5.xlarge",
-	"r5.2xlarge",
-	"r5.4xlarge",
 }
 
 // Custom errors

--- a/pkg/controller/account/cases.go
+++ b/pkg/controller/account/cases.go
@@ -12,6 +12,18 @@ import (
 	controllerutils "github.com/openshift/aws-account-operator/pkg/controller/utils"
 )
 
+const (
+	// Fields used to create/monitor AWS case
+	caseCategoryCode              = "other-account-issues"
+	caseServiceCode               = "customer-account"
+	caseIssueType                 = "customer-service"
+	caseSeverity                  = "urgent"
+	caseStatusResolved            = "resolved"
+	caseLanguage                  = "en"
+	intervalAfterCaseCreationSecs = 30
+	intervalBetweenChecksMinutes  = 10
+)
+
 func createCase(reqLogger logr.Logger, accountID string, client awsclient.Client) (string, error) {
 	// Initialize basic communication body and case subject
 	caseCommunicationBody := fmt.Sprintf(


### PR DESCRIPTION
1. Moves constants still in use to cases.go
2. Removes constant "caseDesiredInstanceLimit" - no longer used
3. Removes slice variable "coveredInstanceTypes" - not referenced in codebase

REF: [OSD-2870](https://issues.redhat.com/browse/OSD-2870): Remove code related to AWS Limit increase support ticket.

Signed-off-by: Christopher Collins <collins.christopher@gmail.com>