### PR TITLE
Splits test-ccs into create-ccs and delete-ccs targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -212,7 +212,15 @@ delete-ccs-2-accountclaim:
 
 # Test CCS
 .PHONY: test-ccs
-test-ccs: create-ccs-namespace create-ccs-secret create-ccs-accountclaim delete-ccs-accountclaim delete-ccs-secret delete-ccs-namespace
+test-ccs: create-ccs delete-ccs
+
+# Deploy a test CCS account
+.PHONY: create-ccs
+create-ccs: create-ccs-namespace create-ccs-secret create-ccs-accountclaim
+
+# Teardown the test CCS account
+.PHONY: delete-ccs
+delete-ccs: delete-ccs-accountclaim delete-ccs-secret delete-ccs-namespace
 
 # Create S3 bucket
 .PHONY: create-s3-bucket


### PR DESCRIPTION
This breaks the long string of targets in `test-ccs` into `create-ccs` and `delete-ccs` targets.  This will allow us to spin up a CCS cluster by calling the `create-ccs` target directly, for testing things manually when necessary.  `delete-ccs` will handle cleanup.  This also matches the behavior for `test-account`.

The `test-ccs` target still behaves as it did before, with `create-ccs` and `delete-ccs` referencing the same targets that were originally there.

Signed-off-by: Christopher Collins <collins.christopher@gmail.com>
