### PR TITLE
OSD-3978 Refactor error handling & logging, reconcile logic for CCS account initialization for flexible re-queuing (pt 2)

### DIFF
--- a/pkg/controller/account/account_finalizer.go
+++ b/pkg/controller/account/account_finalizer.go
@@ -3,20 +3,15 @@ package account
 import (
 	"context"
 
-	"github.com/go-logr/logr"
 	awsv1alpha1 "github.com/openshift/aws-account-operator/pkg/apis/aws/v1alpha1"
 	"github.com/openshift/aws-account-operator/pkg/controller/utils"
 )
 
 // Function to remove finalizer
-func (r *ReconcileAccount) removeFinalizer(reqLogger logr.Logger, account *awsv1alpha1.Account, finalizerName string) error {
-	reqLogger.Info("Removing Finalizer from the Account")
+func (r *ReconcileAccount) removeFinalizer(account *awsv1alpha1.Account, finalizerName string) error {
 	account.SetFinalizers(utils.Remove(account.GetFinalizers(), finalizerName))
-
-	// Update CR
 	err := r.Client.Update(context.TODO(), account)
 	if err != nil {
-		reqLogger.Error(err, "Failed to remove AccountClaim finalizer")
 		return err
 	}
 	return nil


### PR DESCRIPTION
Uses individual error variables (for clarity) and catches and returns them, to create framework for more specific error handling.  This will allow for better surfacing of errors to OCM.

Moves reconcile.Result logic for CCS into initializeNewCCSAccount, to allow flexibility in how or when the account is re-queued based on the types of errors it encounters.  This sets the stage for handling specific errors, and treating them as necessary (ie, mark account failed and do not re-queue, retry, or retry after X period of time).

Part 2 of OSD-3978 "granular status reports"

Depends on #425 