### PR TITLE
Update account state to reflect generic AWS support case pending

### DIFF
--- a/pkg/controller/account/account_controller_test.go
+++ b/pkg/controller/account/account_controller_test.go
@@ -270,20 +270,20 @@ func TestAccountHasSupportCaseID(t *testing.T) {
 	}
 }
 
-// Test accountIsPendingVerification
-func TestAccountIsPendingVerification(t *testing.T) {
+// Test accountIsSupportCasePending
+func TestAccountIsSupportCasePending(t *testing.T) {
 	tests := []struct {
 		name     string
 		expected bool
 		acct     *testAccountBuilder
 	}{
 		{
-			name:     "Account is pending verification",
-			acct:     newTestAccountBuilder().WithState(awsv1alpha1.AccountPendingVerification),
+			name:     "Account is pending AWS support case resolution",
+			acct:     newTestAccountBuilder().WithState(awsv1alpha1.AccountSupportCasePending),
 			expected: true,
 		},
 		{
-			name:     "Account is not pending verificatio",
+			name:     "Account is not pending support case resolution",
 			acct:     newTestAccountBuilder(),
 			expected: false,
 		},
@@ -292,7 +292,7 @@ func TestAccountIsPendingVerification(t *testing.T) {
 		t.Run(
 			test.name,
 			func(t *testing.T) {
-				result := accountIsPendingVerification(&test.acct.acct)
+				result := accountIsSupportCasePending(&test.acct.acct)
 				if result != test.expected {
 					t.Error(
 						"for account:", test.acct,

--- a/pkg/controller/account/cases.go
+++ b/pkg/controller/account/cases.go
@@ -68,7 +68,7 @@ Thanks.
 				returnErr = v1alpha1.ErrAwsFailedCreateSupportCase
 			}
 
-			controllerutils.LogAwsError(reqLogger, "New AWS Error while creating case", returnErr, caseErr)
+			controllerutils.LogAwsError(reqLogger, "New AWS Error while creating AWS support case", returnErr, caseErr)
 		}
 		return "", returnErr
 	}


### PR DESCRIPTION
This PR updates the account CR state when waiting for AWS support cases to be resolved to be more generic. We no longer request quota increases and only enable enterprise support, this message suits the enterprise support status and any other future tickets we might add.