### PR TITLE
API call metrics: Defend against `nil` Response

### DIFF
--- a/pkg/localmetrics/localmetrics.go
+++ b/pkg/localmetrics/localmetrics.go
@@ -293,11 +293,17 @@ func (c *MetricsCollector) SetReconcileDuration(controller string, duration floa
 // - param resp: The HTTP Response structure
 // - param duration: The number of seconds the call took.
 func (c *MetricsCollector) AddAPICall(controller string, req *http.Request, resp *http.Response, duration float64) {
+	var status string
+	if resp == nil {
+		status = "{ERROR}"
+	} else {
+		status = resp.Status
+	}
 	c.apiCallDuration.With(prometheus.Labels{
 		"controller": controller,
 		"method":     req.Method,
 		"resource":   resourceFrom(req.URL),
-		"status":     resp.Status,
+		"status":     status,
 	}).Observe(duration)
 }
 


### PR DESCRIPTION
In the kube API call path, we're only reporting metrics if the request "succeeds", meaning that it returns a real Response (even if that Response is 4xx/5xx). But in the AWS call path, we may still encounter a request failure such that the Response is `nil`. This was panicking the metrics reporting where we fill in the `status` label with the response's HTTP status.

With this commit, we defend against that by checking for a `nil` response and registering `{ERROR}` in the `status` label.