### PR TITLE
Fix example CRs for Account and FederatedAccountAccess

### DIFF
--- a/deploy/crds/aws_v1alpha1_account_cr.yaml
+++ b/deploy/crds/aws_v1alpha1_account_cr.yaml
@@ -2,6 +2,11 @@ apiVersion: aws.managed.openshift.io/v1alpha1
 kind: Account
 metadata:
   name: example-account
+  namespace: example-namespace
 spec:
-  # Add fields here
-  size: 3
+  awsAccountID: "00000000"
+  claimLink: ""
+  iamUserSecret: ""
+  legalEntity:
+    id: "111111"
+    name: Test Organization

--- a/deploy/crds/aws_v1alpha1_awsfederatedaccountaccess_cr.yaml
+++ b/deploy/crds/aws_v1alpha1_awsfederatedaccountaccess_cr.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: aws-account-operator
 spec:
   awsCustomerCredentialSecret: 
-    name: osd-creds-mgmt-w2tclb-secret
-    namespace: aws-account-operator
-  externalCustomerAWSIAMARN: arn:aws:iam::414830704956:user/james.harrington
+    name: secret-name
+    namespace: example-namespace
+  externalCustomerAWSIAMARN: arn:aws:iam::${AWS_ACCOUNT_ID}:user/${AWS_IAM_USER}
   awsFederatedRoleName: read-only 


### PR DESCRIPTION
This PR takes out specific user information from the AWS Federated Account Access example CR, as well as fills out a basic spec for the Account example CR. 