### PR TITLE
add resource limits/requests for the operator per OSD-2109

### DIFF
--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -21,6 +21,13 @@ spec:
           command:
           - aws-account-operator
           imagePullPolicy: Always
+          resources:
+            requests:
+              memory: "200Mi"
+              cpu: "50m"
+            limits:
+              memroy: "400Mi"
+              cpu: "100m"
           env:
             - name: WATCH_NAMESPACE
               value: ""


### PR DESCRIPTION
Current usage on both stg and prod

STG:
aws-account-operator                           aws-account-operator-7578d56b5-l7cqg             45m          158Mi

PROD:
aws-account-operator                              aws-account-operator-647d5b8d7c-h5v2x              17m          112Mi
