### PR TITLE
Adds deploy target for automating install of the aws-account-operator

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,9 +91,24 @@ The below commands can be used to test payer account credentials where we create
 
 ## 1.5. Local Development
 
+### 1.5.1 Operator Install
+
+The operator can be installed locally on a Minishift or Code-Ready-Containers (CRC) cluster (or a private OpenShift cluster).  On a new local cluster, running the Makefile `deploy` target (passing the Access Key ID and Secret Access Key) will install the operator, and create all the necessary OpenShift CRDs and secrets for it to work locally.
+
+You must be logged into the cluster as an administrator, or otherwise have permissions to create namespaces and deploy CRDs.  For Minishift, this can be done:
+
+```sh
+oc login -u system:admin
+OPERATOR_ACCESS_KEY_ID="YOUR_ACCESS_KEY_ID" OPERATOR_SECRET_ACCESS_KEY="YOUR_SECRET_ACCESS_KEY" make deploy
+```
+
+This only needs to be done once for an individual local cluster.
+
+### 1.5.2 Running the Operator and Local Development Mode
+
 When developing locally using operator-sdk you may not have a metrics service running and other stages of the code may not want to be run.  We have introduced the ability to set the environment variable `FORCE_DEV_MODE` to account for these edge cases. Set the dev mode to `local` when running locally.
 
-ex: `FORCE_DEV_MODE=local operator-sdk up local`
+ex: `FORCE_DEV_MODE=local operator-sdk up local --namespace=aws-account-operator`
 
 # 2. The Custom Resources
 

--- a/hack/files/aws_v1alpha1_zero_size_accountpool.yaml
+++ b/hack/files/aws_v1alpha1_zero_size_accountpool.yaml
@@ -1,0 +1,6 @@
+apiVersion: aws.managed.openshift.io/v1alpha1
+kind: AccountPool
+metadata:
+  name: zero-size-accountpool
+spec:
+  poolSize: 0

--- a/hack/templates/aws_v1alpha1_aws_account_operator_credentials.tmpl
+++ b/hack/templates/aws_v1alpha1_aws_account_operator_credentials.tmpl
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Template
+parameters:
+- name: OPERATOR_ACCESS_KEY_ID
+- name: OPERATOR_SECRET_ACCESS_KEY
+metadata:
+  name: test-federated-user-template
+objects:
+- apiVersion: v1
+  data:
+    aws_access_key_id: "${OPERATOR_ACCESS_KEY_ID}"
+    aws_secret_access_key: "${OPERATOR_SECRET_ACCESS_KEY}"
+  kind: Secret
+  metadata:
+    name: aws-account-operator-credentials
+    namespace: aws-account-operator
+    type: Opaque


### PR DESCRIPTION
This change adds a deploy target to the Makefile, to automate the install
of the aws-account-operator pieces required for operation.

`make deploy` will create the operator secret, deploy the CRDs, and create an accountPool with zero size.  It's also idempotent, so it can be run multiple times with no issue and will just replace the resources that differ from what it expects (in case you create a bad secret, or whatnot).

REF: [https://issues.redhat.com/browse/OSD-3077](https://issues.redhat.com/browse/OSD-3077)

Signed-off-by: Christopher Collins <collins.christopher@gmail.com>