### PR TITLE
invalid type error fix

### DIFF
--- a/hack/olm-registry/olm-artifacts-template.yaml
+++ b/hack/olm-registry/olm-artifacts-template.yaml
@@ -66,4 +66,4 @@ objects:
     name: ${ACCOUNT_POOL_NAME}
     namespace: aws-account-operator
   spec:
-    poolSize: ${ACCOUNT_POOL_SIZE}
+    poolSize: ${{ACCOUNT_POOL_SIZE}}


### PR DESCRIPTION
`12:08:42 [2020-08-10 16:08:42] [ERROR] [openshift_base.py:realize_data:343] - [hive-stage-01/aws-account-operator] [https://api.hive-stage-01.n1u3.p1.openshiftapps.com:6443]: The AccountPool "hive-stage-01" is invalid: spec.poolSize: Invalid value: "string": spec.poolSize in body must be of type integer: "string"`