### PR TITLE
Add label for the target awsAccountID where the role is created

### DIFF
--- a/pkg/apis/aws/v1alpha1/shared_types.go
+++ b/pkg/apis/aws/v1alpha1/shared_types.go
@@ -85,3 +85,9 @@ var ErrCreateEC2Instance = errors.New("EC2CreationTimeout")
 
 // ErrFailedAWSTypecast indicates that there was a failure while typecasting to aws error
 var ErrFailedAWSTypecast = errors.New("FailedToTypecastAWSError")
+
+// UIDLabel is the string for the uid label on AWS Federated Account Access CRs
+var UIDLabel = "uid"
+
+// AccountIDLabel is the string for the AWS Account ID label on AWS Federated Account Access CRs
+var AccountIDLabel = "awsAccountID"


### PR DESCRIPTION
Currently, there is no direct reference to the target AWS account for an AWS Federated Account Access. Instead, it relies on using the `aws` secret in the namespace of the accountclaim to call `aws sts get-caller-identity`. This causes an issue if the aws secret is deleted before the finalizer code is run.

This PR fixes this by adding a label to the CR with the account ID. It still relies on the secret to get the account ID, but only needs to happen once. From then on, the ID can be referenced in the CR by the label. 

This also includes a new function to check an arbitrary label on the CR, rather than just the `uid` label.