### PR TITLE
Remove osd-operators-registry targets

### DIFF
--- a/standard.mk
+++ b/standard.mk
@@ -47,7 +47,7 @@ isclean:
 	@(test "$(ALLOW_DIRTY_CHECKOUT)" != "false" || test 0 -eq $$(git status --porcelain | wc -l)) || (echo "Local git checkout is not clean, commit changes and try again." && exit 1)
 
 .PHONY: build
-build: isclean envtest
+build: isclean
 	docker build . -f $(OPERATOR_DOCKERFILE) -t $(OPERATOR_IMAGE_URI)
 	docker tag $(OPERATOR_IMAGE_URI) $(OPERATOR_IMAGE_URI_LATEST)
 
@@ -73,18 +73,5 @@ gobuild: gocheck gotest ## Build binary
 gotest:
 	go test $(TESTOPTS) $(TESTTARGETS)
 
-.PHONY: envtest
-envtest:
-	@# test that the env target can be evaluated, required by osd-operators-registry
-	@eval $$($(MAKE) env --no-print-directory) || (echo 'Unable to evaulate output of `make env`.  This breaks osd-operators-registry.' && exit 1)
-
 .PHONY: test
-test: envtest gotest
-
-.PHONY: env
-.SILENT: env
-env: isclean
-	echo OPERATOR_NAME=$(OPERATOR_NAME)
-	echo OPERATOR_NAMESPACE=$(OPERATOR_NAMESPACE)
-	echo OPERATOR_VERSION=$(OPERATOR_VERSION)
-	echo OPERATOR_IMAGE_URI=$(OPERATOR_IMAGE_URI)
+test: gotest


### PR DESCRIPTION
[osd-operators-registry](https://github.com/openshift/osd-operators-registry) is obsolete; and aws-account-operator was never integrated into it anyway. Remove `make` targets that existed solely for its use.