### PR TITLE
OSD 3978 granular status reports

### DIFF
--- a/pkg/apis/aws/v1alpha1/accountclaim_types.go
+++ b/pkg/apis/aws/v1alpha1/accountclaim_types.go
@@ -58,8 +58,10 @@ type AccountClaimConditionType string
 const (
 	// AccountClaimed is set when an Account is claimed
 	AccountClaimed AccountClaimConditionType = "Claimed"
-	// BYOCAccountClaimFailed is set when a BYOC Account Fails
-	BYOCAccountClaimFailed AccountClaimConditionType = "BYOCAccountClaimFailed"
+	// CCSAccountClaimFailed is set when a CCS Account Fails
+	CCSAccountClaimFailed AccountClaimConditionType = "CCSAccountClaimFailed"
+	// AccountClaimFailed is set when a standard Account Fails
+	AccountClaimFailed AccountClaimConditionType = "AccountClaimFailed"
 	// AccountUnclaimed is set when an Account is not claimed
 	AccountUnclaimed AccountClaimConditionType = "Unclaimed"
 	// BYOCAWSAccountInUse is set when a BYOC AWS Account is in use

--- a/pkg/controller/account/account_controller.go
+++ b/pkg/controller/account/account_controller.go
@@ -18,6 +18,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	k8serr "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	kubeclientpkg "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
@@ -27,6 +28,7 @@ import (
 	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
+	"github.com/openshift/aws-account-operator/pkg/apis/aws/v1alpha1"
 	awsv1alpha1 "github.com/openshift/aws-account-operator/pkg/apis/aws/v1alpha1"
 	"github.com/openshift/aws-account-operator/pkg/awsclient"
 	totalaccountwatcher "github.com/openshift/aws-account-operator/pkg/totalaccountwatcher"
@@ -53,7 +55,8 @@ const (
 	AccountReady = "Ready"
 	// AccountPendingVerification indicates verification (of AWS limits and Enterprise Support) is pending
 	AccountPendingVerification = "PendingVerification"
-	byocRole                   = "BYOCAdminAccess"
+
+	byocRole = "BYOCAdminAccess"
 
 	adminAccessArn = "arn:aws:iam::aws:policy/AdministratorAccess"
 	iamUserNameUHC = "osdManagedAdmin"
@@ -121,6 +124,7 @@ func (r *ReconcileAccount) Reconcile(request reconcile.Request) (reconcile.Resul
 	// Fetch the Account instance
 	currentAcctInstance := &awsv1alpha1.Account{}
 	err := r.Client.Get(context.TODO(), request.NamespacedName, currentAcctInstance)
+
 	if err != nil {
 		if k8serr.IsNotFound(err) {
 			return reconcile.Result{}, nil
@@ -161,6 +165,7 @@ func (r *ReconcileAccount) Reconcile(request reconcile.Request) (reconcile.Resul
 	if newBYOCAccount(currentAcctInstance) {
 		byocRoleID, err = r.initializeNewBYOCAccount(reqLogger, currentAcctInstance, awsSetupClient, adminAccessArn)
 		if err != nil || byocRoleID == "" {
+			r.setStateFailed(reqLogger, currentAcctInstance, err.Error())
 			reqLogger.Error(err, "Failed setting up new BYOC account")
 			return reconcile.Result{}, err
 		}
@@ -182,7 +187,7 @@ func (r *ReconcileAccount) Reconcile(request reconcile.Request) (reconcile.Resul
 
 					// Update supportCaseId in CR
 					currentAcctInstance.Status.SupportCaseID = caseID
-					SetAccountStatus(reqLogger, currentAcctInstance, "Account pending verification in AWS", awsv1alpha1.AccountPendingVerification, AccountPendingVerification)
+					utils.SetAccountStatus(currentAcctInstance, "Account pending verification in AWS", awsv1alpha1.AccountPendingVerification, AccountPendingVerification)
 					err = r.statusUpdate(reqLogger, currentAcctInstance)
 					if err != nil {
 						return reconcile.Result{}, err
@@ -219,7 +224,7 @@ func (r *ReconcileAccount) Reconcile(request reconcile.Request) (reconcile.Resul
 			if resolved {
 				reqLogger.Info(fmt.Sprintf("Case %s resolved", currentAcctInstance.Status.SupportCaseID))
 
-				SetAccountStatus(reqLogger, currentAcctInstance, "Account ready to be claimed", awsv1alpha1.AccountReady, AccountReady)
+				utils.SetAccountStatus(currentAcctInstance, "Account ready to be claimed", awsv1alpha1.AccountReady, AccountReady)
 				err = r.statusUpdate(reqLogger, currentAcctInstance)
 				if err != nil {
 					return reconcile.Result{}, err
@@ -243,7 +248,8 @@ func (r *ReconcileAccount) Reconcile(request reconcile.Request) (reconcile.Resul
 
 		// see if in creating for longer then default wait time
 		if accountCreatingTooLong(currentAcctInstance) {
-			r.setStatusFailed(reqLogger, currentAcctInstance, fmt.Sprintf("Creation pending for longer then %d minutes", utils.WaitTime))
+			errMsg := fmt.Sprintf("Creation pending for longer then %d minutes", utils.WaitTime)
+			r.setStateFailed(reqLogger, currentAcctInstance, errMsg)
 		}
 
 		if accountIsUnclaimedAndHasNoState(currentAcctInstance) {
@@ -264,8 +270,12 @@ func (r *ReconcileAccount) Reconcile(request reconcile.Request) (reconcile.Resul
 				}
 
 				// set state creating if the account was able to create
-				SetAccountStatus(reqLogger, currentAcctInstance, "Attempting to create account", awsv1alpha1.AccountCreating, AccountCreating)
-				err = r.Client.Status().Update(context.TODO(), currentAcctInstance)
+				utils.SetAccountStatus(currentAcctInstance, "Attempting to create account", awsv1alpha1.AccountCreating, AccountCreating)
+				err = r.statusUpdate(reqLogger, currentAcctInstance)
+
+				if err != nil {
+					return reconcile.Result{}, err
+				}
 
 				if utils.DetectDevMode != utils.DevModeProduction {
 					log.Info("Running in development mode, manually creating a case ID number: 11111111")
@@ -286,8 +296,9 @@ func (r *ReconcileAccount) Reconcile(request reconcile.Request) (reconcile.Resul
 			} else {
 
 				// set state creating if the account was already created
-				SetAccountStatus(reqLogger, currentAcctInstance, "AWS account already created", awsv1alpha1.AccountCreating, AccountCreating)
-				err = r.Client.Status().Update(context.TODO(), currentAcctInstance)
+				utils.SetAccountStatus(currentAcctInstance, "AWS account already created", awsv1alpha1.AccountCreating, AccountCreating)
+				err = r.statusUpdate(reqLogger, currentAcctInstance)
+
 				if err != nil {
 					return reconcile.Result{}, err
 				}
@@ -322,10 +333,8 @@ func (r *ReconcileAccount) Reconcile(request reconcile.Request) (reconcile.Resul
 			// Get STS credentials so that we can create an aws client with
 			creds, credsErr = getStsCredentials(reqLogger, awsSetupClient, roleToAssume, currentAcctInstance.Spec.AwsAccountID)
 			if credsErr != nil {
-				stsErrMsg := fmt.Sprintf("Failed to create STS Credentials for account ID %s", currentAcctInstance.Spec.AwsAccountID)
-				reqLogger.Info(stsErrMsg, "Error", credsErr.Error())
-				SetAccountStatus(reqLogger, currentAcctInstance, stsErrMsg, awsv1alpha1.AccountFailed, AccountFailed)
-				r.setStatusFailed(reqLogger, currentAcctInstance, "Failed to get sts credentials")
+				errMsg := fmt.Sprintf("Failed to create STS Credentials for account ID %s: %s", currentAcctInstance.Spec.AwsAccountID, credsErr)
+				r.setStateFailed(reqLogger, currentAcctInstance, errMsg)
 				return reconcile.Result{}, credsErr
 			}
 
@@ -349,13 +358,15 @@ func (r *ReconcileAccount) Reconcile(request reconcile.Request) (reconcile.Resul
 		})
 		if err != nil {
 			reqLogger.Info(err.Error())
-			r.setStatusFailed(reqLogger, currentAcctInstance, "Failed to assume role")
+			errMsg := fmt.Sprintf("Failed to assume role: %s", err)
+			r.setStateFailed(reqLogger, currentAcctInstance, errMsg)
 			return reconcile.Result{}, err
 		}
 
 		secretName, err := r.BuildIAMUser(reqLogger, awsAssumedRoleClient, currentAcctInstance, iamUserUHC, request.Namespace)
 		if err != nil {
-			r.setStatusFailed(reqLogger, currentAcctInstance, fmt.Sprintf("Failed to build IAM UHC user: %s", iamUserUHC))
+			errMsg := fmt.Sprintf("Failed to build IAM UHC user %s: %s", iamUserUHC, err)
+			r.setStateFailed(reqLogger, currentAcctInstance, errMsg)
 			return reconcile.Result{}, err
 		}
 		currentAcctInstance.Spec.IAMUserSecret = *secretName
@@ -367,30 +378,34 @@ func (r *ReconcileAccount) Reconcile(request reconcile.Request) (reconcile.Resul
 		// Create SRE IAM user, we don't care about the credentials because they're saved inside of the build func
 		_, err = r.BuildIAMUser(reqLogger, awsAssumedRoleClient, currentAcctInstance, iamUserSRE, request.Namespace)
 		if err != nil {
-			r.setStatusFailed(reqLogger, currentAcctInstance, fmt.Sprintf("Failed to build IAM SRE user: %s", iamUserSRE))
+			errMsg := fmt.Sprintf("Failed to build IAM SRE user %s: %s", iamUserSRE, err)
+			r.setStateFailed(reqLogger, currentAcctInstance, errMsg)
 			return reconcile.Result{}, err
 		}
 
 		// Initialize all supported regions by creating and terminating an instance in each
 		err = r.InitializeSupportedRegions(reqLogger, currentAcctInstance, awsv1alpha1.CoveredRegions, creds)
 		if err != nil {
-			r.setStatusFailed(reqLogger, currentAcctInstance, "Failed to build and destroy ec2 instances")
+			errMsg := fmt.Sprintf("Unable to build or destroy ec2 instances: %s", err)
+			r.setStateFailed(reqLogger, currentAcctInstance, errMsg)
 			return reconcile.Result{}, err
 		}
 
 		if accountIsBYOC(currentAcctInstance) {
-			SetAccountStatus(reqLogger, currentAcctInstance, "BYOC Account Ready", awsv1alpha1.AccountReady, AccountReady)
+			utils.SetAccountStatus(currentAcctInstance, "BYOC Account Ready", awsv1alpha1.AccountReady, AccountReady)
 
 		} else {
 			if utils.FindAccountCondition(currentAcctInstance.Status.Conditions, awsv1alpha1.AccountReady) != nil {
-				SetAccountStatus(reqLogger, currentAcctInstance, "Account support case already resolved, Account Ready", awsv1alpha1.AccountReady, "Ready")
-				reqLogger.Info("Account support case already resolved, Account Ready")
+				msg := "Account support case already resolved; Account Ready"
+				utils.SetAccountStatus(currentAcctInstance, msg, awsv1alpha1.AccountReady, AccountReady)
+				reqLogger.Info(msg)
 			} else {
-				SetAccountStatus(reqLogger, currentAcctInstance, "Account pending AWS limits verification", awsv1alpha1.AccountPendingVerification, AccountPendingVerification)
-				reqLogger.Info("Account pending AWS limits verification")
+				msg := "Account pending AWS limits verification"
+				utils.SetAccountStatus(currentAcctInstance, msg, awsv1alpha1.AccountPendingVerification, AccountPendingVerification)
+				reqLogger.Info(msg)
 			}
 		}
-		err = r.Client.Status().Update(context.TODO(), currentAcctInstance)
+		err = r.statusUpdate(reqLogger, currentAcctInstance)
 		if err != nil {
 			return reconcile.Result{}, err
 		}
@@ -409,8 +424,8 @@ func (r *ReconcileAccount) BuildAccount(reqLogger logr.Logger, awsClient awsclie
 	if orgErr != nil {
 		switch orgErr {
 		case awsv1alpha1.ErrAwsFailedCreateAccount:
-			SetAccountStatus(reqLogger, account, "Failed to create AWS Account", awsv1alpha1.AccountFailed, AccountFailed)
-			err := r.Client.Status().Update(context.TODO(), account)
+			utils.SetAccountStatus(account, "Failed to create AWS Account", awsv1alpha1.AccountFailed, AccountFailed)
+			err := r.statusUpdate(reqLogger, account)
 			if err != nil {
 				return "", err
 			}
@@ -439,17 +454,6 @@ func (r *ReconcileAccount) BuildAccount(reqLogger logr.Logger, awsClient awsclie
 	reqLogger.Info("Account Created")
 
 	return *orgOutput.CreateAccountStatus.AccountId, nil
-}
-
-func (r *ReconcileAccount) setStatusFailed(reqLogger logr.Logger, awsAccount *awsv1alpha1.Account, message string) error {
-	reqLogger.Info(message)
-	awsAccount.Status.State = AccountFailed
-	err := r.Client.Status().Update(context.TODO(), awsAccount)
-	if err != nil {
-		reqLogger.Error(err, fmt.Sprintf("Account %s status failed to update", awsAccount.Name))
-		return err
-	}
-	return nil
 }
 
 // CreateAccount creates an AWS account for the specified accountName and accountEmail in the organization
@@ -529,27 +533,85 @@ func formatAccountEmail(name string) string {
 	return email
 }
 
-// SetAccountStatus sets the status of an account
-func SetAccountStatus(reqLogger logr.Logger, awsAccount *awsv1alpha1.Account, message string, ctype awsv1alpha1.AccountConditionType, state string) {
-	awsAccount.Status.Conditions = utils.SetAccountCondition(
-		awsAccount.Status.Conditions,
-		ctype,
-		corev1.ConditionTrue,
-		state,
-		message,
-		utils.UpdateConditionNever,
-		awsAccount.Spec.BYOC,
-	)
-	awsAccount.Status.State = state
-	reqLogger.Info(fmt.Sprintf("Account %s status updated", awsAccount.Name))
-}
-
 func (r *ReconcileAccount) statusUpdate(reqLogger logr.Logger, account *awsv1alpha1.Account) error {
 	err := r.Client.Status().Update(context.TODO(), account)
 	if err != nil {
 		reqLogger.Error(err, fmt.Sprintf("Status update for %s failed", account.Name))
 	}
 	reqLogger.Info(fmt.Sprintf("Status updated for %s", account.Name))
+	return err
+}
+
+func (r *ReconcileAccount) setStateFailed(reqLogger logr.Logger, currentAcctInstance *awsv1alpha1.Account, msg string) error {
+	reqLogger.Info(msg)
+	// Upodate the account status (state and condition) to Failed
+	utils.SetAccountStatus(currentAcctInstance, msg, v1alpha1.AccountFailed, AccountFailed)
+
+	var err error
+
+	// Set a failure condition in the accountClaim
+	err = r.setAccountClaimError(reqLogger, currentAcctInstance, msg)
+	if err != nil {
+		return err
+	}
+
+	// Apply the update
+	err = r.statusUpdate(reqLogger, currentAcctInstance)
+	return err
+}
+
+func (r *ReconcileAccount) getAccountClaim(account *awsv1alpha1.Account) (*awsv1alpha1.AccountClaim, error) {
+	accountClaim := &awsv1alpha1.AccountClaim{}
+	err := r.Client.Get(context.TODO(), types.NamespacedName{
+		Name: account.Spec.ClaimLink, Namespace: account.Spec.ClaimLinkNamespace}, accountClaim)
+	if err != nil {
+		return nil, err
+	}
+	return accountClaim, nil
+}
+
+func (r *ReconcileAccount) setAccountClaimError(reqLogger logr.Logger, currentAccountInstance *awsv1alpha1.Account, message string) error {
+	accountClaim, err := r.getAccountClaim(currentAccountInstance)
+	if err != nil {
+		if k8serr.IsNotFound(err) {
+			// If the accountClaim is not found, no need to update the accountClaim
+			return nil
+		}
+		reqLogger.Error(err, fmt.Sprintf("Unable to get accountClaim for %s", currentAccountInstance.Name))
+		return err
+	}
+
+	var reason string
+	var conditionType awsv1alpha1.AccountClaimConditionType
+
+	if accountIsBYOC(currentAccountInstance) {
+		message = fmt.Sprintf("CCS Account Failed: %s", message)
+		conditionType = awsv1alpha1.CCSAccountClaimFailed
+		reason = string(awsv1alpha1.CCSAccountClaimFailed)
+	} else {
+		message = fmt.Sprintf("Account Failed: %s", message)
+		conditionType = awsv1alpha1.AccountClaimFailed
+		reason = string(awsv1alpha1.AccountClaimFailed)
+	}
+
+	accountClaim.Status.Conditions = utils.SetAccountClaimCondition(
+		accountClaim.Status.Conditions,
+		conditionType,
+		corev1.ConditionTrue,
+		reason,
+		message,
+		utils.UpdateConditionIfReasonOrMessageChange,
+		accountClaim.Spec.BYOCAWSAccountID != "",
+	)
+
+	accountClaim.Status.State = awsv1alpha1.ClaimStatusError
+
+	// Update the *accountClaim* status (not the account status)
+	err = r.Client.Status().Update(context.TODO(), accountClaim)
+	if err != nil {
+		reqLogger.Error(err, fmt.Sprintf("Status update for %s failed", accountClaim.Name))
+	}
+
 	return err
 }
 

--- a/pkg/controller/account/iam.go
+++ b/pkg/controller/account/iam.go
@@ -60,7 +60,7 @@ func (r *ReconcileAccount) CreateSecret(reqLogger logr.Logger, account *awsv1alp
 	createErr := r.Client.Create(context.TODO(), secret)
 	if createErr != nil {
 		failedToCreateUserSecretMsg := fmt.Sprintf("Failed to create secret %s", secret.Name)
-		SetAccountStatus(reqLogger, account, failedToCreateUserSecretMsg, awsv1alpha1.AccountFailed, "Failed")
+		utils.SetAccountStatus(account, failedToCreateUserSecretMsg, awsv1alpha1.AccountFailed, "Failed")
 		err := r.Client.Status().Update(context.TODO(), account)
 		if err != nil {
 			return err
@@ -369,7 +369,7 @@ func (r *ReconcileAccount) RotateIAMAccessKeys(reqLogger logr.Logger, awsClient 
 		reqLogger.Error(err, errMsg)
 		// TODO: We should move this status update to the main reconcile where BuildIAMUser is called
 		// This would mean we can remove reqLogger and the awsv1alpha1 account reference to keep things cleaner
-		SetAccountStatus(reqLogger, account, errMsg, awsv1alpha1.AccountFailed, AccountFailed)
+		utils.SetAccountStatus(account, errMsg, awsv1alpha1.AccountFailed, AccountFailed)
 		err := r.Client.Status().Update(context.TODO(), account)
 		if err != nil {
 			return nil, err

--- a/pkg/controller/accountclaim/accountclaim_controller.go
+++ b/pkg/controller/accountclaim/accountclaim_controller.go
@@ -32,8 +32,7 @@ const (
 	AccountClaimed = "AccountClaimed"
 	// AccountUnclaimed indicates the account has not been claimed in the accountClaim status
 	AccountUnclaimed = "AccountUnclaimed"
-	// BYOCAccountFailedClaim indicates a failure to claim a CCS/BYOC account in the accountClaim status
-	BYOCAccountFailedClaim  = "BYOCAccountFailed"
+
 	awsCredsUserName        = "aws_user_name"
 	awsCredsAccessKeyID     = "aws_access_key_id"
 	awsCredsSecretAccessKey = "aws_secret_access_key"
@@ -179,7 +178,7 @@ func (r *ReconcileAccountClaim) Reconcile(request reconcile.Request) (reconcile.
 	}
 
 	if accountClaim.Spec.BYOC {
-		reqLogger.Info("Reconciling BYOC AccountClaim")
+		reqLogger.Info("Reconciling CCS AccountClaim")
 
 		// Ensure BYOC secret has finalizer
 		reqLogger.Info("Ensuring byoc secret has finalizer")
@@ -222,12 +221,12 @@ func (r *ReconcileAccountClaim) Reconcile(request reconcile.Request) (reconcile.
 		if byocAccount.Status.State != string(awsv1alpha1.AccountReady) {
 			if byocAccount.Status.State == string(awsv1alpha1.AccountFailed) {
 				accountClaim.Status.State = awsv1alpha1.ClaimStatusError
-				message := "BYOC account failed"
+				message := "CCS Account Failed"
 				accountClaim.Status.Conditions = controllerutils.SetAccountClaimCondition(
 					accountClaim.Status.Conditions,
-					awsv1alpha1.BYOCAccountClaimFailed,
+					awsv1alpha1.CCSAccountClaimFailed,
 					corev1.ConditionTrue,
-					BYOCAccountFailedClaim,
+					string(awsv1alpha1.CCSAccountClaimFailed),
 					message,
 					controllerutils.UpdateConditionNever,
 					accountClaim.Spec.BYOCAWSAccountID != "",

--- a/pkg/controller/accountclaim/reuse.go
+++ b/pkg/controller/accountclaim/reuse.go
@@ -15,7 +15,6 @@ import (
 	"github.com/go-logr/logr"
 	awsv1alpha1 "github.com/openshift/aws-account-operator/pkg/apis/aws/v1alpha1"
 	"github.com/openshift/aws-account-operator/pkg/awsclient"
-	"github.com/openshift/aws-account-operator/pkg/controller/account"
 	"github.com/openshift/aws-account-operator/pkg/controller/utils"
 	"github.com/openshift/aws-account-operator/pkg/localmetrics"
 )
@@ -155,7 +154,7 @@ func (r *ReconcileAccountClaim) resetAccountSpecStatus(reqLogger logr.Logger, re
 	reusedAccount.Status.Claimed = false
 	reusedAccount.Status.Reused = true
 	conditionMsg := fmt.Sprintf("Account Reuse - %s", conditionStatus)
-	account.SetAccountStatus(reqLogger, reusedAccount, conditionMsg, accountState, conditionStatus)
+	utils.SetAccountStatus(reusedAccount, conditionMsg, accountState, conditionStatus)
 	err = r.accountStatusUpdate(reqLogger, reusedAccount)
 	if err != nil {
 		reqLogger.Error(err, "Failed to update account status for reuse")

--- a/pkg/controller/utils/status.go
+++ b/pkg/controller/utils/status.go
@@ -1,0 +1,20 @@
+package utils
+
+import (
+	awsv1alpha1 "github.com/openshift/aws-account-operator/pkg/apis/aws/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+)
+
+// SetAccountStatus sets the condition and state of an account
+func SetAccountStatus(awsAccount *awsv1alpha1.Account, message string, ctype awsv1alpha1.AccountConditionType, state string) {
+	awsAccount.Status.Conditions = SetAccountCondition(
+		awsAccount.Status.Conditions,
+		ctype,
+		corev1.ConditionTrue,
+		state,
+		message,
+		UpdateConditionNever,
+		awsAccount.Spec.BYOC,
+	)
+	awsAccount.Status.State = state
+}


### PR DESCRIPTION
This includes a number of changes to facilitate surfacing of underlying account failure messages to OCM for CCS accounts, as well as more details error messages for standard accounts upon failure.  It also renames some "BYOC" items to "CCS", and consolidates some code used between both standard and ccs accounts into one place.

This incorporates the bugfixes from #424, and must be merged after.

The complete changelog:

- Adds function to report failed accounts to account claim, retrieve account claim to the account controller
- Removes byoc-specific function for the above, so both types share the same code
- Renamed "SetAccountStatus" to "SetAccountCondition" to match actual workings; renamed "BYOCAccountFailedClaim" to "CCSAccountFailedClaim"
- Renames "setStatusFailed" to "setStateFailed"
- expand use of "statusUpdate" not previously utilized widely in account controller
- creates utils/status.go and moves "SetAccountStatus" to it
- Changes BYOC to CCS in "accountClaimBYOCError" message
- Utilize new constant ClaimedAccountFailed for BYOC account fail message; replace existing "AccountFailed" string with constant
- adds new conditions for accountClaims whose underlying account has failed
- handles missing accountClaims (for standard accounts) and doesn't try to update the accountClaim condition for them

Fixes (or improves toward) https://issues.redhat.com/browse/OSD-3978 "report more granular status for OCM"