### PR TITLE
Update tag builder to take account claim, initialize every time

### DIFF
--- a/pkg/apis/aws/v1alpha1/shared_types.go
+++ b/pkg/apis/aws/v1alpha1/shared_types.go
@@ -92,8 +92,14 @@ var UIDLabel = "uid"
 // AccountIDLabel is the string for the AWS Account ID label on AWS Federated Account Access CRs
 var AccountIDLabel = "awsAccountID"
 
-// ClusterNameTagKey is the AWS key name for cluster name
-var ClusterNameTagKey = "clusterName"
+// ClusterAccountNameTagKey is the AWS key name for cluster account name
+var ClusterAccountNameTagKey = "clusterAccountName"
 
 // ClusterNamespaceTagKey is the AWS key name for cluster namespace
 var ClusterNamespaceTagKey = "clusterNamespace"
+
+// ClusterClaimLinkTagKey is the AWS key name for cluster claim
+var ClusterClaimLinkTagKey = "clusterClaimLink"
+
+// ClusterClaimLinkNamespaceTagKey is the AWS key name for cluster claim namespace
+var ClusterClaimLinkNamespaceTagKey = "clusterClaimLinkNamespace"

--- a/pkg/awsclient/tags.go
+++ b/pkg/awsclient/tags.go
@@ -46,20 +46,25 @@ func (t *AWSAccountOperatorTags) GetEC2Tags() []*ec2.Tag {
 }
 
 // BuildTags intializes AWSTags with required tags
-func BuildTags(accountClaim *awsv1alpha1.AccountClaim) AWSTagBuilder {
-	if AWSTags == nil {
-		ClusterNameTag := AWSTag{
-			Key:   awsv1alpha1.ClusterNameTagKey,
-			Value: accountClaim.Name,
-		}
-		ClusterNamespaceTag := AWSTag{
-			Key:   awsv1alpha1.ClusterNamespaceTagKey,
-			Value: accountClaim.Namespace,
-		}
-		AWSTags = &AWSAccountOperatorTags{
-			Tags: []AWSTag{ClusterNameTag, ClusterNamespaceTag},
-		}
-		return AWSTags
+func (t *AWSAccountOperatorTags) BuildTags(account *awsv1alpha1.Account) AWSTagBuilder {
+	ClusterAccountNameTag := AWSTag{
+		Key:   awsv1alpha1.ClusterAccountNameTagKey,
+		Value: account.Name,
+	}
+	ClusterNamespaceTag := AWSTag{
+		Key:   awsv1alpha1.ClusterNamespaceTagKey,
+		Value: account.Namespace,
+	}
+	ClusterClaimLinkTag := AWSTag{
+		Key:   awsv1alpha1.ClusterClaimLinkTagKey,
+		Value: account.Spec.ClaimLink,
+	}
+	ClusterClaimLinkNamespaceTag := AWSTag{
+		Key:   awsv1alpha1.ClusterClaimLinkNamespaceTagKey,
+		Value: account.Spec.ClaimLinkNamespace,
+	}
+	AWSTags = &AWSAccountOperatorTags{
+		Tags: []AWSTag{ClusterAccountNameTag, ClusterNamespaceTag, ClusterClaimLinkTag, ClusterClaimLinkNamespaceTag},
 	}
 	return AWSTags
 }


### PR DESCRIPTION
This PR makes changes to the tag builder to take an Account CR. It includes claimLink and claimLinkNamespace which will be blank if they don't exist. Ideally in the future we'll move user creation to when the accountClaim is triggered filling in this field. These fields are populated for CCS. 

Remove keeping state and make this function initialize everytime to ensure we don't hold stale data.