### PR TITLE
Tag EC2 instances

### DIFF
--- a/pkg/apis/aws/v1alpha1/shared_types.go
+++ b/pkg/apis/aws/v1alpha1/shared_types.go
@@ -1,6 +1,8 @@
 package v1alpha1
 
-import "errors"
+import (
+	"errors"
+)
 
 // CoveredRegions map
 var CoveredRegions = map[string]map[string]string{
@@ -86,6 +88,8 @@ var ErrCreateEC2Instance = errors.New("EC2CreationTimeout")
 // ErrFailedAWSTypecast indicates that there was a failure while typecasting to aws error
 var ErrFailedAWSTypecast = errors.New("FailedToTypecastAWSError")
 
+// Shared variables
+
 // UIDLabel is the string for the uid label on AWS Federated Account Access CRs
 var UIDLabel = "uid"
 
@@ -109,3 +113,6 @@ var IAMUserIDLabel = "iamUserId"
 
 // EmailID is the ID used for prefixing Account CR names
 var EmailID = "osd-creds-mgmt"
+
+// EC2ResourceType is the resource type used when building EC2 tags
+var EC2ResourceType = "ec2Resources"

--- a/pkg/controller/account/account_controller.go
+++ b/pkg/controller/account/account_controller.go
@@ -443,7 +443,7 @@ func (r *ReconcileAccount) Reconcile(request reconcile.Request) (reconcile.Resul
 		}
 
 		// Initialize all supported regions by creating and terminating an instance in each
-		err = r.InitializeSupportedRegions(reqLogger, awsv1alpha1.CoveredRegions, creds)
+		err = r.InitializeSupportedRegions(reqLogger, currentAcctInstance, awsv1alpha1.CoveredRegions, creds)
 		if err != nil {
 			r.setStatusFailed(reqLogger, currentAcctInstance, "Failed to build and destroy ec2 instances")
 			return reconcile.Result{}, err


### PR DESCRIPTION
The operator should tag AWS resources (eg. EC2 instances) it creates so it can ensure during the clean up process that it deletes any instances that might have been left over during account initialization.

Ticket: https://issues.redhat.com/browse/OSD-3312
Test:

- I simply created an account which should test the creation and termination of ec2 instances

Currently this change tags the instances we start on account [creation](https://github.com/openshift/aws-account-operator/blob/master/pkg/controller/account/account_controller.go#L470). I would like some insight into other resources we should be tagging.