### PR TITLE
OSD-4026 Remove operator resource limits

### DIFF
--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -21,13 +21,6 @@ spec:
           command:
           - aws-account-operator
           imagePullPolicy: Always
-          resources:
-            requests:
-              memory: "200Mi"
-              cpu: "50m"
-            limits:
-              memory: "400Mi"
-              cpu: "100m"
           env:
             - name: WATCH_NAMESPACE
               value: ""


### PR DESCRIPTION
Removing the resource limits so we can:

1. validate the hypothesis that limits are causing accountClaim controller to die unexpectedly
2. profile operator for a couple of days and propose new limits