### PR TITLE
Adds various fixes for Go linter standards

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,6 @@
+# options for analysis running
+run:
+  # default concurrency is a available CPU number
+  concurrency: 10
+  # timeout for analysis, e.g. 30s, 5m, default is 1m
+  timeout: 2m

--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,10 @@ endif
 .PHONY: docker-build
 docker-build: build
 
+.PHONY: lint
+lint:
+	golangci-lint run
+
 # Create account
 .PHONY: create-account
 create-account: check-aws-account-id-env
@@ -341,4 +345,4 @@ test-aws-ou-logic: check-ou-mapping-configmap-env check-ou-mapping-configmap-env
 
 #s Test all
 .PHONY: test-all
-test-all: test-account-creation test-ccs test-reuse test-awsfederatedaccountaccess test-awsfederatedrole test-aws-ou-logic 
+test-all: lint test-account-creation test-ccs test-reuse test-awsfederatedaccountaccess test-awsfederatedrole test-aws-ou-logic 

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -39,11 +39,9 @@ import (
 
 // Change below variables to serve metrics on different host or port.
 var (
-	metricsPort               = "8080"
-	metricsPath               = "/metrics"
-	secretWatcherScanInterval = time.Duration(1) * time.Minute
-	hours                     = 1
-	totalWatcherInterval      = time.Duration(15) * time.Minute
+	metricsPort          = "8080"
+	metricsPath          = "/metrics"
+	totalWatcherInterval = time.Duration(15) * time.Minute
 )
 
 var log = logf.Log.WithName("cmd")
@@ -193,6 +191,11 @@ func initOperatorConfigMapVars(kubeClient client.Client) {
 		NameSpace:  awsv1alpha1.AccountCrNamespace,
 		AwsRegion:  "us-east-1",
 	})
+
+	if err != nil {
+		log.Error(err, "failed creating AWS client")
+		return
+	}
 
 	// Check if config map exists.
 	cm := &corev1.ConfigMap{}

--- a/config/config.go
+++ b/config/config.go
@@ -15,6 +15,9 @@
 package config
 
 const (
-	OperatorName      string = "aws-account-operator"
+	// OperatorName stores the name used by this code for the AWS Account Operator
+	OperatorName string = "aws-account-operator"
+
+	// OperatorNamespace stores a string indicating the Kubernetes namespace in which the operator runs
 	OperatorNamespace string = "aws-account-operator"
 )

--- a/pkg/apis/aws/v1alpha1/account_types.go
+++ b/pkg/apis/aws/v1alpha1/account_types.go
@@ -18,17 +18,9 @@ const (
 	AccountStatusRequested AccountStateStatus = "Requested"
 	// AccountStatusClaimed const for Claimed status
 	AccountStatusClaimed AccountStateStatus = "Claimed"
-	// AccountStatusTransfering const for Transfering status
-	accountStatusTransfering AccountStateStatus = "Transfering"
-	// AccountStatusTransfered const for Transfering status
-	accountStatusTransfered AccountStateStatus = "Transfered"
-	// AccountStatusDeleting const for Deleting status
-	accountStatusDeleting AccountStateStatus = "Deleting"
-	// AccountStatusPendingVerification const for Pending Verification status
-	accountStatusPendingVerification AccountStateStatus = "PendingVerification"
 	// AccountCrNamespace namespace where AWS accounts will be created
 	AccountCrNamespace = "aws-account-operator"
-	// AccountOperatorIAMRole name for IAM user creating resources in account
+	// AccountOperatorIAMRole is the name for IAM user creating resources in account
 	AccountOperatorIAMRole = "OrganizationAccountAccessRole"
 	// SREAccessRoleName for CCS Account Access
 	SREAccessRoleName = "RH-SRE-CCS-Access"
@@ -216,7 +208,7 @@ func (a *Account) HasAwsv1alpha1Finalizer() bool {
 //IsOlderThan takes a parameter of a time and returns true if the creation timestamp is longer than
 //the passed in time.
 func (a *Account) IsOlderThan(maxDuration time.Duration) bool {
-	return time.Now().Sub(a.GetCreationTimestamp().Time) > maxDuration
+	return time.Since(a.GetCreationTimestamp().Time) > maxDuration
 }
 
 //IsBYOCPendingDeletionWithFinalizer returns true if account is a BYOC Account,
@@ -256,7 +248,7 @@ func (a *Account) IsInitializingRegions() bool {
 	return a.Status.State == AccountInitializingRegions
 }
 
-// FindCondition finds in the condition that has the
+// GetCondition finds the condition that has the
 // specified condition type in the given list. If none exists, then returns nil.
 func (a *Account) GetCondition(conditionType AccountConditionType) *AccountCondition {
 	for i, condition := range a.Status.Conditions {

--- a/pkg/apis/aws/v1alpha1/awsfederatedrole_types.go
+++ b/pkg/apis/aws/v1alpha1/awsfederatedrole_types.go
@@ -68,6 +68,7 @@ type AWSFederatedRoleStatus struct {
 	Conditions []AWSFederatedRoleCondition `json:"conditions"`
 }
 
+// AWSFederatedRoleCondition is a Kubernetes condition type for tracking AWS Federated Role status changes
 type AWSFederatedRoleCondition struct {
 	// Type is the type of the condition.
 	Type AWSFederatedRoleConditionType `json:"type"`

--- a/pkg/awsclient/iam.go
+++ b/pkg/awsclient/iam.go
@@ -12,6 +12,7 @@ import (
 	"github.com/openshift/aws-account-operator/pkg/controller/utils"
 )
 
+// ListIAMUserTags returns a list of the tags assigned to an IAM user in AWS
 func ListIAMUserTags(reqLogger logr.Logger, client Client, userName string) (*iam.ListUserTagsOutput, error) {
 	input := &iam.ListUserTagsInput{
 		UserName: aws.String(userName),
@@ -39,6 +40,7 @@ func ListIAMUserTags(reqLogger logr.Logger, client Client, userName string) (*ia
 	return result, nil
 }
 
+// ListIAMUsers returns an *iam.User list of users from the current account
 func ListIAMUsers(reqLogger logr.Logger, client Client) ([]*iam.User, error) {
 	input := &iam.ListUsersInput{}
 	// List of IAM users to return
@@ -76,7 +78,7 @@ func ListIAMUsers(reqLogger logr.Logger, client Client) ([]*iam.User, error) {
 
 }
 
-// checkIAMUserExists checks if a given IAM user exists within an account
+// CheckIAMUserExists checks if a given IAM user exists within an account
 // Takes a logger, an AWS client for the target account, and a target IAM username
 func CheckIAMUserExists(reqLogger logr.Logger, client Client, userName string) (bool, *iam.GetUserOutput, error) {
 	// Retry when getting IAM user information
@@ -174,6 +176,7 @@ func CreateIAMUser(reqLogger logr.Logger, client Client, account *awsv1alpha1.Ac
 	return createUserOutput, err
 }
 
+// ListIAMRoles returns an *iam.Role list of roles in the AWS account
 func ListIAMRoles(reqLogger logr.Logger, client Client) ([]*iam.Role, error) {
 
 	// List of IAM roles to return
@@ -186,9 +189,7 @@ func ListIAMRoles(reqLogger logr.Logger, client Client) ([]*iam.Role, error) {
 			return nil, err
 		}
 
-		for _, role := range output.Roles {
-			iamRoleList = append(iamRoleList, role)
-		}
+		iamRoleList = append(iamRoleList, output.Roles...)
 
 		if *output.IsTruncated {
 			marker = output.Marker

--- a/pkg/controller/account/byoc_test.go
+++ b/pkg/controller/account/byoc_test.go
@@ -26,7 +26,6 @@ var _ = Describe("Byoc", func() {
 	)
 
 	BeforeEach(func() {
-		nullLogger = testutils.NullLogger{}
 		ctrl = gomock.NewController(GinkgoT())
 		mockAWSClient = mock.NewMockClient(ctrl)
 		policyFake = &iam.AttachedPolicy{

--- a/pkg/controller/account/ec2.go
+++ b/pkg/controller/account/ec2.go
@@ -30,7 +30,7 @@ func (r *ReconcileAccount) InitializeSupportedRegions(reqLogger logr.Logger, acc
 
 	// Create go routines to initialize regions in parallel
 	for region := range regions {
-		go r.InitializeRegion(reqLogger, account, region, regions[region]["initializationAMI"], ec2Notifications, ec2Errors, creds)
+		go r.InitializeRegion(reqLogger, account, region, regions[region]["initializationAMI"], ec2Notifications, ec2Errors, creds) //nolint:errcheck // Unable to do anything with the returned error
 	}
 
 	// Wait for all go routines to send a message or error to notify that the region initialization has finished

--- a/pkg/controller/accountclaim/accountclaim_controller_test.go
+++ b/pkg/controller/accountclaim/accountclaim_controller_test.go
@@ -2,6 +2,7 @@ package accountclaim
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws/awserr"
@@ -32,7 +33,10 @@ var _ = Describe("AccountClaim", func() {
 		ctrl         *gomock.Controller
 	)
 
-	apis.AddToScheme(scheme.Scheme)
+	err := apis.AddToScheme(scheme.Scheme)
+	if err != nil {
+		fmt.Printf("failed adding apis to scheme in account controller tests")
+	}
 	localmetrics.Collector = localmetrics.NewMetricsCollector(nil)
 
 	BeforeEach(func() {
@@ -136,7 +140,7 @@ var _ = Describe("AccountClaim", func() {
 			_, err := r.Reconcile(req)
 
 			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(Equal("Account CR Modified during CR reset. Conflict"))
+			Expect(err.Error()).To(Equal("account CR modified during reset: Conflict"))
 		})
 	})
 })

--- a/pkg/controller/accountpool/accountpool_controller.go
+++ b/pkg/controller/accountpool/accountpool_controller.go
@@ -111,7 +111,7 @@ func (r *ReconcileAccountPool) Reconcile(request reconcile.Request) (reconcile.R
 	claimedAccountCount := 0
 	for _, account := range accountList.Items {
 		// We don't want to count reused accounts here, filter by LegalEntity.ID
-		if account.Status.Claimed == false && account.Spec.LegalEntity.ID == "" {
+		if !account.Status.Claimed && account.Spec.LegalEntity.ID == "" {
 			if account.Status.State != "Failed" {
 				unclaimedAccountCount++
 			}

--- a/pkg/controller/awsfederatedaccountaccess/awsfederatedaccountaccess_controller.go
+++ b/pkg/controller/awsfederatedaccountaccess/awsfederatedaccountaccess_controller.go
@@ -275,9 +275,7 @@ func (r *ReconcileAWSFederatedAccountAccess) Reconcile(request reconcile.Request
 
 	awsManagedPolicyNames := []string{}
 	// Add all aws managed policy names to a array
-	for _, policy := range requestedRole.Spec.AWSManagedPolicies {
-		awsManagedPolicyNames = append(awsManagedPolicyNames, policy)
-	}
+	awsManagedPolicyNames = append(awsManagedPolicyNames, requestedRole.Spec.AWSManagedPolicies...)
 	// Get policy arns for managed policies
 	policyArns := createPolicyArns(accountID, awsManagedPolicyNames, true)
 	// Get custom policy arns
@@ -509,7 +507,7 @@ func (r *ReconcileAWSFederatedAccountAccess) attachIAMPolices(awsClient awsclien
 func createPolicyArns(accountID string, policyNames []string, awsManaged bool) []string {
 	awsPolicyArnPrefix := ""
 
-	if awsManaged == true {
+	if awsManaged {
 		awsPolicyArnPrefix = "arn:aws:iam::aws:policy/"
 	} else {
 		awsPolicyArnPrefix = fmt.Sprintf("arn:aws:iam::%s:policy/", accountID)
@@ -640,7 +638,7 @@ func (r *ReconcileAWSFederatedAccountAccess) cleanFederatedRoles(reqLogger logr.
 				default:
 					reqLogger.Error(
 						aerr,
-						fmt.Sprintf(aerr.Error()),
+						fmt.Sprint(aerr.Error()),
 					)
 					reqLogger.Error(err, fmt.Sprintf("%v", err))
 					return err
@@ -658,7 +656,7 @@ func (r *ReconcileAWSFederatedAccountAccess) cleanFederatedRoles(reqLogger logr.
 					default:
 						reqLogger.Error(
 							aerr,
-							fmt.Sprintf(aerr.Error()),
+							fmt.Sprint(aerr.Error()),
 						)
 						reqLogger.Error(err, fmt.Sprintf("%v", err))
 						return err
@@ -676,7 +674,7 @@ func (r *ReconcileAWSFederatedAccountAccess) cleanFederatedRoles(reqLogger logr.
 						default:
 							reqLogger.Error(
 								aerr,
-								fmt.Sprintf(aerr.Error()),
+								fmt.Sprint(aerr.Error()),
 							)
 							reqLogger.Error(err, fmt.Sprintf("%v", err))
 							return err
@@ -703,7 +701,7 @@ func (r *ReconcileAWSFederatedAccountAccess) cleanFederatedRoles(reqLogger logr.
 		if aerr, ok := err.(awserr.Error); ok {
 			switch aerr.Code() {
 			default:
-				reqLogger.Error(aerr, fmt.Sprintf(aerr.Error()))
+				reqLogger.Error(aerr, fmt.Sprint(aerr.Error()))
 				return err
 			}
 		} else {
@@ -725,7 +723,7 @@ func (r *ReconcileAWSFederatedAccountAccess) deleteNonAttachedCustomPolicy(reqLo
 			if aerr, ok := err.(awserr.Error); ok {
 				switch aerr.Code() {
 				default:
-					reqLogger.Error(aerr, fmt.Sprintf(aerr.Error()))
+					reqLogger.Error(aerr, fmt.Sprint(aerr.Error()))
 					return err
 				}
 			}
@@ -739,7 +737,7 @@ func (r *ReconcileAWSFederatedAccountAccess) deleteNonAttachedCustomPolicy(reqLo
 					if aerr, ok := err.(awserr.Error); ok {
 						switch aerr.Code() {
 						default:
-							reqLogger.Error(aerr, fmt.Sprintf(aerr.Error()))
+							reqLogger.Error(aerr, fmt.Sprint(aerr.Error()))
 							return err
 						}
 					}

--- a/pkg/controller/awsfederatedrole/finalizer.go
+++ b/pkg/controller/awsfederatedrole/finalizer.go
@@ -69,9 +69,5 @@ func isFederatedRoleReferenced(awsFederatedAccountAccess *awsv1alpha1.AWSFederat
 	referencedRoleNamespacedName := types.NamespacedName{Name: awsFederatedAccountAccess.Spec.AWSFederatedRole.Name, Namespace: awsFederatedAccountAccess.Spec.AWSFederatedRole.Namespace}
 	roleNamespacedName := types.NamespacedName{Name: awsFederatedRole.Name, Namespace: awsFederatedRole.Namespace}
 
-	if reflect.DeepEqual(referencedRoleNamespacedName, roleNamespacedName) {
-		return true
-	}
-
-	return false
+	return reflect.DeepEqual(referencedRoleNamespacedName, roleNamespacedName)
 }

--- a/pkg/controller/utils/conditions.go
+++ b/pkg/controller/utils/conditions.go
@@ -2,6 +2,7 @@ package utils
 
 import (
 	"fmt"
+
 	"github.com/go-logr/logr"
 	awsv1alpha1 "github.com/openshift/aws-account-operator/pkg/apis/aws/v1alpha1"
 	"github.com/openshift/aws-account-operator/pkg/localmetrics"
@@ -295,6 +296,7 @@ func FindAWSFederatedAccountAccessCondition(conditions []awsv1alpha1.AWSFederate
 }
 
 const (
+	// AwsSecretName is a constant for the name of the Kubernetes secret that holds the AWS Credentials
 	AwsSecretName = "aws-account-operator-credentials"
 )
 

--- a/pkg/controller/utils/utils.go
+++ b/pkg/controller/utils/utils.go
@@ -17,8 +17,11 @@ import (
 )
 
 const (
+	// Finalizer is a constant containing the Kubernetes finalizer used by the AWS Account Operator
 	Finalizer = "finalizer.aws.managed.openshift.io"
-	WaitTime  = 25
+
+	// WaitTime is the default wait time for an account to become ready, before erroring
+	WaitTime = 25
 
 	// envDevMode is the name of the env var we set to indicate we're running in a development
 	// environment vs. production. Set it to one of the DevMode* consts defined below.
@@ -144,6 +147,7 @@ func LogAwsError(logger logr.Logger, errMsg string, customError error, err error
 	}
 }
 
+// Contains returns true a list of strings includes a specific string
 func Contains(list []string, s string) bool {
 	for _, v := range list {
 		if v == s {
@@ -153,6 +157,7 @@ func Contains(list []string, s string) bool {
 	return false
 }
 
+// Remove removes a string from a list of strings
 func Remove(list []string, s string) []string {
 	for i, v := range list {
 		if v == s {
@@ -164,8 +169,7 @@ func Remove(list []string, s string) []string {
 
 // GenerateShortUID Generates a short UID
 func GenerateShortUID() string {
-	UID := rand.String(6)
-	return fmt.Sprintf("%s", UID)
+	return rand.String(6)
 }
 
 // GenerateLabel returns a ObjectMeta Labels

--- a/pkg/totalaccountwatcher/totalaccountwatcher.go
+++ b/pkg/totalaccountwatcher/totalaccountwatcher.go
@@ -55,12 +55,15 @@ func Initialize(client client.Client, watchInterval time.Duration) {
 		return
 	}
 
-	TotalAccountWatcher = NewTotalAccountWatcher(client, awsClient, watchInterval)
-	TotalAccountWatcher.UpdateTotalAccounts(log)
+	TotalAccountWatcher = newTotalAccountWatcher(client, awsClient, watchInterval)
+	err = TotalAccountWatcher.UpdateTotalAccounts(log)
+	if err != nil {
+		log.Error(err, "failed updating total accounts count")
+	}
 }
 
-// NewTotalAccountWatcher returns a new instance of the TotalAccountWatcher interface
-func NewTotalAccountWatcher(
+// newTotalAccountWatcher returns a new instance of the TotalAccountWatcher interface
+func newTotalAccountWatcher(
 	client client.Client,
 	awsClient awsclient.Client,
 	watchInterval time.Duration,

--- a/pkg/totalaccountwatcher/totalaccountwatcher_test.go
+++ b/pkg/totalaccountwatcher/totalaccountwatcher_test.go
@@ -47,7 +47,7 @@ func TestAccountWatcherCreation(t *testing.T) {
 		// after mocks is defined
 		defer mocks.mockCtrl.Finish()
 
-		totalAccountWatcher := NewTotalAccountWatcher(mocks.fakeKubeClient, mocks.mockAWSClient, 10)
+		totalAccountWatcher := newTotalAccountWatcher(mocks.fakeKubeClient, mocks.mockAWSClient, 10)
 		totalAccountWatcher.awsClient = mocks.mockAWSClient
 
 		if totalAccountWatcher.AccountsCanBeCreated() {
@@ -135,7 +135,7 @@ func TestTotalAwsAccounts(t *testing.T) {
 			defer mocks.mockCtrl.Finish()
 
 			// Act
-			TotalAccountWatcher = NewTotalAccountWatcher(mocks.fakeKubeClient, mocks.mockAWSClient, 10)
+			TotalAccountWatcher = newTotalAccountWatcher(mocks.fakeKubeClient, mocks.mockAWSClient, 10)
 			total, err := TotalAccountWatcher.getTotalAwsAccounts()
 
 			// Assert
@@ -368,7 +368,7 @@ func TestTotalAccountsUpdate(t *testing.T) {
 				nullLogger := testutils.NullLogger{}
 				defer mocks.mockCtrl.Finish()
 
-				TotalAccountWatcher = NewTotalAccountWatcher(mocks.fakeKubeClient, mocks.mockAWSClient, 10)
+				TotalAccountWatcher = newTotalAccountWatcher(mocks.fakeKubeClient, mocks.mockAWSClient, 10)
 				TotalAccountWatcher.awsClient = mocks.mockAWSClient
 				err := TotalAccountWatcher.UpdateTotalAccounts(nullLogger)
 


### PR DESCRIPTION
This PR includes a number of fixes to conform to Go linter standards from golangci-linter.  Mostly this includes adding or fixing comments for exported functions, constants and variables.  In a few cases, like the `totalaccountwatcher`, exported-but-unused-outside-the-package functions were changed to be unexported.

Also adds default SREP boilerplate .golangci.yml file provided by @2uasimojo.

Commits have not been squashed so they may be addressed as is, if desired.

Note: `pkg/controller/testutils/testutils.go` has a few linter notices that I am unsure how to fix.  Otherwise, with #471, this handles all the linter issues I could find.
