### PR TITLE
Metrics for API Calls (2 of 2: AWS)

### DIFF
--- a/pkg/controller/account/account_controller.go
+++ b/pkg/controller/account/account_controller.go
@@ -147,7 +147,7 @@ func (r *ReconcileAccount) Reconcile(request reconcile.Request) (reconcile.Resul
 	}
 
 	// We expect this secret to exist in the same namespace Account CR's are created
-	awsSetupClient, err := r.awsClientBuilder.GetClient(r.Client, awsclient.NewAwsClientInput{
+	awsSetupClient, err := r.awsClientBuilder.GetClient(controllerName, r.Client, awsclient.NewAwsClientInput{
 		SecretName: utils.AwsSecretName,
 		NameSpace:  awsv1alpha1.AccountCrNamespace,
 		AwsRegion:  "us-east-1",
@@ -346,7 +346,7 @@ func (r *ReconcileAccount) Reconcile(request reconcile.Request) (reconcile.Resul
 				break
 			}
 		}
-		awsAssumedRoleClient, err := r.awsClientBuilder.GetClient(r.Client, awsclient.NewAwsClientInput{
+		awsAssumedRoleClient, err := r.awsClientBuilder.GetClient(controllerName, r.Client, awsclient.NewAwsClientInput{
 			AwsCredsSecretIDKey:     *creds.Credentials.AccessKeyId,
 			AwsCredsSecretAccessKey: *creds.Credentials.SecretAccessKey,
 			AwsToken:                *creds.Credentials.SessionToken,
@@ -393,7 +393,7 @@ func (r *ReconcileAccount) Reconcile(request reconcile.Request) (reconcile.Resul
 		}
 
 		// Create new awsClient with SRE IAM credentials so we can generate STS and Federation tokens from it
-		SREAWSClient, err := r.awsClientBuilder.GetClient(r.Client, awsclient.NewAwsClientInput{
+		SREAWSClient, err := r.awsClientBuilder.GetClient(controllerName, r.Client, awsclient.NewAwsClientInput{
 			SecretName: *SREIAMUserSecret,
 			NameSpace:  awsv1alpha1.AccountCrNamespace,
 			AwsRegion:  "us-east-1",

--- a/pkg/controller/account/byoc.go
+++ b/pkg/controller/account/byoc.go
@@ -336,7 +336,7 @@ func (r *ReconcileAccount) getBYOCClient(currentAcct *awsv1alpha1.Account) (awsc
 	}
 
 	// Get credentials
-	byocAWSClient, err := r.awsClientBuilder.GetClient(r.Client, awsclient.NewAwsClientInput{
+	byocAWSClient, err := r.awsClientBuilder.GetClient(controllerName, r.Client, awsclient.NewAwsClientInput{
 		SecretName: accountClaim.Spec.BYOCSecretRef.Name,
 		NameSpace:  accountClaim.Spec.BYOCSecretRef.Namespace,
 		AwsRegion:  "us-east-1",

--- a/pkg/controller/account/credentials_rotator.go
+++ b/pkg/controller/account/credentials_rotator.go
@@ -129,7 +129,7 @@ func (r *ReconcileAccount) RotateConsoleCredentials(reqLogger logr.Logger, awsSe
 	SigninTokenDuration := int64(credentialwatcher.STSCredentialsDuration)
 
 	// Create new awsClient with SRE IAM credentials so we can generate STS and Federation tokens from it
-	SREAWSClient, err := r.awsClientBuilder.GetClient(r.Client, awsclient.NewAwsClientInput{
+	SREAWSClient, err := r.awsClientBuilder.GetClient(controllerName, r.Client, awsclient.NewAwsClientInput{
 		SecretName: account.Name + "-" + strings.ToLower(iamUserNameSRE) + "-secret",
 		NameSpace:  awsv1alpha1.AccountCrNamespace,
 		AwsRegion:  "us-east-1",

--- a/pkg/controller/account/ec2.go
+++ b/pkg/controller/account/ec2.go
@@ -51,7 +51,7 @@ func (r *ReconcileAccount) InitializeSupportedRegions(reqLogger logr.Logger, acc
 func (r *ReconcileAccount) InitializeRegion(reqLogger logr.Logger, account *awsv1alpha1.Account, region string, ami string, ec2Notifications chan string, ec2Errors chan string, creds *sts.AssumeRoleOutput) error {
 	reqLogger.Info(fmt.Sprintf("Initializing region: %s", region))
 
-	awsClient, err := r.awsClientBuilder.GetClient(r.Client, awsclient.NewAwsClientInput{
+	awsClient, err := r.awsClientBuilder.GetClient(controllerName, r.Client, awsclient.NewAwsClientInput{
 		AwsCredsSecretIDKey:     *creds.Credentials.AccessKeyId,
 		AwsCredsSecretAccessKey: *creds.Credentials.SecretAccessKey,
 		AwsToken:                *creds.Credentials.SessionToken,

--- a/pkg/controller/accountclaim/organizational_units.go
+++ b/pkg/controller/accountclaim/organizational_units.go
@@ -18,7 +18,7 @@ import (
 // MoveAccountToOU takes care of all the logic surrounding moving an account into an OU
 func MoveAccountToOU(r *ReconcileAccountClaim, reqLogger logr.Logger, accountClaim *awsv1alpha1.AccountClaim, account *awsv1alpha1.Account) error {
 	// aws client
-	awsClient, err := r.awsClientBuilder.GetClient(r.client, awsclient.NewAwsClientInput{
+	awsClient, err := r.awsClientBuilder.GetClient(controllerName, r.client, awsclient.NewAwsClientInput{
 		SecretName: controllerutils.AwsSecretName,
 		NameSpace:  awsv1alpha1.AccountCrNamespace,
 		AwsRegion:  "us-east-1",

--- a/pkg/controller/accountclaim/reuse.go
+++ b/pkg/controller/accountclaim/reuse.go
@@ -58,7 +58,7 @@ func (r *ReconcileAccountClaim) finalizeAccountClaim(reqLogger logr.Logger, acco
 		}
 	}
 
-	awsClient, err := r.awsClientBuilder.GetClient(r.client, awsClientInput)
+	awsClient, err := r.awsClientBuilder.GetClient(controllerName, r.client, awsClientInput)
 
 	if err != nil {
 		connErr := fmt.Sprintf("Unable to create aws client for region %s", clusterAwsRegion)

--- a/pkg/controller/awsfederatedaccountaccess/awsfederatedaccountaccess_controller.go
+++ b/pkg/controller/awsfederatedaccountaccess/awsfederatedaccountaccess_controller.go
@@ -202,7 +202,7 @@ func (r *ReconcileAWSFederatedAccountAccess) Reconcile(request reconcile.Request
 	}
 
 	// Get aws client
-	awsClient, err := r.awsClientBuilder.GetClient(r.client, awsclient.NewAwsClientInput{
+	awsClient, err := r.awsClientBuilder.GetClient(controllerName, r.client, awsclient.NewAwsClientInput{
 		SecretName: currentFAA.Spec.AWSCustomerCredentialSecret.Name,
 		NameSpace:  currentFAA.Spec.AWSCustomerCredentialSecret.Namespace,
 		AwsRegion:  "us-east-1",
@@ -588,7 +588,7 @@ func (r *ReconcileAWSFederatedAccountAccess) cleanFederatedRoles(reqLogger logr.
 	roleName := currentFAA.Spec.AWSFederatedRole.Name + "-" + uidLabel
 
 	// Build AWS client from root secret
-	rootAwsClient, err := r.awsClientBuilder.GetClient(r.client, awsclient.NewAwsClientInput{
+	rootAwsClient, err := r.awsClientBuilder.GetClient(controllerName, r.client, awsclient.NewAwsClientInput{
 		SecretName: "aws-account-operator-credentials",
 		NameSpace:  awsv1alpha1.AccountCrNamespace,
 		AwsRegion:  "us-east-1",
@@ -609,7 +609,7 @@ func (r *ReconcileAWSFederatedAccountAccess) cleanFederatedRoles(reqLogger logr.
 		return err
 	}
 
-	awsClient, err := r.awsClientBuilder.GetClient(r.client, awsclient.NewAwsClientInput{
+	awsClient, err := r.awsClientBuilder.GetClient(controllerName, r.client, awsclient.NewAwsClientInput{
 		AwsCredsSecretIDKey:     *assumeRoleOutput.Credentials.AccessKeyId,
 		AwsCredsSecretAccessKey: *assumeRoleOutput.Credentials.SecretAccessKey,
 		AwsToken:                *assumeRoleOutput.Credentials.SessionToken,

--- a/pkg/controller/awsfederatedrole/awsfederatedrole_controller.go
+++ b/pkg/controller/awsfederatedrole/awsfederatedrole_controller.go
@@ -143,7 +143,7 @@ func (r *ReconcileAWSFederatedRole) Reconcile(request reconcile.Request) (reconc
 		return reconcile.Result{}, nil
 	}
 	// Setup AWS client
-	awsClient, err := r.awsClientBuilder.GetClient(r.client, awsclient.NewAwsClientInput{
+	awsClient, err := r.awsClientBuilder.GetClient(controllerName, r.client, awsclient.NewAwsClientInput{
 		SecretName: awsSecretName,
 		NameSpace:  awsv1alpha1.AccountCrNamespace,
 		AwsRegion:  "us-east-1",

--- a/pkg/localmetrics/localmetrics_test.go
+++ b/pkg/localmetrics/localmetrics_test.go
@@ -10,6 +10,7 @@ import (
 func TestPathParse(t *testing.T) {
 	tests := []struct {
 		name     string
+		host     string
 		path     string
 		expected string
 	}{
@@ -78,10 +79,16 @@ func TestPathParse(t *testing.T) {
 			path:     "",
 			expected: "{OTHER}",
 		},
+		{
+			name:     "an AWS host",
+			host:     "foo.amazonaws.com",
+			path:     "/this/should/be/ignored",
+			expected: "foo.amazonaws.com",
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			result := resourceFrom(&neturl.URL{Path: test.path})
+			result := resourceFrom(&neturl.URL{Path: test.path, Host: test.host})
 			assert.Equal(t, test.expected, result)
 		})
 	}

--- a/pkg/totalaccountwatcher/totalaccountwatcher.go
+++ b/pkg/totalaccountwatcher/totalaccountwatcher.go
@@ -40,7 +40,7 @@ func Initialize(client client.Client, watchInterval time.Duration) {
 	// Builder in their struct and uses it to GetClient() dynamically as needed. This one grabs a
 	// single client one time and stores it in a global.
 	builder := &awsclient.RealBuilder{}
-	AwsClient, err := builder.GetClient(client, awsclient.NewAwsClientInput{
+	AwsClient, err := builder.GetClient("", client, awsclient.NewAwsClientInput{
 		SecretName: controllerutils.AwsSecretName,
 		NameSpace:  awsv1alpha1.AccountCrNamespace,
 		AwsRegion:  "us-east-1",


### PR DESCRIPTION
Instrument AWS API calls to report duration and count metrics in a fashion similar to what #410 did for kubeclient calls.

At this time the `resource` label gets assigned the host, which indicates which AWS service we hit. In the future we may want to drill into the payloads to report the operation more specifically.

Jira: [OSD-4507](https://issues.redhat.com/browse/OSD-4507)