### PR TITLE
Separates BYOC Logic from account_controller.go

### DIFF
--- a/pkg/controller/account/byoc.go
+++ b/pkg/controller/account/byoc.go
@@ -58,8 +58,10 @@ func claimBYOCAccount(r *ReconcileAccount, reqLogger logr.Logger, currentAcctIns
 
 func (r *ReconcileAccount) initializeNewBYOCAccount(reqLogger logr.Logger, currentAcctInstance *awsv1alpha1.Account, awsSetupClient awsclient.Client, adminAccessArn string) (string, error) {
 	client, accountClaim, err := r.getBYOCClient(currentAcctInstance)
-	if err != nil && accountClaim != nil {
-		r.accountClaimBYOCError(reqLogger, accountClaim, err)
+	if err != nil {
+		if accountClaim != nil {
+			r.accountClaimBYOCError(reqLogger, accountClaim, err)
+		}
 		return "", err
 	}
 

--- a/pkg/controller/account/byoc_test.go
+++ b/pkg/controller/account/byoc_test.go
@@ -227,7 +227,7 @@ var testNotNewBYOCAccountInstances = []*awsv1alpha1.Account{
 
 func TestNewBYOCAccount(t *testing.T) {
 	for index, acct := range testNewBYOCAccountInstances {
-		new := accountIsNewBYOC(acct)
+		new := newBYOCAccount(acct)
 		expected := true
 		if new != expected {
 			t.Error(
@@ -241,7 +241,7 @@ func TestNewBYOCAccount(t *testing.T) {
 
 func TestNotNewBYOCAccount(t *testing.T) {
 	for index, acct := range testNotNewBYOCAccountInstances {
-		new := accountIsNewBYOC(acct)
+		new := newBYOCAccount(acct)
 		expected := false
 		if new != expected {
 			t.Error(


### PR DESCRIPTION
This moves the BYOC initialization and logic from the account_controller.go file to byoc.go via a new `initializeNewBYOCAccount` function.  This has been tested locally and is working as expected.

This depends on PR #295 and should not be merged before that.

REF: [https://issues.redhat.com/browse/OSD-2833](https://issues.redhat.com/browse/OSD-2833)