### PR TITLE
Refactors and adds tests for account creation logic

### DIFF
--- a/pkg/controller/account/account_controller.go
+++ b/pkg/controller/account/account_controller.go
@@ -253,12 +253,8 @@ func (r *ReconcileAccount) Reconcile(request reconcile.Request) (reconcile.Resul
 
 			if !accountHasAwsAccountID(currentAcctInstance) {
 				// before doing anything make sure we are not over the limit if we are just error
-				if totalaccountwatcher.TotalAccountWatcher.Total == 0 {
-					reqLogger.Error(awsv1alpha1.ErrAccountWatcherNoTotal, "AccountWatcher has not run successfully yet")
-					return reconcile.Result{}, awsv1alpha1.ErrAccountWatcherNoTotal
-				}
-				if ok, _ := checkAWSAccountsLimitReached(r, reqLogger, totalaccountwatcher.TotalAccountWatcher.Total); ok {
-					reqLogger.Error(awsv1alpha1.ErrAwsAccountLimitExceeded, "AWS Account limit reached", "Account Total", totalaccountwatcher.TotalAccountWatcher.Total)
+				if !totalaccountwatcher.TotalAccountWatcher.AccountsCanBeCreated() {
+					reqLogger.Error(awsv1alpha1.ErrAwsAccountLimitExceeded, "AWS Account limit reached")
 					return reconcile.Result{}, awsv1alpha1.ErrAwsAccountLimitExceeded
 				}
 
@@ -571,28 +567,6 @@ func CreateAccount(reqLogger logr.Logger, client awsclient.Client, accountName, 
 	}
 
 	return accountStatus, nil
-}
-
-func checkAWSAccountsLimitReached(r *ReconcileAccount, reqLogger logr.Logger, currentAccounts int) (bool, error) {
-	instance := &corev1.ConfigMap{}
-	err := r.Client.Get(context.TODO(), types.NamespacedName{Namespace: awsv1alpha1.AccountCrNamespace, Name: awsv1alpha1.DefaultConfigMap}, instance)
-	if err != nil {
-		unexpectedErrorMsg := fmt.Sprintf("%s: Failed to retrieve default ConfigMap, account limit defaulting to 100", awsv1alpha1.ErrMissingDefaultConfigMap)
-		reqLogger.Info(unexpectedErrorMsg)
-	} else {
-		if limit, ok := instance.Data["account-limit"]; ok {
-			if i, err := strconv.Atoi(limit); err == nil {
-				reqLogger.Info(fmt.Sprintf("Number of Current Accounts: %d -- Account Limit: %d", currentAccounts, i))
-				return i <= currentAccounts, nil
-			}
-			unexpectedErrorMsg := fmt.Sprintf("Account: Failed to convert ConfigMap 'account-limit' string field to int, account limit defaulting to 100")
-			reqLogger.Info(unexpectedErrorMsg)
-		} else {
-			unexpectedErrorMsg := fmt.Sprintf("%s: Default ConfigMap missing 'account-limit' field, account limit defaulting to 100", awsv1alpha1.ErrInvalidConfigMap)
-			reqLogger.Info(unexpectedErrorMsg)
-		}
-	}
-	return awsv1alpha1.DefaultConfigMapAccountLimit <= currentAccounts, err
 }
 
 func formatAccountEmail(name string) string {

--- a/pkg/totalaccountwatcher/totalaccountwatcher.go
+++ b/pkg/totalaccountwatcher/totalaccountwatcher.go
@@ -30,10 +30,10 @@ var log = logf.Log.WithName("aws-account-operator")
 
 type totalAccountWatcher struct {
 	watchInterval        time.Duration
-	AwsClient            awsclient.Client
+	awsClient            awsclient.Client
 	client               client.Client
-	Total                int
-	AccountsCanBeCreated bool
+	total                int
+	accountsCanBeCreated bool
 }
 
 // Initialize creates a global instance of the TotalAccountWatcher
@@ -44,7 +44,7 @@ func Initialize(client client.Client, watchInterval time.Duration) {
 	// IBuilder in their struct and uses it to GetClient() dynamically as needed. This one grabs a
 	// single client one time and stores it in a global.
 	builder := &awsclient.Builder{}
-	AwsClient, err := builder.GetClient("", client, awsclient.NewAwsClientInput{
+	awsClient, err := builder.GetClient("", client, awsclient.NewAwsClientInput{
 		SecretName: controllerutils.AwsSecretName,
 		NameSpace:  awsv1alpha1.AccountCrNamespace,
 		AwsRegion:  "us-east-1",
@@ -55,22 +55,22 @@ func Initialize(client client.Client, watchInterval time.Duration) {
 		return
 	}
 
-	TotalAccountWatcher = NewTotalAccountWatcher(client, AwsClient, watchInterval)
+	TotalAccountWatcher = NewTotalAccountWatcher(client, awsClient, watchInterval)
 	TotalAccountWatcher.UpdateTotalAccounts(log)
 }
 
 // NewTotalAccountWatcher returns a new instance of the TotalAccountWatcher interface
 func NewTotalAccountWatcher(
 	client client.Client,
-	AwsClient awsclient.Client,
+	awsClient awsclient.Client,
 	watchInterval time.Duration,
 ) *totalAccountWatcher {
 	return &totalAccountWatcher{
 		watchInterval: watchInterval,
-		AwsClient:     AwsClient,
+		awsClient:     awsClient,
 		client:        client,
 		// Initialize this to be false by default
-		AccountsCanBeCreated: false,
+		accountsCanBeCreated: false,
 	}
 }
 
@@ -95,18 +95,18 @@ func (s *totalAccountWatcher) Start(log logr.Logger, stopCh <-chan struct{}) {
 // UpdateTotalAccounts will update the TotalAccountWatcher's total field
 func (s *totalAccountWatcher) UpdateTotalAccounts(log logr.Logger) error {
 
-	accountTotal, err := TotalAwsAccounts()
+	accountTotal, err := s.getTotalAwsAccounts()
 	if err != nil {
 		log.Error(err, "Failed to get account list with error code")
 		// Stop account creation while we can't talk to AWS
-		TotalAccountWatcher.AccountsCanBeCreated = false
+		s.accountsCanBeCreated = false
 		return err
 	}
 	localmetrics.Collector.SetTotalAWSAccounts(accountTotal)
 
-	if accountTotal != TotalAccountWatcher.Total {
-		log.Info(fmt.Sprintf("Updating total from %d to %d", TotalAccountWatcher.Total, accountTotal))
-		TotalAccountWatcher.Total = accountTotal
+	if accountTotal != s.total {
+		log.Info(fmt.Sprintf("Updating total from %d to %d", s.total, accountTotal))
+		s.total = accountTotal
 	}
 
 	// AccountsCanBeCreated is a bool that returns the opposite of accountLimitReached.
@@ -114,27 +114,27 @@ func (s *totalAccountWatcher) UpdateTotalAccounts(log logr.Logger) error {
 	// account limit has NOT been reached, then account creation can happen.
 	limitReached, err := accountLimitReached(s.client, log, accountTotal)
 	if err != nil {
-		TotalAccountWatcher.AccountsCanBeCreated = false
+		s.accountsCanBeCreated = false
 		return err
 	}
-	TotalAccountWatcher.AccountsCanBeCreated = (!limitReached)
+	s.accountsCanBeCreated = (!limitReached)
 	return nil
 }
 
 // TotalAwsAccounts returns the total number of aws accounts in the aws org
-func TotalAwsAccounts() (int, error) {
+func (s *totalAccountWatcher) getTotalAwsAccounts() (int, error) {
 	var nextToken *string
 
 	accountTotal := 0
 	// Ensure we paginate through the account list
 	for {
-		awsAccountList, err := TotalAccountWatcher.AwsClient.ListAccounts(&organizations.ListAccountsInput{NextToken: nextToken})
+		awsAccountList, err := s.awsClient.ListAccounts(&organizations.ListAccountsInput{NextToken: nextToken})
 		if err != nil {
 			errMsg := "Error getting a list of accounts"
 			if aerr, ok := err.(awserr.Error); ok {
 				errMsg = aerr.Message()
 			}
-			return TotalAccountWatcher.Total, errors.New(errMsg)
+			return s.total, errors.New(errMsg)
 		}
 		accountTotal += len(awsAccountList.Accounts)
 
@@ -146,6 +146,11 @@ func TotalAwsAccounts() (int, error) {
 	}
 
 	return accountTotal, nil
+}
+
+// AccountsCanBeCreated returns whether we can create accounts or not
+func (s *totalAccountWatcher) AccountsCanBeCreated() bool {
+	return s.accountsCanBeCreated
 }
 
 // accountLimitReached returns True if our account limit is reached or False if the account limit is not reached and we can create accounts.

--- a/pkg/totalaccountwatcher/totalaccountwatcher_test.go
+++ b/pkg/totalaccountwatcher/totalaccountwatcher_test.go
@@ -6,11 +6,15 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/aws/aws-sdk-go/service/organizations"
-
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/organizations"
 	"github.com/golang/mock/gomock"
+	awsv1alpha1 "github.com/openshift/aws-account-operator/pkg/apis/aws/v1alpha1"
 	mockAWS "github.com/openshift/aws-account-operator/pkg/awsclient/mock"
+	"github.com/openshift/aws-account-operator/pkg/controller/testutils"
+	"github.com/openshift/aws-account-operator/pkg/localmetrics"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -32,6 +36,24 @@ func setupDefaultMocks(t *testing.T, localObjects []runtime.Object) *mocks {
 
 	mocks.mockAWSClient = mockAWS.NewMockClient(mocks.mockCtrl)
 	return mocks
+}
+
+func TestAccountWatcherCreation(t *testing.T) {
+	t.Run("Tests Account Watcher Creation", func(t *testing.T) {
+		// Arrange
+		mocks := setupDefaultMocks(t, []runtime.Object{})
+
+		// This is necessary for the mocks to report failures like methods not being called an expected number of times.
+		// after mocks is defined
+		defer mocks.mockCtrl.Finish()
+
+		totalAccountWatcher := NewTotalAccountWatcher(mocks.fakeKubeClient, mocks.mockAWSClient, 10)
+		totalAccountWatcher.AwsClient = mocks.mockAWSClient
+
+		if totalAccountWatcher.AccountsCanBeCreated {
+			t.Error("Account Should Not be able to be created by default")
+		}
+	})
 }
 
 func TestTotalAwsAccounts(t *testing.T) {
@@ -131,5 +153,238 @@ func TestTotalAwsAccounts(t *testing.T) {
 				test.validateTotal(t, total)
 			}
 		})
+	}
+}
+
+// This tests our accountLimitReached function
+func TestAccountLimitsReached(t *testing.T) {
+	tests := []struct {
+		name      string
+		limit     string
+		testCount int
+		expected  bool
+	}{
+		{
+			name:      "Test Limit 5 Current 1",
+			limit:     "5",
+			testCount: 1,
+			expected:  false,
+		},
+		{
+			name:      "Test Limit 5 Current 5",
+			limit:     "5",
+			testCount: 5,
+			expected:  true,
+		},
+		{
+			name:      "Test Limit 5 Current 6",
+			limit:     "5",
+			testCount: 6,
+			expected:  true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(
+			test.name,
+			func(t *testing.T) {
+				configMap := &corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      awsv1alpha1.DefaultConfigMap,
+						Namespace: awsv1alpha1.AccountCrNamespace,
+					},
+					Data: map[string]string{
+						"account-limit": test.limit,
+					},
+				}
+				objs := []runtime.Object{configMap}
+				mocks := setupDefaultMocks(t, objs)
+				nullLogger := testutils.NullLogger{}
+
+				result, _ := accountLimitReached(mocks.fakeKubeClient, nullLogger, test.testCount)
+
+				if result != test.expected {
+					t.Error(
+						"Expected", test.expected,
+						"got:", result,
+						"limit:", test.limit,
+						"accountCount:", test.testCount,
+					)
+				}
+			},
+		)
+	}
+}
+
+func TestTotalAccountsUpdate(t *testing.T) {
+	tests := []struct {
+		name         string
+		expected     bool
+		configMap    corev1.ConfigMap
+		expectErr    bool
+		setupAWSMock func(r *mockAWS.MockClientMockRecorder)
+	}{
+		{
+			name:      "Test Cannot get ConfigMap",
+			expected:  false,
+			expectErr: true,
+			configMap: corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "TheWrongConfigMap",
+					Namespace: awsv1alpha1.AccountCrNamespace,
+				},
+			},
+			setupAWSMock: func(r *mockAWS.MockClientMockRecorder) {
+				r.ListAccounts(gomock.Any()).Return(
+					&organizations.ListAccountsOutput{
+						Accounts: []*organizations.Account{
+							{Name: aws.String("test1")},
+						}},
+					nil)
+			},
+		},
+		{
+			name:      "Test fail to convert string to int",
+			expected:  false,
+			expectErr: true,
+			configMap: corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      awsv1alpha1.DefaultConfigMap,
+					Namespace: awsv1alpha1.AccountCrNamespace,
+				},
+				Data: map[string]string{
+					"account-limit": "alskdjf",
+				},
+			},
+			setupAWSMock: func(r *mockAWS.MockClientMockRecorder) {
+				r.ListAccounts(gomock.Any()).Return(
+					&organizations.ListAccountsOutput{
+						Accounts: []*organizations.Account{
+							{Name: aws.String("test1")},
+						}},
+					nil)
+			},
+		},
+		{
+			name:      "Fail to get account-limit key",
+			expected:  false,
+			expectErr: true,
+			configMap: corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      awsv1alpha1.DefaultConfigMap,
+					Namespace: awsv1alpha1.AccountCrNamespace,
+				},
+				Data: map[string]string{
+					"randomKey": "alskdjf",
+				},
+			},
+			setupAWSMock: func(r *mockAWS.MockClientMockRecorder) {
+				r.ListAccounts(gomock.Any()).Return(
+					&organizations.ListAccountsOutput{
+						Accounts: []*organizations.Account{
+							{Name: aws.String("test1")},
+						}},
+					nil)
+			},
+		},
+		{
+			name:      "Fail AWS Error",
+			expected:  false,
+			expectErr: true,
+			configMap: corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      awsv1alpha1.DefaultConfigMap,
+					Namespace: awsv1alpha1.AccountCrNamespace,
+				},
+				Data: map[string]string{
+					"account-limit": "4950",
+				},
+			},
+			setupAWSMock: func(r *mockAWS.MockClientMockRecorder) {
+				r.ListAccounts(gomock.Any()).Return(
+					&organizations.ListAccountsOutput{
+						Accounts: []*organizations.Account{
+							{Name: aws.String("test1")},
+						}},
+					errors.New("FakeError")).Times(1)
+			},
+		},
+		{
+			name:      "Returns lower Limit than Current Accounts",
+			expected:  false,
+			expectErr: false,
+			configMap: corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      awsv1alpha1.DefaultConfigMap,
+					Namespace: awsv1alpha1.AccountCrNamespace,
+				},
+				Data: map[string]string{
+					"account-limit": "1",
+				},
+			},
+			setupAWSMock: func(r *mockAWS.MockClientMockRecorder) {
+				r.ListAccounts(gomock.Any()).Return(
+					&organizations.ListAccountsOutput{
+						Accounts: []*organizations.Account{
+							{Name: aws.String("test1")},
+							{Name: aws.String("test2")},
+						}},
+					nil)
+			},
+		},
+		{
+			name:      "Returns higher Limit than Current Accounts",
+			expected:  true,
+			expectErr: false,
+			configMap: corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      awsv1alpha1.DefaultConfigMap,
+					Namespace: awsv1alpha1.AccountCrNamespace,
+				},
+				Data: map[string]string{
+					"account-limit": "5",
+				},
+			},
+			setupAWSMock: func(r *mockAWS.MockClientMockRecorder) {
+				r.ListAccounts(gomock.Any()).Return(
+					&organizations.ListAccountsOutput{
+						Accounts: []*organizations.Account{
+							{Name: aws.String("test1")},
+						}},
+					nil)
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(
+			test.name,
+			func(t *testing.T) {
+				localmetrics.Collector = localmetrics.NewMetricsCollector(nil)
+
+				objs := []runtime.Object{&test.configMap}
+				mocks := setupDefaultMocks(t, objs)
+				test.setupAWSMock(mocks.mockAWSClient.EXPECT())
+				nullLogger := testutils.NullLogger{}
+				defer mocks.mockCtrl.Finish()
+
+				TotalAccountWatcher = NewTotalAccountWatcher(mocks.fakeKubeClient, mocks.mockAWSClient, 10)
+				TotalAccountWatcher.AwsClient = mocks.mockAWSClient
+				err := TotalAccountWatcher.UpdateTotalAccounts(nullLogger)
+
+				if test.expectErr && err == nil {
+					t.Error(
+						"Expected an error",
+					)
+				}
+
+				if TotalAccountWatcher.AccountsCanBeCreated != test.expected {
+					t.Error(
+						"got:", TotalAccountWatcher.AccountsCanBeCreated,
+						"expected:", test.expected,
+					)
+				}
+			},
+		)
 	}
 }

--- a/pkg/totalaccountwatcher/totalaccountwatcher_test.go
+++ b/pkg/totalaccountwatcher/totalaccountwatcher_test.go
@@ -48,9 +48,9 @@ func TestAccountWatcherCreation(t *testing.T) {
 		defer mocks.mockCtrl.Finish()
 
 		totalAccountWatcher := NewTotalAccountWatcher(mocks.fakeKubeClient, mocks.mockAWSClient, 10)
-		totalAccountWatcher.AwsClient = mocks.mockAWSClient
+		totalAccountWatcher.awsClient = mocks.mockAWSClient
 
-		if totalAccountWatcher.AccountsCanBeCreated {
+		if totalAccountWatcher.AccountsCanBeCreated() {
 			t.Error("Account Should Not be able to be created by default")
 		}
 	})
@@ -136,7 +136,7 @@ func TestTotalAwsAccounts(t *testing.T) {
 
 			// Act
 			TotalAccountWatcher = NewTotalAccountWatcher(mocks.fakeKubeClient, mocks.mockAWSClient, 10)
-			total, err := TotalAwsAccounts()
+			total, err := TotalAccountWatcher.getTotalAwsAccounts()
 
 			// Assert
 			if test.errorExpected {
@@ -369,7 +369,7 @@ func TestTotalAccountsUpdate(t *testing.T) {
 				defer mocks.mockCtrl.Finish()
 
 				TotalAccountWatcher = NewTotalAccountWatcher(mocks.fakeKubeClient, mocks.mockAWSClient, 10)
-				TotalAccountWatcher.AwsClient = mocks.mockAWSClient
+				TotalAccountWatcher.awsClient = mocks.mockAWSClient
 				err := TotalAccountWatcher.UpdateTotalAccounts(nullLogger)
 
 				if test.expectErr && err == nil {
@@ -378,9 +378,9 @@ func TestTotalAccountsUpdate(t *testing.T) {
 					)
 				}
 
-				if TotalAccountWatcher.AccountsCanBeCreated != test.expected {
+				if TotalAccountWatcher.AccountsCanBeCreated() != test.expected {
 					t.Error(
-						"got:", TotalAccountWatcher.AccountsCanBeCreated,
+						"got:", TotalAccountWatcher.AccountsCanBeCreated(),
 						"expected:", test.expected,
 					)
 				}


### PR DESCRIPTION
Refactors the account creation logic to handle the gating of this entirely in the Total Account Watcher instead of in the account controller.