### PR TITLE
Adds secret testing to Account Creation tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ delete-account:
 
 # Test Account creation
 .PHONY: test-account-creation
-test-account-creation: create-account delete-account
+test-account-creation: create-account test-secrets delete-account
 
 # Create account claim namespace
 .PHONY: create-account-claim-namespace
@@ -227,6 +227,12 @@ test-reuse: check-aws-account-id-env create-accountclaim-namespace create-accoun
 	test/integration/api/delete_account.sh
 	# Delete reuse account secrets
 	test/integration/api/delete_account_secrets.sh
+
+# Test secrets are what we expect them to be
+.PHONY: test-secrets
+test-secrets: 
+	# Test Secrets
+	test/integration/test_secrets.sh
 
 # Deploy the operator secrets, CRDs and namesapce.
 .PHONY: deploy-aws-account-operator-credentials

--- a/test/integration/api/delete_account_secrets.sh
+++ b/test/integration/api/delete_account_secrets.sh
@@ -10,5 +10,5 @@ fi
 
 for secret in $(oc get secrets -n "${NAMESPACE}" | awk "/${OSD_STAGING_1_ACCOUNT_CR_NAME_OSD}/"'{ print $1 }')
 do
-    oc delete secret $secret -n ${NAMESPACE}
+    oc delete secret $secret -n ${NAMESPACE} || true
 done

--- a/test/integration/test_secrets.sh
+++ b/test/integration/test_secrets.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-TEST_ACCOUNT="osd-staging-1"
+TEST_ACCOUNT_CR_NAME="osd-staging-1"
 TEST_NAMESPACE="aws-account-operator"
 EXIT_STATUS="PASS"
 
@@ -21,7 +21,7 @@ CONSOLE_KEYS="aws_console_login_url"
 for secret_map in "${EXPECTED_SECRETS[@]}"; do
   secret=${secret_map%%:*}
   expected_keys=${secret_map#*:}
-  test_secret="$(oc get secret osd-creds-mgmt-$TEST_ACCOUNT-$secret -n $TEST_NAMESPACE -o json | jq '.data')"
+  test_secret="$(oc get secret osd-creds-mgmt-$TEST_ACCOUNT_CR_NAME-$secret -n $TEST_NAMESPACE -o json | jq '.data')"
   
   if [ "$test_secret" == "" ]; then
     EXIT_STATUS="FAIL"

--- a/test/integration/test_secrets.sh
+++ b/test/integration/test_secrets.sh
@@ -1,8 +1,12 @@
 #!/bin/bash
 
+EXIT_PASS=0
+EXIT_FAIL_INVALID_KEYS=1
+EXIT_FAIL_INVALID_CREDS=2
+
 TEST_ACCOUNT_CR_NAME="osd-staging-1"
 TEST_NAMESPACE="aws-account-operator"
-EXIT_STATUS="PASS"
+EXIT_STATUS=$EXIT_PASS
 
 # Define Expected Secrets and their keys
 # FORMAT: expectedPosftix:VARIABLE_WITH_KEYS
@@ -19,6 +23,8 @@ SRE_CLI_KEYS="aws_access_key_id aws_secret_access_key aws_session_token"
 CONSOLE_KEYS="aws_console_login_url"
 
 for secret_map in "${EXPECTED_SECRETS[@]}"; do
+  test_secret_validity=false
+  has_session_token=false
   secret=${secret_map%%:*}
   expected_keys=${secret_map#*:}
   test_secret="$(oc get secret osd-creds-mgmt-$TEST_ACCOUNT_CR_NAME-$secret -n $TEST_NAMESPACE -o json | jq '.data')"
@@ -28,18 +34,43 @@ for secret_map in "${EXPECTED_SECRETS[@]}"; do
     continue
   fi
 
+  unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_SESSION_TOKEN
+
   # Lookup the expected keys
   for key in ${!expected_keys}; do
     val=$(jq -r ".$key" <<< "$test_secret")
     if [ "$val" == "null" ]; then
-      echo "key: '$key' not found in $TEST_ACCOUNT-$secret"
-      EXIT_STATUS="FAIL"
+      echo "key: '$key' not found in $TEST_ACCOUNT_CR_NAME-$secret"
+      EXIT_STATUS=$EXIT_FAIL_INVALID_KEYS
+      continue
+    fi
+
+    # Prepare variables for validity check
+    if [ $key == "aws_access_key_id" ]; then
+      export AWS_ACCESS_KEY_ID=$(echo -n $val | base64 -d)
+    fi
+    if [ $key == "aws_secret_access_key" ]; then
+      export AWS_SECRET_ACCESS_KEY=$(echo -n $val | base64 -d)
+    fi
+    if [ $key == "aws_session_token" ]; then
+      export AWS_SESSION_TOKEN=$(echo -n $val | base64 -d)
     fi
   done
+
+  # if the aws access key id is set, we should check the credential too.
+  if [ -n "$AWS_ACCESS_KEY_ID" ]; then
+    if ! aws sts get-caller-identity > /dev/null 2>&1; then
+      echo "Credentials for $TEST_ACCOUNT_CR_NAME-$secret are invalid."
+      # We only want to override the status if it's not already failing
+      if [ $EXIT_STATUS -eq $EXIT_PASS ]; then
+        EXIT_STATUS=$EXIT_FAIL_INVALID_CREDS
+      fi
+    fi
+  fi
 done
 
-if [ $EXIT_STATUS == "FAIL" ]; then
-  exit 1
+if [ $EXIT_STATUS -eq $EXIT_PASS ]; then
+  echo "Tested Secrets have valid structure and credentials are valid."
 fi
 
-echo "Tested Secrets have valid structure."
+exit $EXIT_STATUS

--- a/test/integration/test_secrets.sh
+++ b/test/integration/test_secrets.sh
@@ -41,3 +41,5 @@ done
 if [ $EXIT_STATUS == "FAIL" ]; then
   exit 1
 fi
+
+echo "Tested Secrets have valid structure."

--- a/test/integration/test_secrets.sh
+++ b/test/integration/test_secrets.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+TEST_ACCOUNT="osd-staging-1"
+TEST_NAMESPACE="aws-account-operator"
+EXIT_STATUS="PASS"
+
+# Define Expected Secrets and their keys
+# FORMAT: expectedPosftix:VARIABLE_WITH_KEYS
+EXPECTED_SECRETS=(
+  "osdmanagedadminsre-secret:OSDMASRE_SECRET_KEYS"
+  "secret:SECRET_KEYS"
+  "sre-cli-credentials:SRE_CLI_KEYS"
+  "sre-console-url:CONSOLE_KEYS"
+)
+
+OSDMASRE_SECRET_KEYS="aws_access_key_id aws_secret_access_key aws_user_name"
+SECRET_KEYS="aws_access_key_id aws_secret_access_key aws_user_name"
+SRE_CLI_KEYS="aws_access_key_id aws_secret_access_key aws_session_token"
+CONSOLE_KEYS="aws_console_login_url"
+
+for secret_map in "${EXPECTED_SECRETS[@]}"; do
+  secret=${secret_map%%:*}
+  expected_keys=${secret_map#*:}
+  test_secret="$(oc get secret osd-creds-mgmt-$TEST_ACCOUNT-$secret -n $TEST_NAMESPACE -o json | jq '.data')"
+  
+  if [ "$test_secret" == "" ]; then
+    EXIT_STATUS="FAIL"
+    continue
+  fi
+
+  # Lookup the expected keys
+  for key in ${!expected_keys}; do
+    val=$(jq -r ".$key" <<< "$test_secret")
+    if [ "$val" == "null" ]; then
+      echo "key: '$key' not found in $TEST_ACCOUNT-$secret"
+      EXIT_STATUS="FAIL"
+    fi
+  done
+done
+
+if [ $EXIT_STATUS == "FAIL" ]; then
+  exit 1
+fi


### PR DESCRIPTION
Adds the ability to test that

* Expected secrets are present at the end of account creation
* Expected secrets have expected keys

To Test:
* `make test-account-creation`
* It should now verify that the secrets are present.

Or if you already have an `osd-staging-1` account created:
* `make test-secrets`