### PR TITLE
Factor out Reconciler metrics

### DIFF
--- a/pkg/controller/account/account_controller.go
+++ b/pkg/controller/account/account_controller.go
@@ -14,7 +14,6 @@ import (
 	"github.com/aws/aws-sdk-go/service/sts"
 	"github.com/go-logr/logr"
 	"github.com/openshift/aws-account-operator/pkg/controller/utils"
-	"github.com/openshift/aws-account-operator/pkg/localmetrics"
 	corev1 "k8s.io/api/core/v1"
 	k8serr "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -70,11 +69,12 @@ func Add(mgr manager.Manager) error {
 
 // newReconciler returns a new reconcile.Reconciler
 func newReconciler(mgr manager.Manager) reconcile.Reconciler {
-	return &ReconcileAccount{
+	reconciler := &ReconcileAccount{
 		Client:           utils.NewClientWithMetricsOrDie(log, mgr, controllerName),
 		scheme:           mgr.GetScheme(),
 		awsClientBuilder: &awsclient.Builder{},
 	}
+	return utils.NewReconcilerWithMetrics(reconciler, controllerName)
 }
 
 // add adds a new Controller to mgr with r as the reconcile.Reconciler
@@ -108,15 +108,7 @@ type ReconcileAccount struct {
 // The Controller will requeue the Request to be processed again if the returned error is non-nil or
 // Result.Requeue is true, otherwise upon completion it will remove the work from the queue.
 func (r *ReconcileAccount) Reconcile(request reconcile.Request) (reconcile.Result, error) {
-	start := time.Now()
 	reqLogger := log.WithValues("Controller", controllerName, "Request.Namespace", request.Namespace, "Request.Name", request.Name)
-	reqLogger.Info("Reconciling")
-
-	defer func() {
-		dur := time.Since(start)
-		localmetrics.Collector.SetReconcileDuration(controllerName, dur.Seconds())
-		reqLogger.WithValues("Duration", dur).Info("Reconcile complete")
-	}()
 
 	// Fetch the Account instance
 	currentAcctInstance := &awsv1alpha1.Account{}

--- a/pkg/controller/accountclaim/accountclaim_controller.go
+++ b/pkg/controller/accountclaim/accountclaim_controller.go
@@ -12,7 +12,6 @@ import (
 	"github.com/openshift/aws-account-operator/pkg/controller/account"
 	"github.com/openshift/aws-account-operator/pkg/controller/utils"
 	controllerutils "github.com/openshift/aws-account-operator/pkg/controller/utils"
-	"github.com/openshift/aws-account-operator/pkg/localmetrics"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -53,11 +52,12 @@ func Add(mgr manager.Manager) error {
 
 // newReconciler returns a new reconcile.Reconciler
 func newReconciler(mgr manager.Manager) reconcile.Reconciler {
-	return &ReconcileAccountClaim{
+	reconciler := &ReconcileAccountClaim{
 		client:           utils.NewClientWithMetricsOrDie(log, mgr, controllerName),
 		scheme:           mgr.GetScheme(),
 		awsClientBuilder: &awsclient.Builder{},
 	}
+	return utils.NewReconcilerWithMetrics(reconciler, controllerName)
 }
 
 // add adds a new Controller to mgr with r as the reconcile.Reconciler
@@ -101,15 +101,7 @@ type ReconcileAccountClaim struct {
 // The Controller will requeue the Request to be processed again if the returned error is non-nil or
 // Result.Requeue is true, otherwise upon completion it will remove the work from the queue.
 func (r *ReconcileAccountClaim) Reconcile(request reconcile.Request) (reconcile.Result, error) {
-	start := time.Now()
 	reqLogger := log.WithValues("Controller", controllerName, "Request.Namespace", request.Namespace, "Request.Name", request.Name)
-	reqLogger.Info("Reconciling")
-
-	defer func() {
-		dur := time.Since(start)
-		localmetrics.Collector.SetReconcileDuration(controllerName, dur.Seconds())
-		reqLogger.WithValues("Duration", dur).Info("Reconcile complete")
-	}()
 
 	// Watch AccountClaim
 	accountClaim := &awsv1alpha1.AccountClaim{}

--- a/pkg/controller/awsfederatedrole/awsfederatedrole_controller.go
+++ b/pkg/controller/awsfederatedrole/awsfederatedrole_controller.go
@@ -4,14 +4,12 @@ import (
 	"context"
 	goerr "errors"
 	"fmt"
-	"time"
 
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/iam"
 
 	awsv1alpha1 "github.com/openshift/aws-account-operator/pkg/apis/aws/v1alpha1"
 	"github.com/openshift/aws-account-operator/pkg/controller/utils"
-	"github.com/openshift/aws-account-operator/pkg/localmetrics"
 
 	"github.com/openshift/aws-account-operator/pkg/awsclient"
 
@@ -45,11 +43,12 @@ func Add(mgr manager.Manager) error {
 
 // newReconciler returns a new reconcile.Reconciler
 func newReconciler(mgr manager.Manager) reconcile.Reconciler {
-	return &ReconcileAWSFederatedRole{
+	reconciler := &ReconcileAWSFederatedRole{
 		client:           utils.NewClientWithMetricsOrDie(log, mgr, controllerName),
 		scheme:           mgr.GetScheme(),
 		awsClientBuilder: &awsclient.Builder{},
 	}
+	return utils.NewReconcilerWithMetrics(reconciler, controllerName)
 }
 
 // add adds a new Controller to mgr with r as the reconcile.Reconciler
@@ -86,15 +85,7 @@ type ReconcileAWSFederatedRole struct {
 // The Controller will requeue the Request to be processed again if the returned error is non-nil or
 // Result.Requeue is true, otherwise upon completion it will remove the work from the queue.
 func (r *ReconcileAWSFederatedRole) Reconcile(request reconcile.Request) (reconcile.Result, error) {
-	start := time.Now()
 	reqLogger := log.WithValues("Controller", controllerName, "Request.Namespace", request.Namespace, "Request.Name", request.Name)
-	reqLogger.Info("Reconciling")
-
-	defer func() {
-		dur := time.Since(start)
-		localmetrics.Collector.SetReconcileDuration(controllerName, dur.Seconds())
-		reqLogger.WithValues("Duration", dur).Info("Reconcile complete")
-	}()
 
 	// Fetch the AWSFederatedRole instance
 	instance := &awsv1alpha1.AWSFederatedRole{}

--- a/pkg/controller/utils/reconcilermetrics.go
+++ b/pkg/controller/utils/reconcilermetrics.go
@@ -1,0 +1,40 @@
+package utils
+
+import (
+	"time"
+
+	"github.com/go-logr/logr"
+	"github.com/openshift/aws-account-operator/pkg/localmetrics"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
+)
+
+// NewReconcilerWithMetrics wraps an existing Reconciler such that calls to Reconcile report the
+// reconcileDuration metric.
+func NewReconcilerWithMetrics(wrapped reconcile.Reconciler, controllerName string) reconcile.Reconciler {
+	return &reconcilerWithMetrics{
+		wrappedReconciler: wrapped,
+		controllerName:    controllerName,
+		logger:            logf.Log.WithName("controller_"+controllerName).WithValues("Controller", controllerName),
+	}
+}
+
+type reconcilerWithMetrics struct {
+	wrappedReconciler reconcile.Reconciler
+	controllerName    string
+	logger            logr.Logger
+}
+
+// Reconcile implements Reconciler. It logs and reports duration metrics for the wrapped Reconciler.
+func (rwm *reconcilerWithMetrics) Reconcile(request reconcile.Request) (reconcile.Result, error) {
+	reqLogger := rwm.logger.WithValues("Request.Namespace", request.Namespace, "Request.Name", request.Name)
+	reqLogger.Info("Reconciling")
+
+	start := time.Now()
+	result, err := rwm.wrappedReconciler.Reconcile(request)
+	dur := time.Since(start)
+	localmetrics.Collector.SetReconcileDuration(rwm.controllerName, dur.Seconds())
+
+	rwm.logger.WithValues("Duration", dur).Info("Reconcile complete")
+	return result, err
+}


### PR DESCRIPTION
We're about to add a success/error dimension to the Reconciler duration metric. Doing so inline would entail creating a wrapper func for each controller's Reconcile. Each such wrapper func would have the same code in it.

Instead, prepare by factoring the existing reporting into a utility. This will allow the subsequent commit to add the new dimension in one place rather than having to touch all the controllers.

The utility exposes a wrapper factory, `NewReconcilerWithMetrics`, that accepts and returns a Reconciler. Its job is to
- Log the start & completion messages.
- Time the wrapped Reconciler's Reconcile func and report it to the appropriate prometheus Collector.

Now controllers no longer need to do the above. Instead they simply wrap their locally-defined Reconciler instance via the new util func.