### PR TITLE
Removes duplicate "name" field from awsCredentialSecret; trailing whitespaces

### DIFF
--- a/hack/templates/aws_v1alpha1_ccs_accountclaim_cr.tmpl
+++ b/hack/templates/aws_v1alpha1_ccs_accountclaim_cr.tmpl
@@ -1,9 +1,9 @@
 apiVersion: v1
 kind: Template
 parameters:
-- name: NAME 
+- name: NAME
 - name: NAMESPACE
-- name: CCS_ACCOUNT_ID 
+- name: CCS_ACCOUNT_ID
 metadata:
   name: test-aws-ccs-accountclaim-template
 objects:
@@ -18,14 +18,13 @@ objects:
       regions:
       - name: us-east-1
     awsCredentialSecret:
-      name: aws
-      namespace: ${NAMESPACE} 
+      namespace: ${NAMESPACE}
       name: ${NAME}
     byoc: true
     byocAWSAccountID: ${CCS_ACCOUNT_ID}
     byocSecretRef:
       name: "byoc"
-      namespace: ${NAMESPACE} 
+      namespace: ${NAMESPACE}
     legalEntity:
       id: "111111"
       name: ${NAME}


### PR DESCRIPTION
This PR removes the duplicate "name" field from the awsCredentialSecret in the CCS accountClaim CR template.

It also removes trailing whitespaces from lines.

Tested with the `make test-ccs` target with no issues.

Signed-off-by: Christopher Collins <collins.christopher@gmail.com>