### PR TITLE
Remove owner reference for BYOC accounts from creating accountclaim

### DIFF
--- a/pkg/controller/accountclaim/reuse.go
+++ b/pkg/controller/accountclaim/reuse.go
@@ -31,6 +31,14 @@ func (r *ReconcileAccountClaim) finalizeAccountClaim(reqLogger logr.Logger, acco
 		return err
 	}
 
+	if reusedAccount.Spec.BYOC == true {
+		err := r.client.Delete(context.TODO(), reusedAccount)
+		if err != nil {
+			reqLogger.Error(err, "Failed to delete BYOC account from accountclaim cleanup")
+		}
+		return nil
+	}
+
 	// Perform account clean up in AWS
 	err = r.cleanUpAwsAccount(reqLogger, accountClaim, reusedAccount)
 	if err != nil {


### PR DESCRIPTION
Cross namespace ownership is disallowed by kubernetes by design.
From https://kubernetes.io/docs/concepts/workloads/controllers/garbage-collection

"Note: Cross-namespace owner references are disallowed by design. This means: 1) Namespace-scoped dependents can only specify owners in the same namespace, and owners that are cluster-scoped. 2) Cluster-scoped dependents can only specify cluster-scoped owners, but not namespace-scoped owners."
In one case, an Account CR was garbage collected while having an active cluster and accountclaim.
To fix this
1) The owner reference is removed when creating a BYOC Account CR
2) The AccountClaim finalizer code now does a Delete on the Account CR if the account is BYOC