### PR TITLE
Refactor metrics collector

### DIFF
--- a/pkg/controller/account/byoc.go
+++ b/pkg/controller/account/byoc.go
@@ -346,7 +346,9 @@ func (r *ReconcileAccount) accountClaimBYOCError(reqLogger logr.Logger, accountC
 		corev1.ConditionTrue,
 		"AccountFailed",
 		message,
-		controllerutils.UpdateConditionNever)
+		controllerutils.UpdateConditionNever,
+		accountClaim.Spec.BYOCAWSAccountID != "",
+	)
 	accountClaim.Status.State = awsv1alpha1.ClaimStatusError
 	err := r.Client.Status().Update(context.TODO(), accountClaim)
 	if err != nil {

--- a/pkg/controller/accountpool/accountpool_controller.go
+++ b/pkg/controller/accountpool/accountpool_controller.go
@@ -7,7 +7,6 @@ import (
 	awsv1alpha1 "github.com/openshift/aws-account-operator/pkg/apis/aws/v1alpha1"
 	"github.com/openshift/aws-account-operator/pkg/controller/account"
 	"github.com/openshift/aws-account-operator/pkg/controller/utils"
-	"github.com/openshift/aws-account-operator/pkg/localmetrics"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -134,9 +133,6 @@ func (r *ReconcileAccountPool) Reconcile(request reconcile.Request) (reconcile.R
 			return reconcile.Result{}, err
 		}
 	}
-
-	localmetrics.UpdateAccountCRMetrics(accountList)
-	localmetrics.UpdatePoolSizeVsUnclaimed(currentAccountPool.Spec.PoolSize, unclaimedAccountCount)
 
 	if unclaimedAccountCount >= poolSizeCount {
 		reqLogger.Info(fmt.Sprintf("unclaimed account pool satisfied, unclaimedAccounts %d >= poolSize %d", unclaimedAccountCount, poolSizeCount))

--- a/pkg/totalaccountwatcher/totalaccountwatcher.go
+++ b/pkg/totalaccountwatcher/totalaccountwatcher.go
@@ -52,7 +52,11 @@ func Initialize(client client.Client, watchInterval time.Duration) {
 }
 
 // NewTotalAccountWatcher returns a new instance of the TotalAccountWatcher interface
-func NewTotalAccountWatcher(client client.Client, AwsClient awsclient.Client, watchInterval time.Duration) *totalAccountWatcher {
+func NewTotalAccountWatcher(
+	client client.Client,
+	AwsClient awsclient.Client,
+	watchInterval time.Duration,
+) *totalAccountWatcher {
 	return &totalAccountWatcher{
 		watchInterval: watchInterval,
 		AwsClient:     AwsClient,
@@ -85,8 +89,7 @@ func (s *totalAccountWatcher) UpdateTotalAccounts(log logr.Logger) error {
 	if err != nil {
 		log.Error(err, "Failed to get account list with error code")
 	}
-
-	localmetrics.MetricTotalAWSAccounts.Set(float64(accountTotal))
+	localmetrics.Collector.SetTotalAWSAccounts(accountTotal)
 
 	if accountTotal != TotalAccountWatcher.Total {
 		log.Info(fmt.Sprintf("Updating total from %d to %d", TotalAccountWatcher.Total, accountTotal))


### PR DESCRIPTION
Signed-off-by: yeya24 <yb532204897@gmail.com>

Fixes:

https://issues.redhat.com/browse/OSD-4030
https://issues.redhat.com/browse/OSD-4033
https://issues.redhat.com/browse/OSD-4032
https://issues.redhat.com/browse/OSD-4031

## What are changed and how it works?

In the pervious metrics implementation, the metrics are updated in each reconcile loops. This way is not very reusable because if we add a new controller, maybe we have to add metrics update logic to its reconcile loop as well.

The main idea of refactoring is to move the metrics update logic out of the reconcile loop and it is also better to put all metrics collecting stuff in one place so it can be easily reused .

A common practice in controller metrics is https://github.com/coreos/prometheus-operator/blob/master/pkg/alertmanager/collector.go. We just need to implement a collector struct with two interfaces, then the struct can be registered to the Prometheus registry and collected at the configured Prometheus scrape interval.

```
Describe(ch chan<- *prometheus.Desc)
Collect(ch chan<- prometheus.Metric)
```

## label changes

In previous metrics, we have some metrics like `aws_account_operator_total_accounts_crs_unclaimed` or `aws_account_operator_total_accounts_crs_claimed`, I put some of the status fields in Prometheus metrics label.

Labels we have 
![Screenshot from 2020-06-11 10-11-37](https://user-images.githubusercontent.com/25150124/84395335-fe37c500-abcb-11ea-8860-748af78d7dd2.png)

