### PR TITLE
Detect and recover stale region initialization

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -71,6 +71,15 @@ func main() {
 
 	printVersion()
 
+	// This is used by controllers to detect whether conditions happened during the current
+	// invocation of the operator or a previous one. Thus it *must* be done before controllers
+	// are started.
+	// It must also be done exactly once -- see the docstring.
+	if err := utils.InitOperatorStartTime(); err != nil {
+		log.Error(err, "")
+		os.Exit(1)
+	}
+
 	// Get a config to talk to the apiserver
 	cfg, err := config.GetConfig()
 	if err != nil {


### PR DESCRIPTION
Commit 801903c1 (PR #454) made region initialization happen in the
background. To prevent subsequent reconciles of the same Account from
thrashing, it introduced a new InitializingRegions state which was
ignored by the controller; unless a really long time elapsed, whereupon
we assumed the goroutine died and we set the account to Failed.

This caused a regression: Previously, Accounts stayed in Creating while
regions were being initialized. If the operator died, it would come back
up and churn through to the region initialization code path again. With
the new InitializingRegions state, that wasn't happening.

With this commit, we restore that behavior by detecting whether the
InitializingRegions condition was set earlier than the start time of the
operator. If so, we assume it's dead, and we set the Account's state
back to Creating to give the controller another crack at it.