### PR TITLE
OSD 3573 ensure ccs uses osdmanagedadmin creds

### DIFF
--- a/hack/templates/aws_v1alpha1_ccs_accountclaim_cr.tmpl
+++ b/hack/templates/aws_v1alpha1_ccs_accountclaim_cr.tmpl
@@ -18,12 +18,12 @@ objects:
       regions:
       - name: us-east-1
     awsCredentialSecret:
+      name: aws
       namespace: ${NAMESPACE}
-      name: ${NAME}
     byoc: true
     byocAWSAccountID: ${CCS_ACCOUNT_ID}
     byocSecretRef:
-      name: "byoc"
+      name: byoc
       namespace: ${NAMESPACE}
     legalEntity:
       id: "111111"

--- a/pkg/controller/accountclaim/accountclaim_controller.go
+++ b/pkg/controller/accountclaim/accountclaim_controller.go
@@ -162,7 +162,6 @@ func (r *ReconcileAccountClaim) Reconcile(request reconcile.Request) (reconcile.
 	}
 
 	if accountClaim.Spec.BYOC {
-
 		reqLogger.Info("Reconciling BYOC AccountClaim")
 
 		// Ensure BYOC secret has finalizer
@@ -239,6 +238,14 @@ func (r *ReconcileAccountClaim) Reconcile(request reconcile.Request) (reconcile.
 			)
 			// Update the status on AccountClaim
 			return reconcile.Result{}, r.statusUpdate(reqLogger, accountClaim)
+		}
+
+		// Create secret for OCM to consume
+		if !r.checkIAMSecretExists(accountClaim.Spec.AwsCredentialSecret.Name, accountClaim.Spec.AwsCredentialSecret.Namespace) {
+			err = r.createIAMSecret(reqLogger, accountClaim, byocAccount)
+			if err != nil {
+				return reconcile.Result{}, nil
+			}
 		}
 
 		return reconcile.Result{}, nil


### PR DESCRIPTION
* Creates the osdManagesAdmin secrets as `aws` in the CCS accouncClaim namespaces alongside the `byoc` secrets.
* Replaces references to UHC in accountclaim_controller.go with OCM

REF: https://issues.redhat.com/browse/OSD-3573
