### PR TITLE
Create and Delete BYOCAdminAccess role per cluster

### DIFF
--- a/pkg/awsclient/client.go
+++ b/pkg/awsclient/client.go
@@ -84,6 +84,7 @@ type Client interface {
 	CreateRole(*iam.CreateRoleInput) (*iam.CreateRoleOutput, error)
 	GetRole(*iam.GetRoleInput) (*iam.GetRoleOutput, error)
 	DeleteRole(*iam.DeleteRoleInput) (*iam.DeleteRoleOutput, error)
+	ListRoles(input *iam.ListRolesInput) (*iam.ListRolesOutput, error)
 
 	//Organizations
 	ListAccounts(*organizations.ListAccountsInput) (*organizations.ListAccountsOutput, error)
@@ -257,6 +258,10 @@ func (c *awsClient) GetRole(input *iam.GetRoleInput) (*iam.GetRoleOutput, error)
 
 func (c *awsClient) DeleteRole(input *iam.DeleteRoleInput) (*iam.DeleteRoleOutput, error) {
 	return c.iamClient.DeleteRole(input)
+}
+
+func (c *awsClient) ListRoles(input *iam.ListRolesInput) (*iam.ListRolesOutput, error) {
+	return c.iamClient.ListRoles(input)
 }
 
 func (c *awsClient) ListAccounts(input *organizations.ListAccountsInput) (*organizations.ListAccountsOutput, error) {

--- a/pkg/awsclient/iam.go
+++ b/pkg/awsclient/iam.go
@@ -173,3 +173,27 @@ func CreateIAMUser(reqLogger logr.Logger, client Client, account *awsv1alpha1.Ac
 
 	return createUserOutput, err
 }
+
+func ListIAMRoles(reqLogger logr.Logger, client Client) ([]*iam.Role, error) {
+
+	// List of IAM roles to return
+	iamRoleList := []*iam.Role{}
+	var marker *string
+
+	for {
+		output, err := client.ListRoles(&iam.ListRolesInput{Marker: marker})
+		if err != nil {
+			return nil, err
+		}
+
+		for _, role := range output.Roles {
+			iamRoleList = append(iamRoleList, role)
+		}
+
+		if *output.IsTruncated {
+			marker = output.Marker
+		} else {
+			return iamRoleList, nil
+		}
+	}
+}

--- a/pkg/awsclient/mock/mock_client.go
+++ b/pkg/awsclient/mock/mock_client.go
@@ -503,6 +503,21 @@ func (mr *MockClientMockRecorder) DeleteRole(arg0 interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteRole", reflect.TypeOf((*MockClient)(nil).DeleteRole), arg0)
 }
 
+// ListRoles mocks base method
+func (m *MockClient) ListRoles(input *iam.ListRolesInput) (*iam.ListRolesOutput, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListRoles", input)
+	ret0, _ := ret[0].(*iam.ListRolesOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListRoles indicates an expected call of ListRoles
+func (mr *MockClientMockRecorder) ListRoles(input interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListRoles", reflect.TypeOf((*MockClient)(nil).ListRoles), input)
+}
+
 // ListAccounts mocks base method
 func (m *MockClient) ListAccounts(arg0 *organizations.ListAccountsInput) (*organizations.ListAccountsOutput, error) {
 	m.ctrl.T.Helper()

--- a/pkg/controller/account/account_controller.go
+++ b/pkg/controller/account/account_controller.go
@@ -312,7 +312,8 @@ func (r *ReconcileAccount) Reconcile(request reconcile.Request) (reconcile.Resul
 			currentAccInstanceID := currentAcctInstance.Labels[fmt.Sprintf("%s", awsv1alpha1.IAMUserIDLabel)]
 			iamUserUHC = fmt.Sprintf("%s-%s", iamUserNameUHC, currentAccInstanceID)
 			iamUserSRE = fmt.Sprintf("%s-%s", iamUserNameSRE, currentAccInstanceID)
-			roleToAssume = byocRole
+			byocRoleToAssume := fmt.Sprintf("%s-%s", byocRole, currentAccInstanceID)
+			roleToAssume = byocRoleToAssume
 		} else {
 			roleToAssume = awsv1alpha1.AccountOperatorIAMRole
 		}

--- a/pkg/controller/account/byoc_test.go
+++ b/pkg/controller/account/byoc_test.go
@@ -135,20 +135,20 @@ var _ = Describe("Byoc", func() {
 	Context("Testing CreateRole", func() {
 		It("Works properly without error", func() {
 			mockAWSClient.EXPECT().CreateRole(gomock.Any()).Return(&iam.CreateRoleOutput{Role: &iam.Role{RoleId: aws.String("AROA1234567890EXAMPLE")}}, nil).AnyTimes()
-			roleID, err := CreateRole(nullLogger, "roleName", userARN, mockAWSClient)
+			roleID, err := CreateRole(nullLogger, "roleName", userARN, mockAWSClient, nil)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(roleID).To(Equal("AROA1234567890EXAMPLE"))
 		})
 
 		It("Throws an error on any AWS error", func() {
 			mockAWSClient.EXPECT().CreateRole(gomock.Any()).Return(nil, awserr.New("AWSError", "Some AWS Error", nil)).AnyTimes()
-			_, err := CreateRole(nullLogger, "roleName", userARN, mockAWSClient)
+			_, err := CreateRole(nullLogger, "roleName", userARN, mockAWSClient, nil)
 			Expect(err).To(HaveOccurred())
 		})
 
 		It("Throws an error on any Non-AWS error", func() {
 			mockAWSClient.EXPECT().CreateRole(gomock.Any()).Return(nil, errors.New("NonAWSError")).AnyTimes()
-			_, err := CreateRole(nullLogger, "roleName", userARN, mockAWSClient)
+			_, err := CreateRole(nullLogger, "roleName", userARN, mockAWSClient, nil)
 			Expect(err).To(HaveOccurred())
 		})
 	})


### PR DESCRIPTION
This PR alters the creation of the BYOCAdminAccess role to match osdManagedAdmin and osdManagedAdminSRE users creation to be unique per cluster/accountclaim. 