### PR TITLE
Use configmap to determine aws account limit

### DIFF
--- a/pkg/apis/aws/v1alpha1/shared_types.go
+++ b/pkg/apis/aws/v1alpha1/shared_types.go
@@ -92,7 +92,7 @@ var ErrFailedAWSTypecast = errors.New("FailedToTypecastAWSError")
 var ErrMissingDefaultConfigMap = errors.New("MissingDefaultConfigMap")
 
 // ErrInvalidConfigMap indicates that the ConfigMap has invalid fields
-var ErrInvalidConfigMap = errors.New("OUConfigMapInvalid")
+var ErrInvalidConfigMap = errors.New("ConfigMapInvalid")
 
 // ErrNonexistentOU indicates that an OU does not exist
 var ErrNonexistentOU = errors.New("OUWithNameNotFound")

--- a/pkg/apis/aws/v1alpha1/shared_types.go
+++ b/pkg/apis/aws/v1alpha1/shared_types.go
@@ -88,8 +88,11 @@ var ErrCreateEC2Instance = errors.New("EC2CreationTimeout")
 // ErrFailedAWSTypecast indicates that there was a failure while typecasting to aws error
 var ErrFailedAWSTypecast = errors.New("FailedToTypecastAWSError")
 
-// ErrInvalidOUMap indicates that the OU ConfigMap is not valid
-var ErrInvalidOUMap = errors.New("OUConfigMapInvalid")
+// ErrMissingDefaultConfigMap indicates that the expected default confimap was not found
+var ErrMissingDefaultConfigMap = errors.New("MissingDefaultConfigMap")
+
+// ErrInvalidConfigMap indicates that the ConfigMap has invalid fields
+var ErrInvalidConfigMap = errors.New("OUConfigMapInvalid")
 
 // ErrNonexistentOU indicates that an OU does not exist
 var ErrNonexistentOU = errors.New("OUWithNameNotFound")
@@ -128,3 +131,9 @@ var EmailID = "osd-creds-mgmt"
 
 // InstanceResourceType is the resource type used when building Instance tags
 var InstanceResourceType = "instance"
+
+// DefaultConfigMap holds the expected name for the operator's ConfigMap
+var DefaultConfigMap = "aws-account-operator-configmap"
+
+// DefaultConfigMapAccountLimit holds the fallback limit of aws-accounts
+var DefaultConfigMapAccountLimit = 100

--- a/pkg/controller/account/account_controller.go
+++ b/pkg/controller/account/account_controller.go
@@ -36,7 +36,6 @@ var log = logf.Log.WithName("controller_account")
 
 const (
 	// AwsLimit tracks the hard limit to the number of accounts; exported for use in cmd/manager/main.go
-	AwsLimit                = 4800
 	awsCredsUserName        = "aws_user_name"
 	awsCredsSecretIDKey     = "aws_access_key_id"
 	awsCredsSecretAccessKey = "aws_secret_access_key"
@@ -286,7 +285,7 @@ func (r *ReconcileAccount) Reconcile(request reconcile.Request) (reconcile.Resul
 
 			if !accountHasAwsAccountID(currentAcctInstance) {
 				// before doing anything make sure we are not over the limit if we are just error
-				if totalaccountwatcher.TotalAccountWatcher.Total >= AwsLimit {
+				if ok, _ := checkAWSAccountsLimitReached(r, reqLogger, totalaccountwatcher.TotalAccountWatcher.Total); ok {
 					reqLogger.Error(awsv1alpha1.ErrAwsAccountLimitExceeded, "AWS Account limit reached", "Account Total", totalaccountwatcher.TotalAccountWatcher.Total)
 					return reconcile.Result{}, awsv1alpha1.ErrAwsAccountLimitExceeded
 				}
@@ -603,6 +602,27 @@ func CreateAccount(reqLogger logr.Logger, client awsclient.Client, accountName, 
 	}
 
 	return accountStatus, nil
+}
+
+func checkAWSAccountsLimitReached(r *ReconcileAccount, reqLogger logr.Logger, currentAccounts int) (bool, error) {
+	instance := &corev1.ConfigMap{}
+	err := r.Client.Get(context.TODO(), types.NamespacedName{Namespace: awsv1alpha1.AccountCrNamespace, Name: awsv1alpha1.DefaultConfigMap}, instance)
+	if err != nil {
+		unexpectedErrorMsg := fmt.Sprintf("%s: Failed to retrieve default ConfigMap, account limit defaulting to 100", awsv1alpha1.ErrMissingDefaultConfigMap)
+		reqLogger.Info(unexpectedErrorMsg)
+	} else {
+		if limit, ok := instance.Data["account-limit"]; ok {
+			if i, err := strconv.Atoi(limit); err == nil {
+				return i <= currentAccounts, nil
+			}
+			unexpectedErrorMsg := fmt.Sprintf("Account: Failed to convert ConfigMap 'account-limit' string field to int, account limit defaulting to 100")
+			reqLogger.Info(unexpectedErrorMsg)
+		} else {
+			unexpectedErrorMsg := fmt.Sprintf("%s: Default ConfigMap missing 'account-limit' field, account limit defaulting to 100", awsv1alpha1.ErrInvalidConfigMap)
+			reqLogger.Info(unexpectedErrorMsg)
+		}
+	}
+	return awsv1alpha1.DefaultConfigMapAccountLimit <= currentAccounts, err
 }
 
 func formatAccountEmail(name string) string {

--- a/pkg/controller/accountclaim/accountclaim_controller.go
+++ b/pkg/controller/accountclaim/accountclaim_controller.go
@@ -29,7 +29,6 @@ import (
 const (
 	AccountClaimed          = "AccountClaimed"
 	AccountUnclaimed        = "AccountUnclaimed"
-	OUConfigMapName         = "aws-account-operator-configmap"
 	BYOCAccountFailedClaim  = "BYOCAccountFailed"
 	awsCredsUserName        = "aws_user_name"
 	awsCredsAccessKeyId     = "aws_access_key_id"

--- a/pkg/controller/accountclaim/organizational_units.go
+++ b/pkg/controller/accountclaim/organizational_units.go
@@ -26,7 +26,7 @@ func MoveAccountToOU(r *ReconcileAccountClaim, reqLogger logr.Logger, accountCla
 
 	// Search for ConfigMap that holds OU mapping
 	instance := &corev1.ConfigMap{}
-	err = r.client.Get(context.TODO(), types.NamespacedName{Namespace: awsv1alpha1.AccountCrNamespace, Name: OUConfigMapName}, instance)
+	err = r.client.Get(context.TODO(), types.NamespacedName{Namespace: awsv1alpha1.AccountCrNamespace, Name: awsv1alpha1.DefaultConfigMap}, instance)
 	if err != nil {
 		// If we failed to retrieve the ConfigMap, simply leave the account in Root
 		unexpectedErrorMsg := fmt.Sprintf("OU: Failed to find OU mapping ConfigMap, leaving account in root")
@@ -196,10 +196,10 @@ func findOUIDFromName(reqLogger logr.Logger, client awsclient.Client, parentid s
 
 func checkOUMapping(cMap *corev1.ConfigMap) (string, string, error) {
 	if _, ok := cMap.Data["base"]; !ok {
-		return "", "", awsv1alpha1.ErrInvalidOUMap
+		return "", "", awsv1alpha1.ErrInvalidConfigMap
 	}
 	if _, ok := cMap.Data["root"]; !ok {
-		return "", "", awsv1alpha1.ErrInvalidOUMap
+		return "", "", awsv1alpha1.ErrInvalidConfigMap
 	}
 	return cMap.Data["base"], cMap.Data["root"], nil
 }

--- a/pkg/controller/accountclaim/organizational_units_test.go
+++ b/pkg/controller/accountclaim/organizational_units_test.go
@@ -107,7 +107,7 @@ func TestCheckOUMapping(t *testing.T) {
 					"base": "claim-test",
 				},
 			},
-			expectedError:      awsv1alpha1.ErrInvalidOUMap,
+			expectedError:      awsv1alpha1.ErrInvalidConfigMap,
 			checkOUMappingFunc: checkOUMapping,
 		},
 		{
@@ -117,7 +117,7 @@ func TestCheckOUMapping(t *testing.T) {
 					"root": "test",
 				},
 			},
-			expectedError:      awsv1alpha1.ErrInvalidOUMap,
+			expectedError:      awsv1alpha1.ErrInvalidConfigMap,
 			checkOUMappingFunc: checkOUMapping,
 		},
 		{
@@ -127,7 +127,7 @@ func TestCheckOUMapping(t *testing.T) {
 					"root": "test",
 				},
 			},
-			expectedError:      awsv1alpha1.ErrInvalidOUMap,
+			expectedError:      awsv1alpha1.ErrInvalidConfigMap,
 			checkOUMappingFunc: checkOUMapping,
 		},
 	}


### PR DESCRIPTION
[ticket](https://issues.redhat.com/browse/OSD-3924)

Remove hard coded account limit from the operator. Since different environments have different account limits we should look for the given limit in the operator's ConfigMap.