### PR TITLE
Change summary metrics to histogram

### DIFF
--- a/pkg/controller/account/account_controller.go
+++ b/pkg/controller/account/account_controller.go
@@ -605,7 +605,9 @@ func SetAccountStatus(reqLogger logr.Logger, awsAccount *awsv1alpha1.Account, me
 		corev1.ConditionTrue,
 		state,
 		message,
-		utils.UpdateConditionNever)
+		utils.UpdateConditionNever,
+		awsAccount.Spec.BYOC,
+	)
 	awsAccount.Status.State = state
 	reqLogger.Info(fmt.Sprintf("Account %s status updated", awsAccount.Name))
 }

--- a/pkg/controller/utils/conditions.go
+++ b/pkg/controller/utils/conditions.go
@@ -114,6 +114,7 @@ func SetAccountCondition(
 	reason string,
 	message string,
 	updateConditionCheck UpdateConditionCheck,
+	ccs bool,
 ) []awsv1alpha1.AccountCondition {
 	now := metav1.Now()
 	existingCondition := FindAccountCondition(conditions, conditionType)
@@ -153,7 +154,7 @@ func SetAccountCondition(
 		creatingCondition := FindAccountCondition(conditions, awsv1alpha1.AccountCreating)
 		if creatingCondition != nil {
 			readyDuration := now.Sub(creatingCondition.LastProbeTime.Time)
-			localmetrics.Collector.SetAccountReadyDuration(readyDuration.Seconds())
+			localmetrics.Collector.SetAccountReadyDuration(ccs, readyDuration.Seconds())
 		}
 	}
 

--- a/pkg/localmetrics/localmetrics.go
+++ b/pkg/localmetrics/localmetrics.go
@@ -42,9 +42,9 @@ type MetricsCollector struct {
 	accountClaims                   *prometheus.GaugeVec
 	accountReuseAvailable           *prometheus.GaugeVec
 	accountPoolSize                 *prometheus.GaugeVec
-	accountReadyDuration            prometheus.Summary
-	accountClaimReadyDuration       *prometheus.SummaryVec
-	accountReuseCleanupDuration     prometheus.Summary
+	accountReadyDuration            prometheus.Histogram
+	accountClaimReadyDuration       *prometheus.HistogramVec
+	accountReuseCleanupDuration     prometheus.Histogram
 	accountReuseCleanupFailureCount prometheus.Counter
 }
 
@@ -85,21 +85,24 @@ func NewMetricsCollector(store cache.Cache) *MetricsCollector {
 			Help:        "Report the size of account pool cr",
 			ConstLabels: prometheus.Labels{"name": operatorName},
 		}, []string{"namespace", "pool_name"}),
-		accountReadyDuration: prometheus.NewSummary(prometheus.SummaryOpts{
+		accountReadyDuration: prometheus.NewHistogram(prometheus.HistogramOpts{
 			Name:        "aws_account_operator_account_ready_duration_seconds",
 			Help:        "The duration for account cr to get ready",
 			ConstLabels: prometheus.Labels{"name": operatorName},
+			Buckets:     []float64{1, 3, 5, 10, 15, 20, 30},
 		}),
-		accountClaimReadyDuration: prometheus.NewSummaryVec(prometheus.SummaryOpts{
+		accountClaimReadyDuration: prometheus.NewHistogramVec(prometheus.HistogramOpts{
 			Name:        "aws_account_operator_account_claim_ready_duration_seconds",
 			Help:        "The duration for account claim cr to get claimed",
 			ConstLabels: prometheus.Labels{"name": operatorName},
+			Buckets:     []float64{1, 3, 5, 10, 15, 20, 30},
 		}, []string{"ccs"}),
 
-		accountReuseCleanupDuration: prometheus.NewSummary(prometheus.SummaryOpts{
+		accountReuseCleanupDuration: prometheus.NewHistogram(prometheus.HistogramOpts{
 			Name:        "aws_account_operator_account_reuse_cleanup_duration_seconds",
 			Help:        "The duration for account reuse cleanup",
 			ConstLabels: prometheus.Labels{"name": operatorName},
+			Buckets:     []float64{1, 3, 5, 10, 15, 20, 30},
 		}),
 
 		accountReuseCleanupFailureCount: prometheus.NewCounter(prometheus.CounterOpts{


### PR DESCRIPTION
Signed-off-by: Ben Ye <yb532204897@gmail.com>

Summary metrics are collected in client side, which means every time the operator restarts (maybe triggered by CD update), the current metrics will be lost. Histogram also has some other advantages.

So this pr updates the metrics type to histogram.