### PR TITLE
Fix account failure race condition

### DIFF
--- a/pkg/controller/accountclaim/accountclaim_controller_test.go
+++ b/pkg/controller/accountclaim/accountclaim_controller_test.go
@@ -2,11 +2,13 @@ package accountclaim
 
 import (
 	"context"
-	"reflect"
-	"testing"
+	"time"
 
-	"github.com/golang/mock/gomock"
-	"github.com/stretchr/testify/assert"
+	"github.com/openshift/aws-account-operator/pkg/apis"
+	awsv1alpha1 "github.com/openshift/aws-account-operator/pkg/apis/aws/v1alpha1"
+	"github.com/openshift/aws-account-operator/pkg/localmetrics"
+	"github.com/openshift/aws-account-operator/test/fixtures"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/scheme"
@@ -14,103 +16,118 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
-	awsaccountapis "github.com/openshift/aws-account-operator/pkg/apis"
-	awsv1alpha1 "github.com/openshift/aws-account-operator/pkg/apis/aws/v1alpha1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
 )
 
-type mocks struct {
-	fakeKubeClient client.Client
-	mockCtrl       *gomock.Controller
-}
+var _ = Describe("AccountClaim", func() {
+	var (
+		name         = "testAccountClaim"
+		namespace    = "myAccountClaimNamespace"
+		accountClaim *awsv1alpha1.AccountClaim
+		r            *ReconcileAccountClaim
+		fakeClient   client.Client
+	)
 
-// create fake client to mock API calls
-func newTestReconciler() *ReconcileAccountClaim {
-	return &ReconcileAccountClaim{
-		client: fake.NewFakeClient(),
-		scheme: scheme.Scheme,
-	}
-}
+	apis.AddToScheme(scheme.Scheme)
+	localmetrics.Collector = localmetrics.NewMetricsCollector(nil)
 
-// setupDefaultMocks is an easy way to setup all of the default mocks
-func setupDefaultMocks(t *testing.T, localObjects []runtime.Object) *mocks {
-	mocks := &mocks{
-		fakeKubeClient: fake.NewFakeClient(localObjects...),
-		mockCtrl:       gomock.NewController(t),
-	}
-
-	return mocks
-}
-
-func TestReconcileAccountClaim(t *testing.T) {
-	awsaccountapis.AddToScheme(scheme.Scheme)
-	tests := []struct {
-		name                  string
-		localObjects          []runtime.Object
-		expectedAccountClaim  awsv1alpha1.AccountClaim
-		verifyAccountFunction func(client.Client, *awsv1alpha1.AccountClaim) bool
-	}{
-		{
-			name: "Placeholder",
-			localObjects: []runtime.Object{
-				&awsv1alpha1.AccountClaim{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "test",
-						Namespace: "claim-test",
-					},
+	BeforeEach(func() {
+		region := awsv1alpha1.AwsRegions{
+			Name: "us-east-1",
+		}
+		accountClaim = &awsv1alpha1.AccountClaim{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: namespace,
+			},
+			Spec: awsv1alpha1.AccountClaimSpec{
+				LegalEntity: awsv1alpha1.LegalEntity{
+					Name: "LegalCorp. Inc.",
+					ID:   "abcdefg123456",
+				},
+				AccountLink: "osd-creds-mgmt-aaabbb",
+				Aws: awsv1alpha1.Aws{
+					Regions: []awsv1alpha1.AwsRegions{region},
 				},
 			},
-			expectedAccountClaim: awsv1alpha1.AccountClaim{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test",
-					Namespace: "claim-test",
+		}
+	})
+
+	JustBeforeEach(func() {
+		// Objects to track in the fake client.
+		objs := []runtime.Object{accountClaim}
+		fakeClient = fake.NewFakeClient(objs...)
+	})
+
+	Context("Reconcile", func() {
+		It("should reconcile correctly", func() {
+			r = &ReconcileAccountClaim{client: fakeClient, scheme: scheme.Scheme}
+			req := reconcile.Request{
+				NamespacedName: types.NamespacedName{
+					Name:      name,
+					Namespace: namespace,
 				},
-			},
-			verifyAccountFunction: verifyAccountClaim,
-		},
-	}
-
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			// Arrange
-			mocks := setupDefaultMocks(t, test.localObjects)
-			// This is necessary for the mocks to report failures like methods not being called an expected number of times.
-			// after mocks is defined
-			defer mocks.mockCtrl.Finish()
-
-			rap := &ReconcileAccountClaim{
-				client: mocks.fakeKubeClient,
-				scheme: scheme.Scheme,
 			}
 
-			ap := awsv1alpha1.AccountPool{}
-			err := mocks.fakeKubeClient.Get(context.TODO(), types.NamespacedName{Name: "test", Namespace: "test"}, &ap)
+			_, err := r.Reconcile(req)
 
-			_, err = rap.Reconcile(reconcile.Request{
-				NamespacedName: types.NamespacedName{
-					Name:      "test",
+			Expect(err).NotTo(HaveOccurred())
+			ac := awsv1alpha1.AccountClaim{}
+			err = fakeClient.Get(context.TODO(), types.NamespacedName{Name: name, Namespace: namespace}, &ac)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(ac.Spec).To(Equal(accountClaim.Spec))
+		})
+
+		It("should retry on a conflict error", func() {
+			accountClaim.DeletionTimestamp = &metav1.Time{Time: time.Now()}
+			accountClaim.SetFinalizers(append(accountClaim.GetFinalizers(), "finalizer.aws.managed.openshift.io"))
+
+			account := &awsv1alpha1.Account{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "osd-creds-mgmt-aaabbb",
 					Namespace: "aws-account-operator",
 				},
-			})
+				Spec: awsv1alpha1.AccountSpec{
+					LegalEntity: awsv1alpha1.LegalEntity{
+						Name: "LegalCorp. Inc.",
+						ID:   "abcdefg123456",
+					},
+				},
+			}
 
-			assert.NoError(t, err, "Unexpected Error")
-			assert.True(t, test.verifyAccountFunction(mocks.fakeKubeClient, &test.expectedAccountClaim))
+			objs := []runtime.Object{accountClaim, account}
+			fakeClient = fake.NewFakeClient(objs...)
+			cl := &possiblyErroringFakeCtrlRuntimeClient{
+				fakeClient,
+				true,
+			}
+			r = &ReconcileAccountClaim{client: cl, scheme: scheme.Scheme}
+			req := reconcile.Request{
+				NamespacedName: types.NamespacedName{
+					Name:      name,
+					Namespace: namespace,
+				},
+			}
+
+			_, err := r.Reconcile(req)
+
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(Equal("Account CR Modified during CR reset. Conflict"))
 		})
-	}
+	})
+})
+
+type possiblyErroringFakeCtrlRuntimeClient struct {
+	client.Client
+	shouldError bool
 }
 
-func verifyAccountClaim(c client.Client, expected *awsv1alpha1.AccountClaim) bool {
-
-	ap := awsv1alpha1.AccountClaim{}
-	err := c.Get(context.TODO(), types.NamespacedName{Name: expected.Name, Namespace: expected.Namespace}, &ap)
-
-	if err != nil {
-		return false
+func (p *possiblyErroringFakeCtrlRuntimeClient) Update(
+	ctx context.Context,
+	acc runtime.Object) error {
+	if p.shouldError {
+		return fixtures.Conflict
 	}
-
-	if !reflect.DeepEqual(ap, *expected) {
-		return false
-	}
-
-	return true
+	return p.Client.Update(ctx, acc)
 }

--- a/pkg/controller/accountclaim/accountclaim_suite_test.go
+++ b/pkg/controller/accountclaim/accountclaim_suite_test.go
@@ -1,0 +1,13 @@
+package accountclaim_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestAccountclaim(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Accountclaim Suite")
+}

--- a/test/fixtures/clientErrors.go
+++ b/test/fixtures/clientErrors.go
@@ -1,0 +1,34 @@
+package fixtures
+
+// For use with the generated crclient mocks, these can be used as .Return() values
+// when the code path expects an error condition.
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// clientError will answer APIStatus questions like IsNotFound according to its `status`.
+type clientError struct {
+	reason metav1.StatusReason
+}
+
+// Status implements APIStatus
+func (ce clientError) Status() metav1.Status {
+	return metav1.Status{Reason: ce.reason}
+}
+
+// Error implements error
+func (ce clientError) Error() string {
+	return string(ce.reason)
+}
+
+// A couple of error stubs that can be returned from the Client.
+
+// NotFound stub API response
+var NotFound error = clientError{reason: metav1.StatusReasonNotFound}
+
+// AlreadyExists stub API response
+var AlreadyExists error = clientError{reason: metav1.StatusReasonAlreadyExists}
+
+// Conflict stub API response
+var Conflict error = clientError{reason: metav1.StatusReasonConflict}


### PR DESCRIPTION
Sometimes, when attempting to run the finalizer on an accountclaim the secrets watcher will update the CR in an attempt to rotate the credentials, which will cause the finalizer to fail and the account to go into a failed state.

This PR is designed to catch that specific error and requeue instead of failing the account.