### PR TITLE
Make sure byoc secret finalizer is gone then return

### DIFF
--- a/pkg/controller/accountclaim/reuse.go
+++ b/pkg/controller/accountclaim/reuse.go
@@ -37,6 +37,15 @@ func (r *ReconcileAccountClaim) finalizeAccountClaim(reqLogger logr.Logger, acco
 		if !accountClaim.Spec.BYOC {
 			reqLogger.Error(err, "Failed to get claimed account")
 			return err
+		} else {
+			// Cleanup BYOC secret
+			err = r.removeBYOCSecretFinalizer(accountClaim)
+			if err != nil {
+				reqLogger.Error(err, "Failed to remove BYOC secret finalizer")
+				return err
+			}
+
+			return nil
 		}
 
 	}


### PR DESCRIPTION
Turns out if the Account doesn't exist, there's a nil pointer. Who knew?

This PR makes sure the BYOC secret finalizer logic is removed if the AccountClaim finalizer hotloop situation is hit. 