### PR TITLE
Fix Double Logging for Secrets Refresh

### DIFF
--- a/pkg/credentialwatcher/secretwatcher.go
+++ b/pkg/credentialwatcher/secretwatcher.go
@@ -135,7 +135,6 @@ func (s *secretWatcher) updateAccountRotateCredentialsStatus(log logr.Logger, ac
 
 	// Only rotate STS credentials if the account CR is in a Ready state
 	if accountInstance.Status.State != string(awsv1alpha1.AccountReady) {
-		log.Info(fmt.Sprintf("Account %s not in %s state, not rotating STS credentials", accountInstance.Name, awsv1alpha1.AccountReady))
 		return
 	}
 


### PR DESCRIPTION
Since this log message is logging twice, let's just remove it because it's not really adding much value since the account isn't ready anyway, and with failed accounts this is just causing a bunch of noise in the logs.