### PR TITLE
Add finalizer to the byoc secret, ensure it can be used before deletion

### DIFF
--- a/pkg/controller/accountclaim/accountclaim_controller.go
+++ b/pkg/controller/accountclaim/accountclaim_controller.go
@@ -35,6 +35,7 @@ const (
 	awsCredsAccessKeyId     = "aws_access_key_id"
 	awsCredsSecretAccessKey = "aws_secret_access_key"
 	accountClaimFinalizer   = "finalizer.aws.managed.openshift.io"
+	byocSecretFinalizer     = accountClaimFinalizer + "/byoc"
 	waitPeriod              = 30
 )
 
@@ -166,6 +167,13 @@ func (r *ReconcileAccountClaim) Reconcile(request reconcile.Request) (reconcile.
 	if accountClaim.Spec.BYOC {
 
 		reqLogger.Info("Reconciling BYOC AccountClaim")
+
+		// Ensure BYOC secret has finalizer
+		reqLogger.Info("Ensuring byoc secret has finalizer")
+		err = r.addBYOCSecretFinalizer(accountClaim)
+		if err != nil {
+			reqLogger.Error(err, "Unable to add finalizer to byoc secret")
+		}
 
 		if accountClaim.Spec.AccountLink == "" {
 

--- a/pkg/controller/accountclaim/accountclaim_finalizer.go
+++ b/pkg/controller/accountclaim/accountclaim_finalizer.go
@@ -4,8 +4,11 @@ import (
 	"context"
 
 	"github.com/go-logr/logr"
+	"k8s.io/apimachinery/pkg/types"
+
 	awsv1alpha1 "github.com/openshift/aws-account-operator/pkg/apis/aws/v1alpha1"
 	"github.com/openshift/aws-account-operator/pkg/controller/utils"
+	corev1 "k8s.io/api/core/v1"
 )
 
 func (r *ReconcileAccountClaim) addFinalizer(reqLogger logr.Logger, accountClaim *awsv1alpha1.AccountClaim) error {
@@ -31,5 +34,49 @@ func (r *ReconcileAccountClaim) removeFinalizer(reqLogger logr.Logger, accountCl
 		reqLogger.Error(err, "Failed to remove AccountClaim finalizer")
 		return err
 	}
+	return nil
+}
+
+func (r *ReconcileAccountClaim) addBYOCSecretFinalizer(accountClaim *awsv1alpha1.AccountClaim) error {
+
+	byocSecret := &corev1.Secret{}
+	err := r.client.Get(context.TODO(),
+		types.NamespacedName{
+			Name:      accountClaim.Spec.BYOCSecretRef.Name,
+			Namespace: accountClaim.Spec.BYOCSecretRef.Namespace},
+		byocSecret)
+	if err != nil {
+		return err
+	}
+
+	if !utils.Contains(byocSecret.GetFinalizers(), byocSecretFinalizer) {
+		utils.AddFinalizer(byocSecret, byocSecretFinalizer)
+		err = r.client.Update(context.TODO(), byocSecret)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (r *ReconcileAccountClaim) removeBYOCSecretFinalizer(accountClaim *awsv1alpha1.AccountClaim) error {
+
+	byocSecret := &corev1.Secret{}
+	err := r.client.Get(context.TODO(),
+		types.NamespacedName{
+			Name:      accountClaim.Spec.BYOCSecretRef.Name,
+			Namespace: accountClaim.Spec.BYOCSecretRef.Namespace},
+		byocSecret)
+	if err != nil {
+		return err
+	}
+
+	byocSecret.Finalizers = utils.Remove(byocSecret.Finalizers, byocSecretFinalizer)
+	err = r.client.Update(context.TODO(), byocSecret)
+	if err != nil {
+		return err
+	}
+
 	return nil
 }

--- a/pkg/controller/accountclaim/reuse.go
+++ b/pkg/controller/accountclaim/reuse.go
@@ -85,6 +85,14 @@ func (r *ReconcileAccountClaim) finalizeAccountClaim(reqLogger logr.Logger, acco
 		if err != nil {
 			reqLogger.Error(err, "Failed to delete BYOC account from accountclaim cleanup")
 		}
+
+		// Cleanup BYOC secret
+		err = r.removeBYOCSecretFinalizer(accountClaim)
+		if err != nil {
+			reqLogger.Error(err, "Failed to remove BYOC secret finalizer")
+			return err
+		}
+
 		return nil
 	}
 


### PR DESCRIPTION
Currently, the byoc secret can be deleted before the accountclaim has a chance to finalize. This PR adds a finalizer to the byoc secret to ensure the secret is still around when the accountclaim tries to use it. Once the claim has used the secret, it removes the finalizer. 