### PR TITLE
Make region init fully asynchronous

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,7 @@ create-account: check-aws-account-id-env
 # Delete account
 .PHONY: delete-account
 delete-account:
-	# Create Account
+	# Delete Account
 	test/integration/api/delete_account.sh
 	# Delete Secrets
 	test/integration/api/delete_account_secrets.sh

--- a/pkg/apis/aws/v1alpha1/account_types.go
+++ b/pkg/apis/aws/v1alpha1/account_types.go
@@ -99,6 +99,9 @@ const (
 	AccountPendingVerification AccountConditionType = "PendingVerification"
 	// AccountReused is set when account is reused
 	AccountReused AccountConditionType = "Reused"
+	// AccountInitializingRegions indicates we've kicked off the process of creating and terminating
+	// instances in all supported regions
+	AccountInitializingRegions = "InitializingRegions"
 )
 
 // +genclient

--- a/pkg/controller/account/ec2.go
+++ b/pkg/controller/account/ec2.go
@@ -19,7 +19,9 @@ import (
 
 // InitializeSupportedRegions concurrently calls InitializeRegion to create instances in all supported regions
 // This should ensure we don't see any AWS API "PendingVerification" errors when launching instances
-func (r *ReconcileAccount) InitializeSupportedRegions(reqLogger logr.Logger, account *awsv1alpha1.Account, regions map[string]map[string]string, creds *sts.AssumeRoleOutput) error {
+// NOTE: This function does not have any returns. In particular, error conditions from the
+// goroutines are logged, but do not result in a failure up the stack.
+func (r *ReconcileAccount) InitializeSupportedRegions(reqLogger logr.Logger, account *awsv1alpha1.Account, regions map[string]map[string]string, creds *sts.AssumeRoleOutput) {
 	// Create some channels to listen and error on when creating EC2 instances in all supported regions
 	ec2Notifications, ec2Errors := make(chan string), make(chan string)
 
@@ -43,8 +45,6 @@ func (r *ReconcileAccount) InitializeSupportedRegions(reqLogger logr.Logger, acc
 	}
 
 	reqLogger.Info("Completed initializing all supported regions")
-
-	return nil
 }
 
 // InitializeRegion sets up a connection to the AWS `region` and then creates and terminates an EC2 instance


### PR DESCRIPTION
TL;DR: free up the Account controller to carry on servicing events for
other Accounts while regions are being initialized.

Background: Initializing supported regions can take a nontrivial amount
of time.  Previously the regions were initialized in parallel, but the
parent account controller Reconcile would wait for all of those threads
to complete.  Thus the controller's ability to service the next event
was constrained to however long the longest region init took. As
currently written, this is a theoretical maximum of 50 minutes if we hit
all the timeouts, but is always at least four seconds plus four AWS API
calls.

With this commit, we set a new state, InitializingRegions, and decouple
the parent of these threads from the main account controller Reconcile,
spawning it in its own thread and immediately returning with no requeue.
The new parent thread is responsible for the final state transition once
all the per-region threads complete. (This state transition would be
what triggers subsequent Reconciles, e.g. to continue watching for
verification of non-CCS Accounts.) The main Reconcile ignores an Account
in the InitializingRegions state, allowing the thread to work, unless it
stays in that state for way too long, in which case we time it out and
transition it to Failed. (Note that if, by some chance, the thread is
still running, its final state transition will bounce because its
`resourceVersion` will be stale due to the Failed transition from the
main controller.)

Jira: [OSD-4766](https://issues.redhat.com/browse/OSD-4766)