### PR TITLE
increase the resource limits/requests for the operator to make sure it…

### DIFF
--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -23,11 +23,11 @@ spec:
           imagePullPolicy: Always
           resources:
             requests:
-              memory: "200Mi"
-              cpu: "50m"
+              memory: "500Mi"
+              cpu: "500m"
             limits:
-              memory: "400Mi"
-              cpu: "100m"
+              memory: "500Mi"
+              cpu: "500m"
           env:
             - name: WATCH_NAMESPACE
               value: ""


### PR DESCRIPTION
… would be running well all the time

After discussing with @drewandersonnz and based on the problem @jharrington22 raised in https://github.com/openshift/aws-account-operator/pull/354

Too make sure the operator can be ran without any risk, bump the values of the memory and cpu to the same, large enough value for limits and requests.

cc @rogbas @jharrington22 