### PR TITLE
Refactor BuildIAMUser

### DIFF
--- a/pkg/controller/account/account_controller.go
+++ b/pkg/controller/account/account_controller.go
@@ -396,7 +396,7 @@ func (r *ReconcileAccount) Reconcile(request reconcile.Request) (reconcile.Resul
 			r.setStatusFailed(reqLogger, currentAcctInstance, fmt.Sprintf("Failed to build IAM UHC user: %s", iamUserNameUHC))
 			return reconcile.Result{}, err
 		}
-		currentAcctInstance.Spec.IAMUserSecret = secretName
+		currentAcctInstance.Spec.IAMUserSecret = *secretName
 		err = r.Client.Update(context.TODO(), currentAcctInstance)
 		if err != nil {
 			return reconcile.Result{}, err
@@ -412,7 +412,7 @@ func (r *ReconcileAccount) Reconcile(request reconcile.Request) (reconcile.Resul
 		// Intermittently our secret wont be ready before the next call, lets ensure it exists
 		for i := 0; i < 10; i++ {
 			secret := &corev1.Secret{}
-			err := r.Client.Get(context.TODO(), types.NamespacedName{Name: SREIAMUserSecret, Namespace: request.Namespace}, secret)
+			err := r.Client.Get(context.TODO(), types.NamespacedName{Name: *SREIAMUserSecret, Namespace: request.Namespace}, secret)
 			if err != nil {
 				if k8serr.IsNotFound(err) {
 					reqLogger.Info("SREIAMUserSecret not ready, trying again")
@@ -427,7 +427,7 @@ func (r *ReconcileAccount) Reconcile(request reconcile.Request) (reconcile.Resul
 
 		// Create new awsClient with SRE IAM credentials so we can generate STS and Federation tokens from it
 		SREAWSClient, err := awsclient.GetAWSClient(r.Client, awsclient.NewAwsClientInput{
-			SecretName: SREIAMUserSecret,
+			SecretName: *SREIAMUserSecret,
 			NameSpace:  awsv1alpha1.AccountCrNamespace,
 			AwsRegion:  "us-east-1",
 		})

--- a/pkg/controller/account/byoc.go
+++ b/pkg/controller/account/byoc.go
@@ -329,7 +329,7 @@ func (r *ReconcileAccount) byocRotateAccessKeys(reqLogger logr.Logger, byocAWSCl
 	}
 
 	// Create new BYOC access keys
-	userSecretInfo, err := CreateUserAccessKey(reqLogger, byocAWSClient, *getBYOCUserOutput.User.UserName)
+	userSecretInfo, err := CreateUserAccessKey(byocAWSClient, getBYOCUserOutput.User)
 	if err != nil {
 		failedToCreateUserAccessKeyMsg := fmt.Sprintf("Failed to create IAM access key for %s", *getBYOCUserOutput.User.UserName)
 		reqLogger.Info(failedToCreateUserAccessKeyMsg)

--- a/pkg/controller/utils/utils.go
+++ b/pkg/controller/utils/utils.go
@@ -103,7 +103,7 @@ func LogAwsError(logger logr.Logger, errMsg string, customError error, err error
 
 		logger.Error(customError,
 			fmt.Sprintf(`%s,
-				AWS Error Code: %s, 
+				AWS Error Code: %s,
 				AWS Error Message: %s`,
 				errMsg,
 				aerr.Code(),


### PR DESCRIPTION
This PR is a first pass at refactoring the BuildIAMUser function. It removes the logger from outer functions where possible and cleans up the logic within the function by moving out as much as possible into smaller functions. A couple of TODO's but this makes it much easier to read.

I think that we should move the logger completely from BuildIAMUser and return any errors out to the reconcile and parse there. I didn't do that here because of 1. time and 2. PR size.

All errors are returned to the reconcile function which will then fail the account if there is a problem.

`make test-all` is passing locally and I've verified that the AWS credentials are working.