### PR TITLE
Adds secret owner refs during refresh.

### DIFF
--- a/pkg/controller/account/credentials_rotator.go
+++ b/pkg/controller/account/credentials_rotator.go
@@ -13,6 +13,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
 // RotateCredentials update existing secret with new STS tokens and Singin URL
@@ -70,6 +71,10 @@ func (r *ReconcileAccount) RotateCredentials(reqLogger logr.Logger, awsSetupClie
 	}
 
 	STSCredentialsSecret := CreateSecret(secretName, STSCredentialsSecretNamespace, secretData)
+
+	if err := controllerutil.SetControllerReference(account, STSCredentialsSecret, r.scheme); err != nil {
+		return err
+	}
 
 	err = r.Client.Create(context.TODO(), STSCredentialsSecret)
 	if err != nil {
@@ -146,6 +151,10 @@ func (r *ReconcileAccount) RotateConsoleCredentials(reqLogger logr.Logger, awsSe
 	}
 
 	userConsoleSecret := CreateSecret(STSConsoleSecretName, account.Namespace, STSConsoleSecretData)
+
+	if err := controllerutil.SetControllerReference(account, userConsoleSecret, r.scheme); err != nil {
+		return err
+	}
 
 	STSSecret := &corev1.Secret{}
 


### PR DESCRIPTION
This PR adds secret owner refs during a refresh as well as during the initial creation.

To Test:
* Start on the master branch.
* `operator-sdk up local --namepsace aws-account-operator`
* `make create-account`
* Wait one hour and then ensure that both `osd-creds-mgmt-osd-staging-1-sre-console-url` and `osd-creds-mgmt-osd-staging-1-sre-cli-credentials` are both refreshed (secret age will be less than 1 hour)
* `oc get secret -n aws-account-operator osd-creds-mgmt-osd-staging-1-sre-console-url -o json` as well as `-sre-cli-credentials` and see that there is no longer an owner reference.
* checkout this PR
* `operator-sdk up local --namespace aws-account-operator`
* Wait another hour, and ensure that both of the secrets above have refreshed again.
* `oc get secret -o json` for both secrets and verify that there is again an owner reference.

You don't have to sit here and wait for 2 hours, though, you can run one part, go do something else, come back later in the day to verify.  Or if you have a better way to force a secret refresh early I'd be willing to hear it.

Alternative way to test:
* Modify https://github.com/openshift/aws-account-operator/blob/master/cmd/manager/main.go#L37 to 1 minute
* Modify these to 1 minute (or 60 sec) https://github.com/openshift/aws-account-operator/blob/master/pkg/credentialwatcher/secretwatcher.go#L24-L26
* Follow the steps above but without waiting one hour you wait one minute.
- Thanks @jharrington22 