### PR TITLE
Consistent, mockable AWS Clients

### DIFF
--- a/pkg/controller/account/account_controller.go
+++ b/pkg/controller/account/account_controller.go
@@ -74,7 +74,7 @@ func newReconciler(mgr manager.Manager) reconcile.Reconciler {
 	return &ReconcileAccount{
 		Client:           utils.NewClientWithMetricsOrDie(log, mgr, controllerName),
 		scheme:           mgr.GetScheme(),
-		awsClientBuilder: awsclient.GetAWSClient,
+		awsClientBuilder: &awsclient.RealBuilder{},
 	}
 }
 
@@ -101,7 +101,7 @@ var _ reconcile.Reconciler = &ReconcileAccount{}
 type ReconcileAccount struct {
 	Client           kubeclientpkg.Client
 	scheme           *runtime.Scheme
-	awsClientBuilder func(kubeClient kubeclientpkg.Client, input awsclient.NewAwsClientInput) (awsclient.Client, error)
+	awsClientBuilder awsclient.Builder
 }
 
 // Reconcile reads that state of the cluster for a Account object and makes changes based on the state read
@@ -147,7 +147,7 @@ func (r *ReconcileAccount) Reconcile(request reconcile.Request) (reconcile.Resul
 	}
 
 	// We expect this secret to exist in the same namespace Account CR's are created
-	awsSetupClient, err := r.awsClientBuilder(r.Client, awsclient.NewAwsClientInput{
+	awsSetupClient, err := r.awsClientBuilder.GetClient(r.Client, awsclient.NewAwsClientInput{
 		SecretName: utils.AwsSecretName,
 		NameSpace:  awsv1alpha1.AccountCrNamespace,
 		AwsRegion:  "us-east-1",
@@ -343,7 +343,7 @@ func (r *ReconcileAccount) Reconcile(request reconcile.Request) (reconcile.Resul
 				break
 			}
 		}
-		awsAssumedRoleClient, err := r.awsClientBuilder(r.Client, awsclient.NewAwsClientInput{
+		awsAssumedRoleClient, err := r.awsClientBuilder.GetClient(r.Client, awsclient.NewAwsClientInput{
 			AwsCredsSecretIDKey:     *creds.Credentials.AccessKeyId,
 			AwsCredsSecretAccessKey: *creds.Credentials.SecretAccessKey,
 			AwsToken:                *creds.Credentials.SessionToken,
@@ -390,7 +390,7 @@ func (r *ReconcileAccount) Reconcile(request reconcile.Request) (reconcile.Resul
 		}
 
 		// Create new awsClient with SRE IAM credentials so we can generate STS and Federation tokens from it
-		SREAWSClient, err := r.awsClientBuilder(r.Client, awsclient.NewAwsClientInput{
+		SREAWSClient, err := r.awsClientBuilder.GetClient(r.Client, awsclient.NewAwsClientInput{
 			SecretName: *SREIAMUserSecret,
 			NameSpace:  awsv1alpha1.AccountCrNamespace,
 			AwsRegion:  "us-east-1",

--- a/pkg/controller/account/byoc.go
+++ b/pkg/controller/account/byoc.go
@@ -331,7 +331,7 @@ func (r *ReconcileAccount) getBYOCClient(currentAcct *awsv1alpha1.Account) (awsc
 	}
 
 	// Get credentials
-	byocAWSClient, err := awsclient.GetAWSClient(r.Client, awsclient.NewAwsClientInput{
+	byocAWSClient, err := r.awsClientBuilder.GetClient(r.Client, awsclient.NewAwsClientInput{
 		SecretName: accountClaim.Spec.BYOCSecretRef.Name,
 		NameSpace:  accountClaim.Spec.BYOCSecretRef.Namespace,
 		AwsRegion:  "us-east-1",

--- a/pkg/controller/account/credentials_rotator.go
+++ b/pkg/controller/account/credentials_rotator.go
@@ -129,7 +129,7 @@ func (r *ReconcileAccount) RotateConsoleCredentials(reqLogger logr.Logger, awsSe
 	SigninTokenDuration := int64(credentialwatcher.STSCredentialsDuration)
 
 	// Create new awsClient with SRE IAM credentials so we can generate STS and Federation tokens from it
-	SREAWSClient, err := awsclient.GetAWSClient(r.Client, awsclient.NewAwsClientInput{
+	SREAWSClient, err := r.awsClientBuilder.GetClient(r.Client, awsclient.NewAwsClientInput{
 		SecretName: account.Name + "-" + strings.ToLower(iamUserNameSRE) + "-secret",
 		NameSpace:  awsv1alpha1.AccountCrNamespace,
 		AwsRegion:  "us-east-1",

--- a/pkg/controller/account/ec2.go
+++ b/pkg/controller/account/ec2.go
@@ -51,7 +51,7 @@ func (r *ReconcileAccount) InitializeSupportedRegions(reqLogger logr.Logger, acc
 func (r *ReconcileAccount) InitializeRegion(reqLogger logr.Logger, account *awsv1alpha1.Account, region string, ami string, ec2Notifications chan string, ec2Errors chan string, creds *sts.AssumeRoleOutput) error {
 	reqLogger.Info(fmt.Sprintf("Initializing region: %s", region))
 
-	awsClient, err := awsclient.GetAWSClient(r.Client, awsclient.NewAwsClientInput{
+	awsClient, err := r.awsClientBuilder.GetClient(r.Client, awsclient.NewAwsClientInput{
 		AwsCredsSecretIDKey:     *creds.Credentials.AccessKeyId,
 		AwsCredsSecretAccessKey: *creds.Credentials.SecretAccessKey,
 		AwsToken:                *creds.Credentials.SessionToken,

--- a/pkg/controller/accountclaim/accountclaim_controller.go
+++ b/pkg/controller/accountclaim/accountclaim_controller.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/go-logr/logr"
 	awsv1alpha1 "github.com/openshift/aws-account-operator/pkg/apis/aws/v1alpha1"
+	"github.com/openshift/aws-account-operator/pkg/awsclient"
 	"github.com/openshift/aws-account-operator/pkg/controller/account"
 	"github.com/openshift/aws-account-operator/pkg/controller/utils"
 	controllerutils "github.com/openshift/aws-account-operator/pkg/controller/utils"
@@ -53,8 +54,9 @@ func Add(mgr manager.Manager) error {
 // newReconciler returns a new reconcile.Reconciler
 func newReconciler(mgr manager.Manager) reconcile.Reconciler {
 	return &ReconcileAccountClaim{
-		client: utils.NewClientWithMetricsOrDie(log, mgr, controllerName),
-		scheme: mgr.GetScheme(),
+		client:           utils.NewClientWithMetricsOrDie(log, mgr, controllerName),
+		scheme:           mgr.GetScheme(),
+		awsClientBuilder: &awsclient.RealBuilder{},
 	}
 }
 
@@ -89,8 +91,9 @@ var _ reconcile.Reconciler = &ReconcileAccountClaim{}
 type ReconcileAccountClaim struct {
 	// This client, initialized using mgr.Client() above, is a split client
 	// that reads objects from the cache and writes to the apiserver
-	client client.Client
-	scheme *runtime.Scheme
+	client           client.Client
+	scheme           *runtime.Scheme
+	awsClientBuilder awsclient.Builder
 }
 
 // Reconcile reads that state of the cluster for a AccountClaim object and makes changes based on the state read

--- a/pkg/controller/accountclaim/accountclaim_controller_test.go
+++ b/pkg/controller/accountclaim/accountclaim_controller_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/openshift/aws-account-operator/pkg/apis"
 	awsv1alpha1 "github.com/openshift/aws-account-operator/pkg/apis/aws/v1alpha1"
+	"github.com/openshift/aws-account-operator/pkg/awsclient"
 	"github.com/openshift/aws-account-operator/pkg/localmetrics"
 	"github.com/openshift/aws-account-operator/test/fixtures"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -62,7 +63,12 @@ var _ = Describe("AccountClaim", func() {
 
 	Context("Reconcile", func() {
 		It("should reconcile correctly", func() {
-			r = &ReconcileAccountClaim{client: fakeClient, scheme: scheme.Scheme}
+			r = &ReconcileAccountClaim{
+				client: fakeClient,
+				scheme: scheme.Scheme,
+				// TODO(efried): Mock this!
+				awsClientBuilder: &awsclient.RealBuilder{},
+			}
 			req := reconcile.Request{
 				NamespacedName: types.NamespacedName{
 					Name:      name,
@@ -102,7 +108,12 @@ var _ = Describe("AccountClaim", func() {
 				fakeClient,
 				true,
 			}
-			r = &ReconcileAccountClaim{client: cl, scheme: scheme.Scheme}
+			r = &ReconcileAccountClaim{
+				client: cl,
+				scheme: scheme.Scheme,
+				// TODO(efried): Mock this!
+				awsClientBuilder: &awsclient.RealBuilder{},
+			}
 			req := reconcile.Request{
 				NamespacedName: types.NamespacedName{
 					Name:      name,

--- a/pkg/controller/accountclaim/organizational_units.go
+++ b/pkg/controller/accountclaim/organizational_units.go
@@ -18,7 +18,7 @@ import (
 // MoveAccountToOU takes care of all the logic surrounding moving an account into an OU
 func MoveAccountToOU(r *ReconcileAccountClaim, reqLogger logr.Logger, accountClaim *awsv1alpha1.AccountClaim, account *awsv1alpha1.Account) error {
 	// aws client
-	awsClient, err := awsclient.GetAWSClient(r.client, awsclient.NewAwsClientInput{
+	awsClient, err := r.awsClientBuilder.GetClient(r.client, awsclient.NewAwsClientInput{
 		SecretName: controllerutils.AwsSecretName,
 		NameSpace:  awsv1alpha1.AccountCrNamespace,
 		AwsRegion:  "us-east-1",

--- a/pkg/controller/accountclaim/reuse.go
+++ b/pkg/controller/accountclaim/reuse.go
@@ -58,7 +58,7 @@ func (r *ReconcileAccountClaim) finalizeAccountClaim(reqLogger logr.Logger, acco
 		}
 	}
 
-	awsClient, err := awsclient.GetAWSClient(r.client, awsClientInput)
+	awsClient, err := r.awsClientBuilder.GetClient(r.client, awsClientInput)
 
 	if err != nil {
 		connErr := fmt.Sprintf("Unable to create aws client for region %s", clusterAwsRegion)

--- a/pkg/totalaccountwatcher/totalaccountwatcher.go
+++ b/pkg/totalaccountwatcher/totalaccountwatcher.go
@@ -36,7 +36,11 @@ type totalAccountWatcher struct {
 func Initialize(client client.Client, watchInterval time.Duration) {
 	log.Info("Initializing the totalAccountWatcher")
 
-	AwsClient, err := awsclient.GetAWSClient(client, awsclient.NewAwsClientInput{
+	// NOTE(efried): This is a snowflake use of awsclient.Builder. Everyone else puts the
+	// Builder in their struct and uses it to GetClient() dynamically as needed. This one grabs a
+	// single client one time and stores it in a global.
+	builder := &awsclient.RealBuilder{}
+	AwsClient, err := builder.GetClient(client, awsclient.NewAwsClientInput{
 		SecretName: controllerutils.AwsSecretName,
 		NameSpace:  awsv1alpha1.AccountCrNamespace,
 		AwsRegion:  "us-east-1",

--- a/pkg/totalaccountwatcher/totalaccountwatcher_test.go
+++ b/pkg/totalaccountwatcher/totalaccountwatcher_test.go
@@ -114,7 +114,6 @@ func TestTotalAwsAccounts(t *testing.T) {
 
 			// Act
 			TotalAccountWatcher = NewTotalAccountWatcher(mocks.fakeKubeClient, mocks.mockAWSClient, 10)
-			TotalAccountWatcher.AwsClient = mocks.mockAWSClient
 			total, err := TotalAwsAccounts()
 
 			// Assert

--- a/test/integration/federated_access_cr_test.go
+++ b/test/integration/federated_access_cr_test.go
@@ -76,7 +76,7 @@ func TestFederatedAccessRolePermissions(t *testing.T) {
 	awsSecret := awsUserSecret{}
 	getSecretCredentials(t, &awsSecret)
 
-	iamClient, err := getAWSClient(t, awsSecret)
+	iamClient, err := getAWSIAMClient(t, awsSecret)
 	if err != nil {
 		t.Fatal("Unable to get AWS Client", err)
 	}
@@ -191,7 +191,7 @@ func getSecretCredentials(t *testing.T, secret *awsUserSecret) {
 }
 
 // Gets AWS Client using passed in credentials struct
-func getAWSClient(t *testing.T, awsCreds awsUserSecret) (*iam.IAM, error) {
+func getAWSIAMClient(t *testing.T, awsCreds awsUserSecret) (*iam.IAM, error) {
 	accessKeyID, err := base64.StdEncoding.DecodeString(awsCreds.Data.AccessKeyID)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Building on [OSD-2839](https://issues.redhat.com/browse/OSD-2839), this commit refactors AWS Client generating such that it is done the same way by all controllers, and is easily mocked for testing purposes.

With this commit, the `awsclient` package exposes:
- A `Builder` interface with a `GetClient` method whose contract is identical to the (now gone) GetAWSClient func (except it now needs a receiver).
- A `RealBuilder` empty concrete implementation of `Builder`, whose `GetClient` method is exactly the artist formerly known as `GetAWSClient`.
- A `MockBuilder` concrete implementation of `Builder`. This struct has a field for a `gomock.Controller`, and its `GetClient` method returns a singleton instance of the mocked AWS client (from generated code in the `mock` package).
- A `GetMockClient` convenience method to facilitate access to an `EXPECT()`able `MockClient` from tests.
 
Controllers should use this as follows:
- Include a field of type `awsclient.Builder` in their Reconciler impl struct.
- Initialize that field to a pointer to an instance of `awsclient.RealBuilder`.
- Invoke the Reconciler's `Builder`'s `GetClient()` method to grab a new AWS Client.

Tests should do one of two things, depending on their scope:
- When testing `Reconcile` or other methods with a Reconciler receiver, initialize the receiver's `Builder` field to a pointer to an instance of `MockBuilder`. To `EXPECT()` things, get the mocked Client in your test via the `GetMockClient` helper.

- When testing a func that accepts a `Client`, that `Client` can still be created via `mock.NewMockClient()` as before.

This commit makes every effort **not** to change any logic. There are places where clients could potentially be cached/reused, places (such as totalaccountwatcher) that don't follow the above pattern perfectly, etc. Those are left for future work.

Of particular note, accountclaim_controller_test.go was previously making real AWS calls implicitly. **It still is**, but now it's explicit in that the Reconciler it's using is being initialized with a `RealBuilder`. A subsequent commit will mock this properly.

Jira: [OSD-4575](https://issues.redhat.com/browse/OSD-4575)