### PR TITLE
Add role for ccs access

### DIFF
--- a/pkg/apis/aws/v1alpha1/account_types.go
+++ b/pkg/apis/aws/v1alpha1/account_types.go
@@ -28,8 +28,10 @@ const (
 	accountStatusPendingVerification AccountStateStatus = "PendingVerification"
 	// AccountCrNamespace namespace where AWS accounts will be created
 	AccountCrNamespace = "aws-account-operator"
-	// IAM Role name for IAM user creating resources in account
+	// AccountOperatorIAMRole name for IAM user creating resources in account
 	AccountOperatorIAMRole = "OrganizationAccountAccessRole"
+	// SREAccessRoleName for CCS Account Access
+	SREAccessRoleName = "RH-SRE-CCS-Access"
 	// AccountFinalizer is the string finalizer name
 	AccountFinalizer = "finalizer.aws.managed.openshift.io"
 )

--- a/pkg/apis/aws/v1alpha1/awsfederatedrole_types.go
+++ b/pkg/apis/aws/v1alpha1/awsfederatedrole_types.go
@@ -52,7 +52,7 @@ type StatementEntry struct {
 // Principal  contains the aws account id for the principle entity of a role
 type Principal struct {
 	// aws account id
-	AWS string `json:"AWS"`
+	AWS []string `json:"AWS"`
 }
 
 // Condition contains the aws Condition map to use for IAM roles

--- a/pkg/controller/account/byoc_test.go
+++ b/pkg/controller/account/byoc_test.go
@@ -140,20 +140,20 @@ var _ = Describe("Byoc", func() {
 	Context("Testing CreateRole", func() {
 		It("Works properly without error", func() {
 			mockAWSClient.EXPECT().CreateRole(gomock.Any()).Return(&iam.CreateRoleOutput{Role: &iam.Role{RoleId: aws.String("AROA1234567890EXAMPLE")}}, nil)
-			roleID, err := CreateRole(nullLogger, "roleName", userARN, mockAWSClient, nil)
+			roleID, err := CreateRole(nullLogger, "roleName", []string{userARN, "arn2"}, mockAWSClient, nil)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(roleID).To(Equal("AROA1234567890EXAMPLE"))
 		})
 
 		It("Throws an error on any AWS error", func() {
 			mockAWSClient.EXPECT().CreateRole(gomock.Any()).Return(nil, awserr.New("AWSError", "Some AWS Error", nil))
-			_, err := CreateRole(nullLogger, "roleName", userARN, mockAWSClient, nil)
+			_, err := CreateRole(nullLogger, "roleName", []string{userARN, "arn2"}, mockAWSClient, nil)
 			Expect(err).To(HaveOccurred())
 		})
 
 		It("Throws an error on any Non-AWS error", func() {
 			mockAWSClient.EXPECT().CreateRole(gomock.Any()).Return(nil, errors.New("NonAWSError"))
-			_, err := CreateRole(nullLogger, "roleName", userARN, mockAWSClient, nil)
+			_, err := CreateRole(nullLogger, "roleName", []string{userARN}, mockAWSClient, nil)
 			Expect(err).To(HaveOccurred())
 		})
 	})

--- a/pkg/controller/awsfederatedaccountaccess/awsfederatedaccountaccess_controller.go
+++ b/pkg/controller/awsfederatedaccountaccess/awsfederatedaccountaccess_controller.go
@@ -384,7 +384,7 @@ func (r *ReconcileAWSFederatedAccountAccess) createIAMRole(awsClient awsclient.C
 			Effect: "Allow",
 			Action: []string{"sts:AssumeRole"},
 			Principal: &awsv1alpha1.Principal{
-				AWS: afaa.Spec.ExternalCustomerAWSIAMARN,
+				AWS: []string{afaa.Spec.ExternalCustomerAWSIAMARN},
 			},
 		}},
 	}

--- a/pkg/controller/utils/utils.go
+++ b/pkg/controller/utils/utils.go
@@ -30,6 +30,10 @@ const (
 	//           value: cluster
 	//   . `oc apply` all the YAML files in deploy/, including the updated operator.yaml.
 	envDevMode = "FORCE_DEV_MODE"
+
+	// SREAssumeRole is the name of the role that SREs need to use to role-chain to get temporary
+	// credentials for a CCS account
+	SREAssumeRole = "RH-SREP-CCS-Access"
 )
 
 // operatorStartTime is (roughly) the time at which the operator came up.


### PR DESCRIPTION
Fulfills OSD-4893.  Prerequisite to https://github.com/openshift/osd-utils-cli/pull/68

This PR is a pre-requisite to being able to assume the BYOCAdminAccess role in CCS accounts.  This PR adds a second principal to the BYOCAdminAccess role.

For SREs to access that role they first assume the RH-SRE-CCS-Access role in the payer account that the account was created in and then using the STS credentials for that role they should be able to further access the BYOCAdminAccess role in the customer's account.

To test:

* `make create-ccs`
* `oc get accountclaim --all-namespaces` and note the hash at the end of the account CR name
* `unset AWS_SESSION_TOKEN AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY` to ensure that your env vars are clear
* `aws sts assume-role --role-arn arn:aws:iam::[staging2 account number]:role/RH-SRE-CCS-Access --role-session-name role-chain-test`
* `aws sts assume-role --role-arn arn:aws:iam::[your staging2 account number]:role/BYOCAdminAccess-[hash from step2]`
* `aws sts get-caller-identity` and confirm that you are now accessing your CCS account