### PR TITLE
Log failed accounts and don't reconcile

### DIFF
--- a/pkg/controller/account/account_controller.go
+++ b/pkg/controller/account/account_controller.go
@@ -141,6 +141,12 @@ func (r *ReconcileAccount) Reconcile(request reconcile.Request) (reconcile.Resul
 		return reconcile.Result{}, nil
 	}
 
+	// Log accounts that have failed and don't attempt to reconcile them
+	if accountIsFailed(currentAcctInstance) {
+		reqLogger.Info(fmt.Sprintf("Account %s is failed ignoring", currentAcctInstance.Name))
+		return reconcile.Result{}, nil
+	}
+
 	// We expect this secret to exist in the same namespace Account CR's are created
 	awsSetupClient, err := awsclient.GetAWSClient(r.Client, awsclient.NewAwsClientInput{
 		SecretName: utils.AwsSecretName,
@@ -606,6 +612,14 @@ func (r *ReconcileAccount) statusUpdate(reqLogger logr.Logger, account *awsv1alp
 func matchSubstring(roleID, role string) (bool, error) {
 	matched, err := regexp.MatchString(roleID, role)
 	return matched, err
+}
+
+// Returns true if account CR is Failed
+func accountIsFailed(currentAcctInstance *awsv1alpha1.Account) bool {
+	if currentAcctInstance.Status.State == AccountFailed {
+		return true
+	}
+	return false
 }
 
 // Returns true of there is no state set

--- a/pkg/controller/account/account_controller_test.go
+++ b/pkg/controller/account/account_controller_test.go
@@ -340,6 +340,41 @@ func TestAccountIsReady(t *testing.T) {
 	}
 }
 
+// Test accountIsFailed
+func TestAccountIsFailed(t *testing.T) {
+	tests := []struct {
+		name     string
+		expected bool
+		acct     *testAccountBuilder
+	}{
+		{
+			name:     "Account is ready",
+			acct:     newTestAccountBuilder(),
+			expected: false,
+		},
+		{
+			name:     "Account is failed",
+			acct:     newTestAccountBuilder().WithState(awsv1alpha1.AccountFailed),
+			expected: true,
+		},
+	}
+	for _, test := range tests {
+		t.Run(
+			test.name,
+			func(t *testing.T) {
+				result := accountIsFailed(&test.acct.acct)
+				if result != test.expected {
+					t.Error(
+						"for account:", test.acct,
+						"expected", test.expected,
+						"got", result,
+					)
+				}
+			},
+		)
+	}
+}
+
 // Test accountIsCreating
 func TestAccountIsCreating(t *testing.T) {
 	tests := []struct {


### PR DESCRIPTION
This PR sets the account controller to log and ignore accounts with the `.status.state` "Failed"