### PR TITLE
Fix EBS volume failed to delete error

### DIFF
--- a/pkg/awsclient/client.go
+++ b/pkg/awsclient/client.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/aws/aws-sdk-go/service/ec2/ec2iface"
@@ -52,10 +53,14 @@ const (
 type Client interface {
 	//EC2
 	RunInstances(*ec2.RunInstancesInput) (*ec2.Reservation, error)
+	DescribeInstances(input *ec2.DescribeInstancesInput) (*ec2.DescribeInstancesOutput, error)
 	DescribeInstanceStatus(*ec2.DescribeInstanceStatusInput) (*ec2.DescribeInstanceStatusOutput, error)
 	TerminateInstances(*ec2.TerminateInstancesInput) (*ec2.TerminateInstancesOutput, error)
+	TerminateInstancesRequest(*ec2.TerminateInstancesInput) (*request.Request, *ec2.TerminateInstancesOutput)
 	DescribeVolumes(*ec2.DescribeVolumesInput) (*ec2.DescribeVolumesOutput, error)
 	DeleteVolume(*ec2.DeleteVolumeInput) (*ec2.DeleteVolumeOutput, error)
+	DetachVolume(input *ec2.DetachVolumeInput) (*ec2.VolumeAttachment, error)
+	DetachVolumeRequest(input *ec2.DetachVolumeInput) (req *request.Request, output *ec2.VolumeAttachment)
 	DescribeSnapshots(*ec2.DescribeSnapshotsInput) (*ec2.DescribeSnapshotsOutput, error)
 	DeleteSnapshot(*ec2.DeleteSnapshotInput) (*ec2.DeleteSnapshotOutput, error)
 
@@ -140,6 +145,10 @@ func (c *awsClient) RunInstances(input *ec2.RunInstancesInput) (*ec2.Reservation
 	return c.ec2Client.RunInstances(input)
 }
 
+func (c *awsClient) DescribeInstances(input *ec2.DescribeInstancesInput) (*ec2.DescribeInstancesOutput, error) {
+	return c.ec2Client.DescribeInstances(input)
+}
+
 func (c *awsClient) DescribeInstanceStatus(input *ec2.DescribeInstanceStatusInput) (*ec2.DescribeInstanceStatusOutput, error) {
 	return c.ec2Client.DescribeInstanceStatus(input)
 }
@@ -148,12 +157,24 @@ func (c *awsClient) TerminateInstances(input *ec2.TerminateInstancesInput) (*ec2
 	return c.ec2Client.TerminateInstances(input)
 }
 
+func (c *awsClient) TerminateInstancesRequest(input *ec2.TerminateInstancesInput) (*request.Request, *ec2.TerminateInstancesOutput) {
+	return c.ec2Client.TerminateInstancesRequest(input)
+}
+
 func (c *awsClient) DescribeVolumes(input *ec2.DescribeVolumesInput) (*ec2.DescribeVolumesOutput, error) {
 	return c.ec2Client.DescribeVolumes(input)
 }
 
 func (c *awsClient) DeleteVolume(input *ec2.DeleteVolumeInput) (*ec2.DeleteVolumeOutput, error) {
 	return c.ec2Client.DeleteVolume(input)
+}
+
+func (c *awsClient) DetachVolume(input *ec2.DetachVolumeInput) (*ec2.VolumeAttachment, error) {
+	return c.ec2Client.DetachVolume(input)
+}
+
+func (c *awsClient) DetachVolumeRequest(input *ec2.DetachVolumeInput) (req *request.Request, output *ec2.VolumeAttachment) {
+	return c.ec2Client.DetachVolumeRequest(input)
 }
 
 func (c *awsClient) DescribeSnapshots(input *ec2.DescribeSnapshotsInput) (*ec2.DescribeSnapshotsOutput, error) {

--- a/pkg/awsclient/client.go
+++ b/pkg/awsclient/client.go
@@ -57,6 +57,7 @@ type Client interface {
 	DescribeInstanceStatus(*ec2.DescribeInstanceStatusInput) (*ec2.DescribeInstanceStatusOutput, error)
 	TerminateInstances(*ec2.TerminateInstancesInput) (*ec2.TerminateInstancesOutput, error)
 	TerminateInstancesRequest(*ec2.TerminateInstancesInput) (*request.Request, *ec2.TerminateInstancesOutput)
+	WaitUntilInstanceTerminated(input *ec2.DescribeInstancesInput) error
 	DescribeVolumes(*ec2.DescribeVolumesInput) (*ec2.DescribeVolumesOutput, error)
 	DeleteVolume(*ec2.DeleteVolumeInput) (*ec2.DeleteVolumeOutput, error)
 	DetachVolume(input *ec2.DetachVolumeInput) (*ec2.VolumeAttachment, error)
@@ -159,6 +160,10 @@ func (c *awsClient) TerminateInstances(input *ec2.TerminateInstancesInput) (*ec2
 
 func (c *awsClient) TerminateInstancesRequest(input *ec2.TerminateInstancesInput) (*request.Request, *ec2.TerminateInstancesOutput) {
 	return c.ec2Client.TerminateInstancesRequest(input)
+}
+
+func (c *awsClient) WaitUntilInstanceTerminated(input *ec2.DescribeInstancesInput) error {
+	return c.ec2Client.WaitUntilInstanceTerminated(input)
 }
 
 func (c *awsClient) DescribeVolumes(input *ec2.DescribeVolumesInput) (*ec2.DescribeVolumesOutput, error) {

--- a/pkg/awsclient/mock/mock_client.go
+++ b/pkg/awsclient/mock/mock_client.go
@@ -115,6 +115,20 @@ func (mr *MockClientMockRecorder) TerminateInstancesRequest(arg0 interface{}) *g
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TerminateInstancesRequest", reflect.TypeOf((*MockClient)(nil).TerminateInstancesRequest), arg0)
 }
 
+// WaitUntilInstanceTerminated mocks base method
+func (m *MockClient) WaitUntilInstanceTerminated(input *ec2.DescribeInstancesInput) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "WaitUntilInstanceTerminated", input)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// WaitUntilInstanceTerminated indicates an expected call of WaitUntilInstanceTerminated
+func (mr *MockClientMockRecorder) WaitUntilInstanceTerminated(input interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WaitUntilInstanceTerminated", reflect.TypeOf((*MockClient)(nil).WaitUntilInstanceTerminated), input)
+}
+
 // DescribeVolumes mocks base method
 func (m *MockClient) DescribeVolumes(arg0 *ec2.DescribeVolumesInput) (*ec2.DescribeVolumesOutput, error) {
 	m.ctrl.T.Helper()

--- a/pkg/awsclient/mock/mock_client.go
+++ b/pkg/awsclient/mock/mock_client.go
@@ -5,6 +5,7 @@
 package mock
 
 import (
+	request "github.com/aws/aws-sdk-go/aws/request"
 	ec2 "github.com/aws/aws-sdk-go/service/ec2"
 	iam "github.com/aws/aws-sdk-go/service/iam"
 	organizations "github.com/aws/aws-sdk-go/service/organizations"
@@ -54,6 +55,21 @@ func (mr *MockClientMockRecorder) RunInstances(arg0 interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RunInstances", reflect.TypeOf((*MockClient)(nil).RunInstances), arg0)
 }
 
+// DescribeInstances mocks base method
+func (m *MockClient) DescribeInstances(input *ec2.DescribeInstancesInput) (*ec2.DescribeInstancesOutput, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DescribeInstances", input)
+	ret0, _ := ret[0].(*ec2.DescribeInstancesOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DescribeInstances indicates an expected call of DescribeInstances
+func (mr *MockClientMockRecorder) DescribeInstances(input interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeInstances", reflect.TypeOf((*MockClient)(nil).DescribeInstances), input)
+}
+
 // DescribeInstanceStatus mocks base method
 func (m *MockClient) DescribeInstanceStatus(arg0 *ec2.DescribeInstanceStatusInput) (*ec2.DescribeInstanceStatusOutput, error) {
 	m.ctrl.T.Helper()
@@ -84,6 +100,21 @@ func (mr *MockClientMockRecorder) TerminateInstances(arg0 interface{}) *gomock.C
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TerminateInstances", reflect.TypeOf((*MockClient)(nil).TerminateInstances), arg0)
 }
 
+// TerminateInstancesRequest mocks base method
+func (m *MockClient) TerminateInstancesRequest(arg0 *ec2.TerminateInstancesInput) (*request.Request, *ec2.TerminateInstancesOutput) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "TerminateInstancesRequest", arg0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.TerminateInstancesOutput)
+	return ret0, ret1
+}
+
+// TerminateInstancesRequest indicates an expected call of TerminateInstancesRequest
+func (mr *MockClientMockRecorder) TerminateInstancesRequest(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TerminateInstancesRequest", reflect.TypeOf((*MockClient)(nil).TerminateInstancesRequest), arg0)
+}
+
 // DescribeVolumes mocks base method
 func (m *MockClient) DescribeVolumes(arg0 *ec2.DescribeVolumesInput) (*ec2.DescribeVolumesOutput, error) {
 	m.ctrl.T.Helper()
@@ -112,6 +143,36 @@ func (m *MockClient) DeleteVolume(arg0 *ec2.DeleteVolumeInput) (*ec2.DeleteVolum
 func (mr *MockClientMockRecorder) DeleteVolume(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteVolume", reflect.TypeOf((*MockClient)(nil).DeleteVolume), arg0)
+}
+
+// DetachVolume mocks base method
+func (m *MockClient) DetachVolume(input *ec2.DetachVolumeInput) (*ec2.VolumeAttachment, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DetachVolume", input)
+	ret0, _ := ret[0].(*ec2.VolumeAttachment)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DetachVolume indicates an expected call of DetachVolume
+func (mr *MockClientMockRecorder) DetachVolume(input interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DetachVolume", reflect.TypeOf((*MockClient)(nil).DetachVolume), input)
+}
+
+// DetachVolumeRequest mocks base method
+func (m *MockClient) DetachVolumeRequest(input *ec2.DetachVolumeInput) (*request.Request, *ec2.VolumeAttachment) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DetachVolumeRequest", input)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.VolumeAttachment)
+	return ret0, ret1
+}
+
+// DetachVolumeRequest indicates an expected call of DetachVolumeRequest
+func (mr *MockClientMockRecorder) DetachVolumeRequest(input interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DetachVolumeRequest", reflect.TypeOf((*MockClient)(nil).DetachVolumeRequest), input)
 }
 
 // DescribeSnapshots mocks base method


### PR DESCRIPTION
If an EBS volume is attached to an instance, force detach it before attempting to delete.
Ticket: https://issues.redhat.com/browse/OSD-3311
Test:
- Create an account -> Claim the account created -> Delete account claim

This ticket is WIP because I want others to test it, it works for me but my environment hasn't been working properly.