### PR TITLE
Consolidate duplicate pkg/controller/utils imports

### DIFF
--- a/pkg/controller/account/ec2.go
+++ b/pkg/controller/account/ec2.go
@@ -13,7 +13,6 @@ import (
 	"github.com/openshift/aws-account-operator/pkg/apis/aws/v1alpha1"
 	awsv1alpha1 "github.com/openshift/aws-account-operator/pkg/apis/aws/v1alpha1"
 	"github.com/openshift/aws-account-operator/pkg/awsclient"
-	"github.com/openshift/aws-account-operator/pkg/controller/utils"
 	controllerutils "github.com/openshift/aws-account-operator/pkg/controller/utils"
 )
 
@@ -70,7 +69,7 @@ func (r *ReconcileAccount) InitializeRegion(reqLogger logr.Logger, account *awsv
 
 	if err != nil {
 		createErr := fmt.Sprintf("Unable to create instance in region: %s", region)
-		utils.LogAwsError(reqLogger, createErr, nil, err)
+		controllerutils.LogAwsError(reqLogger, createErr, nil, err)
 		// Notify Error channel that this region has errored and to move on
 		ec2Errors <- createErr
 


### PR DESCRIPTION
There were a few files where pkg/controller/utils was being imported twice with different aliases. Consolidate.

Note that in these cases I chose to retain the `controllerutils` alias, since `utils` is so generic. However, I didn't go back through and change all the other files where that alias isn't used.
