### PR TITLE
Enable AWS China for CCS/BYOC

### DIFF
--- a/pkg/apis/aws/v1alpha1/shared_types.go
+++ b/pkg/apis/aws/v1alpha1/shared_types.go
@@ -1,55 +1,68 @@
 package v1alpha1
 
-import "errors"
+import (
+	"errors"
+)
 
-// CoveredRegions map
-var CoveredRegions = map[string]map[string]string{
-	"us-east-1": {
-		"initializationAMI": "ami-000db10762d0c4c05",
-	},
-	"us-east-2": {
-		"initializationAMI": "ami-094720ddca649952f",
-	},
-	"us-west-1": {
-		"initializationAMI": "ami-04642fc8fca1e8e67",
-	},
-	"us-west-2": {
-		"initializationAMI": "ami-0a7e1ebfee7a4570e",
-	},
-	"ca-central-1": {
-		"initializationAMI": "ami-06ca3c0058d0275b3",
-	},
-	"eu-central-1": {
-		"initializationAMI": "ami-09de4a4c670389e4b",
-	},
-	"eu-west-1": {
-		"initializationAMI": "ami-0202869bdd0fc8c75",
-	},
-	"eu-west-2": {
-		"initializationAMI": "ami-0188c0c5eddd2d032",
-	},
-	"eu-west-3": {
-		"initializationAMI": "ami-0c4224e392ec4e440",
-	},
-	"ap-northeast-1": {
-		"initializationAMI": "ami-00b95502a4d51a07e",
-	},
-	"ap-northeast-2": {
-		"initializationAMI": "ami-041b16ca28f036753",
-	},
-	"ap-south-1": {
-		"initializationAMI": "ami-0963937a03c01ecd4",
-	},
-	"ap-southeast-1": {
-		"initializationAMI": "ami-055c55112e25b1f1f",
-	},
-	"ap-southeast-2": {
-		"initializationAMI": "ami-036b423b657376f5b",
-	},
-	"sa-east-1": {
-		"initializationAMI": "ami-05c1c16cac05a7c0b",
-	},
-}
+var (
+	// AWSRegionsGlobal provides a map of AWS Region to initializationAMI for AWS Global.
+	AWSRegionsGlobal = map[string]map[string]string{
+		"us-east-1": {
+			"initializationAMI": "ami-000db10762d0c4c05",
+		},
+		"us-east-2": {
+			"initializationAMI": "ami-094720ddca649952f",
+		},
+		"us-west-1": {
+			"initializationAMI": "ami-04642fc8fca1e8e67",
+		},
+		"us-west-2": {
+			"initializationAMI": "ami-0a7e1ebfee7a4570e",
+		},
+		"ca-central-1": {
+			"initializationAMI": "ami-06ca3c0058d0275b3",
+		},
+		"eu-central-1": {
+			"initializationAMI": "ami-09de4a4c670389e4b",
+		},
+		"eu-west-1": {
+			"initializationAMI": "ami-0202869bdd0fc8c75",
+		},
+		"eu-west-2": {
+			"initializationAMI": "ami-0188c0c5eddd2d032",
+		},
+		"eu-west-3": {
+			"initializationAMI": "ami-0c4224e392ec4e440",
+		},
+		"ap-northeast-1": {
+			"initializationAMI": "ami-00b95502a4d51a07e",
+		},
+		"ap-northeast-2": {
+			"initializationAMI": "ami-041b16ca28f036753",
+		},
+		"ap-south-1": {
+			"initializationAMI": "ami-0963937a03c01ecd4",
+		},
+		"ap-southeast-1": {
+			"initializationAMI": "ami-055c55112e25b1f1f",
+		},
+		"ap-southeast-2": {
+			"initializationAMI": "ami-036b423b657376f5b",
+		},
+		"sa-east-1": {
+			"initializationAMI": "ami-05c1c16cac05a7c0b",
+		},
+	}
+	// AWSRegionsChina provides a map of AWS Region to initializationAMI for AWS China.
+	AWSRegionsChina = map[string]map[string]string{
+		"cn-north-1": {
+			"initializationAMI": "ami-0402362f7a41e7d77", // Currently not publically available
+		},
+		"cn-northwest-1": {
+			"initializationAMI": "ami-0ffcfd88e7e2a84ef", // Currently not publically available
+		},
+	}
+)
 
 // Custom errors
 

--- a/pkg/controller/utils/conditions.go
+++ b/pkg/controller/utils/conditions.go
@@ -261,10 +261,6 @@ func FindAWSFederatedAccountAccessCondition(conditions []awsv1alpha1.AWSFederate
 	return nil
 }
 
-const (
-	AwsSecretName = "aws-account-operator-credentials"
-)
-
 // SetBYOCAccountClaimStatusAWSAccountInUse Sets the Status.State and appends an account Status.Condition
 func SetBYOCAccountClaimStatusAWSAccountInUse(reqLogger logr.Logger, accountClaim *awsv1alpha1.AccountClaim) {
 	message := fmt.Sprintf("AWS Account %s already in use", accountClaim.Spec.BYOCAWSAccountID)

--- a/pkg/controller/utils/utils.go
+++ b/pkg/controller/utils/utils.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/go-logr/logr"
 	awsv1alpha1 "github.com/openshift/aws-account-operator/pkg/apis/aws/v1alpha1"
+	"github.com/openshift/aws-account-operator/pkg/awsclient"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/rand"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -128,3 +129,69 @@ func Remove(list []string, s string) []string {
 	}
 	return list
 }
+
+const (
+	AWSRegionDefaultGlobal = "us-east-1"
+	AWSRegionDefaultChina  = "cn-north-1"
+
+	AWSSecretNameGlobal = "aws-account-operator-credentials"
+	AWSSecretNameChina  = "aws-account-operator-china-credentials"
+
+	AWSARNPrefixGlobal = "arn:aws:"
+	AWSARNPrefixChina  = "arn:aws-cn:"
+
+	AWSIAMPolicyAdministrator = "iam::aws:policy/AdministratorAccess"
+
+	AWSFedEndpointURLGlobal = "https://signin.aws.amazon.com/federation"
+	AWSFedEndpointURLChina  = "https://signin.amazonaws.cn/federation"
+
+	AWSFedConsURLGlobal = "https://console.aws.amazon.com/"
+	AWSFedConsURLChina  = "https://console.amazonaws.cn/"
+)
+
+// AwsPlatformConfig contains all required fields to service either AWS Global or AWS China.
+type AwsPlatformConfig struct {
+	ClientInput      awsclient.NewAwsClientInput
+	ARNPrefix        string
+	CoveredRegions   map[string]map[string]string
+	FederationConfig AwsFederationConfig
+}
+
+// AwsFederationConfig consolidates EndpointURL and ConsoleURL into one structure that accounts
+// for requirements of FederationConfig.
+type AwsFederationConfig struct {
+	EndpointURL string
+	ConsoleURL  string
+}
+
+var (
+	// AwsPlatformConfigGlobal provides a default struct with fields configured for AWS Global.
+	AwsPlatformConfigGlobal = AwsPlatformConfig{
+		ClientInput: awsclient.NewAwsClientInput{
+			AwsRegion:  AWSRegionDefaultGlobal,
+			SecretName: AWSSecretNameGlobal,
+			NameSpace:  awsv1alpha1.AccountCrNamespace,
+		},
+		ARNPrefix:      AWSARNPrefixGlobal,
+		CoveredRegions: awsv1alpha1.AWSRegionsGlobal,
+		FederationConfig: AwsFederationConfig{
+			EndpointURL: AWSFedEndpointURLGlobal,
+			ConsoleURL:  AWSFedConsURLGlobal,
+		},
+	}
+
+	// AwsPlatformConfigChina provides a default struct with fields configured for AWS China.
+	AwsPlatformConfigChina = AwsPlatformConfig{
+		ClientInput: awsclient.NewAwsClientInput{
+			AwsRegion:  AWSRegionDefaultChina,
+			SecretName: AWSSecretNameChina,
+			NameSpace:  awsv1alpha1.AccountCrNamespace,
+		},
+		ARNPrefix:      AWSARNPrefixChina,
+		CoveredRegions: awsv1alpha1.AWSRegionsChina,
+		FederationConfig: AwsFederationConfig{
+			EndpointURL: AWSFedEndpointURLChina,
+			ConsoleURL:  AWSFedConsURLChina,
+		},
+	}
+)

--- a/pkg/totalaccountwatcher/totalaccountwatcher.go
+++ b/pkg/totalaccountwatcher/totalaccountwatcher.go
@@ -11,9 +11,8 @@ import (
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/organizations"
 	"github.com/go-logr/logr"
-	awsv1alpha1 "github.com/openshift/aws-account-operator/pkg/apis/aws/v1alpha1"
 	"github.com/openshift/aws-account-operator/pkg/awsclient"
-	controllerutils "github.com/openshift/aws-account-operator/pkg/controller/utils"
+	"github.com/openshift/aws-account-operator/pkg/controller/utils"
 	"github.com/openshift/aws-account-operator/pkg/localmetrics"
 	"github.com/prometheus/client_golang/prometheus"
 )
@@ -37,11 +36,11 @@ type totalAccountWatcher struct {
 func Initialize(client client.Client, watchInterval time.Duration) {
 	log.Info("Initializing the totalAccountWatcher")
 
-	AwsClient, err := awsclient.GetAWSClient(client, awsclient.NewAwsClientInput{
-		SecretName: controllerutils.AwsSecretName,
-		NameSpace:  awsv1alpha1.AccountCrNamespace,
-		AwsRegion:  "us-east-1",
-	})
+	// Create this as AWS Global by default as there is currently no
+	// need to support China.
+	awsPlatformConfig := utils.AwsPlatformConfigGlobal
+
+	AwsClient, err := awsclient.GetAWSClient(client, awsPlatformConfig.ClientInput)
 
 	if err != nil {
 		log.Error(err, "Failed to get AwsClient")


### PR DESCRIPTION
This PR enabled the aws-account-operator to spawn AWS clients, based on
the region passed in the acccountClaim. The platform (AWS)
now has two default configs, one for AWS Global and one for AWS China.
Each PlatformConfig struct contains platform specific:
* AWS Client
* ARN Prefix
* Covered Regions
* Federation Config

EC2 instance tagging is also included to provide clarity over what
process created and destroyed the instances. `AaoInitRegion` = Aws
Account Operator Initialise Region.