### PR TITLE
Fix Typo for memory limit

### DIFF
--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -26,7 +26,7 @@ spec:
               memory: "200Mi"
               cpu: "50m"
             limits:
-              memroy: "400Mi"
+              memory: "400Mi"
               cpu: "100m"
           env:
             - name: WATCH_NAMESPACE


### PR DESCRIPTION
Fixes the typo that's preventing the operator from deploying.