### PR TITLE
Add tag builder to client

### DIFF
--- a/pkg/apis/aws/v1alpha1/shared_types.go
+++ b/pkg/apis/aws/v1alpha1/shared_types.go
@@ -91,3 +91,9 @@ var UIDLabel = "uid"
 
 // AccountIDLabel is the string for the AWS Account ID label on AWS Federated Account Access CRs
 var AccountIDLabel = "awsAccountID"
+
+// ClusterNameTagKey is the AWS key name for cluster name
+var ClusterNameTagKey = "clusterName"
+
+// ClusterNamespaceTagKey is the AWS key name for cluster namespace
+var ClusterNamespaceTagKey = "clusterNamespace"

--- a/pkg/awsclient/tags.go
+++ b/pkg/awsclient/tags.go
@@ -1,0 +1,65 @@
+package awsclient
+
+import (
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/aws/aws-sdk-go/service/iam"
+	awsv1alpha1 "github.com/openshift/aws-account-operator/pkg/apis/aws/v1alpha1"
+)
+
+// AWSTag is a representation of an AWS Tag
+type AWSTag struct {
+	Key   string
+	Value string
+}
+
+// AWSAccountOperatorTags contains a list of tags to be applied to resources created by the aws-account-operator
+type AWSAccountOperatorTags struct {
+	Tags []AWSTag
+}
+
+// AWSTags implements AWSTagBuilder to return AWS Tags
+var AWSTags *AWSAccountOperatorTags
+
+// AWSTagBuilder provides a common interface to generate AWS Tags
+type AWSTagBuilder interface {
+	GetIAMTags() []*iam.Tag
+	GetEC2Tags() []*ec2.Tag
+}
+
+// GetIAMTags returns IAM tags
+func (t *AWSAccountOperatorTags) GetIAMTags() []*iam.Tag {
+	var tags []*iam.Tag
+	for _, tag := range t.Tags {
+		tags = append(tags, &iam.Tag{Key: aws.String(tag.Key), Value: aws.String(tag.Value)})
+	}
+	return tags
+}
+
+// GetEC2Tags returns EC2 tags
+func (t *AWSAccountOperatorTags) GetEC2Tags() []*ec2.Tag {
+	var tags []*ec2.Tag
+	for _, tag := range t.Tags {
+		tags = append(tags, &ec2.Tag{Key: aws.String(tag.Key), Value: aws.String(tag.Value)})
+	}
+	return tags
+}
+
+// BuildTags intializes AWSTags with required tags
+func BuildTags(accountClaim *awsv1alpha1.AccountClaim) AWSTagBuilder {
+	if AWSTags == nil {
+		ClusterNameTag := AWSTag{
+			Key:   awsv1alpha1.ClusterNameTagKey,
+			Value: accountClaim.Name,
+		}
+		ClusterNamespaceTag := AWSTag{
+			Key:   awsv1alpha1.ClusterNamespaceTagKey,
+			Value: accountClaim.Namespace,
+		}
+		AWSTags = &AWSAccountOperatorTags{
+			Tags: []AWSTag{ClusterNameTag, ClusterNamespaceTag},
+		}
+		return AWSTags
+	}
+	return AWSTags
+}


### PR DESCRIPTION
This PR implements a tag builder to the awsclient currently it would support EC2 and IAM tags