### PR TITLE
Cleans up Legacy Permissions into blocks.

### DIFF
--- a/deploy/crds/aws_v1alpha1_awsfederatedrole_networkmgmt_cr.yaml
+++ b/deploy/crds/aws_v1alpha1_awsfederatedrole_networkmgmt_cr.yaml
@@ -12,58 +12,33 @@ spec:
     description: Description of CustomerAdministratorAccess
     # list of statements for the policy
     awsStatements:
+      ## START LEGACY PERMISSIONS
+      # AWS Transit Gateway
+      - effect: Allow
+        action:
+          - "ec2:CreateTransitGatewayVpcAttachment"
+        resource:
+          - "arn:aws:ec2:*:*:subnet/*"
+          - "arn:aws:ec2:*:*:transit-gateway/*"
+          - "arn:aws:ec2:*:*:vpc/*"
+          - "arn:aws:ec2:*:*:transit-gateway-attachment/*"
+
+      # AWS EC2
       - effect: Allow
         action:
           - "ec2:AcceptVpcPeeringConnection"
-          - "ec2:AttachVpnGateway"
-          - "ec2:CreateCustomerGateway"
-          - "ec2:CreateRoute"
-          - "ec2:CreateTags"
           - "ec2:CreateVPCEndpoint"
-          - "ec2:CreateVpcPeeringConnection"
-          - "ec2:CreateVpnConnection"
           - "ec2:CreateVpnConnectionRoute"
-          - "ec2:CreateVpnGateway"
-          - "ec2:DeleteVpcPeeringConnection"
-          - "ec2:DeleteVpnConnection"
           - "ec2:DeleteVpnConnectionRoute"
-          - "ec2:DeleteVpnGateway"
-          - "ec2:DescribeAvailabilityZones"
-          - "ec2:DescribeRouteTables"
-          - "ec2:DescribeSubnets"
-          - "ec2:DescribeTransitGatewayAttachments"
-          - "ec2:DescribeTransitGatewayVpcAttachments"
-          - "ec2:DescribeTransitGateways"
-          - "ec2:DescribeVPCEndpoints"
-          - "ec2:DescribeVpcPeeringConnections"
-          - "ec2:DescribeVpcs"
-          - "ec2:DescribeVpnConnections"
-          - "ec2:DescribeVpnGateways"
-          - "ec2:CreateVpnConnection"
-          - "ec2:CreateTags"
-          - "ec2:CreateRoute"
-          - "ec2:DescribeRouteTables"
-          - "ec2:DetachVpnGateway"
           - "ec2:ModifyVpcPeeringConnectionOptions"
           - "ec2:RejectVpcPeeringConnection"
-          - "ec2:DisableVgwRoutePropagation"
-          - "ec2:EnableVgwRoutePropagation"
-          - "guardduty:GetDetector"
-          - "guardduty:GetFindings"
-          - "guardduty:GetFindingsStatistics"
-          - "guardduty:GetFreeTrialStatistics"
-          - "guardduty:GetIPSet"
-          - "guardduty:GetInvitationsCount"
-          - "guardduty:GetMasterAccount"
-          - "guardduty:GetMembers"
-          - "guardduty:GetThreatIntelSet"
-          - "guardduty:ListDetectors"
-          - "guardduty:ListFilters"
-          - "guardduty:ListFindings"
-          - "guardduty:ListIPSets"
-          - "guardduty:ListInvitations"
-          - "guardduty:ListMembers"
-          - "guardduty:ListThreatIntelSets"
+        resource:
+          - "*"
+
+      # Resource Access Management
+      # Allows sharing resources between VPCs
+      - effect: Allow
+        action:
           - "ram:AcceptResourceShareInvitation"
           - "ram:DeleteResourceShare"
           - "ram:GetResourcePolicies"
@@ -74,6 +49,12 @@ spec:
           - "ram:ListPrincipals"
           - "ram:ListResources"
           - "ram:RejectResourceShareInvitation"
+        resource:
+          - "*"
+     
+      # DNS Route Propagation
+      - effect: Allow
+        action:
           - "route53resolver:AssociateResolverRule"
           - "route53resolver:DeleteResolverRule"
           - "route53resolver:DisassociateResolverRule"
@@ -81,7 +62,6 @@ spec:
           - "route53resolver:GetResolverRuleAssociation"
           - "route53resolver:ListResolverRuleAssociations"
           - "route53resolver:ListResolverRules"
-          - "directconnect:*"
         resource: 
           - "*"
       - effect: Allow
@@ -92,14 +72,7 @@ spec:
         condition:
           StringEquals:
             ram:RequestedResourceType: route53resolver:ResolverRule
-      - effect: Allow
-        action:
-          - "ec2:CreateTransitGatewayVpcAttachment"
-        resource:
-          - "arn:aws:ec2:*:*:subnet/*"
-          - "arn:aws:ec2:*:*:transit-gateway/*"
-          - "arn:aws:ec2:*:*:vpc/*"
-          - "arn:aws:ec2:*:*:transit-gateway-attachment/*"
+
 
       # START Targeted Statements
       # AWS VPN


### PR DESCRIPTION
Instead of completely removing legacy permissions some made sense to keep, so I added them.

I took the liberty of getting rid of GuardDuty reporting.  That's not applicable to Network Management and if we want to enable customer self-service for that then we should consider adding a separate role they can assume.

I do have questions about others, though:

- [ ] Do we want to let our VPCs accept peering connections?  The documentation says it should go one way, outbound from our cluster.  I guess the small argument is that there might be a rogue peering request that someone might blindly accept, but I could see that argument going either way.
- [ ] During my setup I didn't see anything that needed the `ec2:CreateVpnConnectionRoute` or Delete of the same.  Not sure if this is related to troubleshooting or something that needs to also be enabled, maybe someone smarter than me can comment.
- [x] Can someone confirm that RAM and Route53Resolver are both related to VPC Peering?  RAM seems to be something that allows you to "see" resources in other accounts/VPCs that are sharing, and the Route53 Resolver looks to be like it automatically creates DNS routes between VPCs, so these seem useful to keep.  Just looking for confirmation so I can add it to our permissions document for future reference. - [kbater note: RAM was used for DirectConnect, being able to share a transit gateway]
