### PR TITLE
Adds conditional retry for some specific errors, eg: InvalidClientTokenID

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -34,6 +34,14 @@
   version = "1.0.0"
 
 [[projects]]
+  digest = "1:c67a4f1ad6bb0a6d743a93078f932e2553290b0402efdf655eaf58634dd254be"
+  name = "github.com/avast/retry-go"
+  packages = ["."]
+  pruneopts = "NT"
+  revision = "06f486a96c4838bd52f71d225c149f87e8504127"
+  version = "v2.6.1"
+
+[[projects]]
   digest = "1:5091dfd89af51f89aff22ed4d5ebf3ea6eb93d332fa1f40a7c0c8d504a6c1abb"
   name = "github.com/aws/aws-sdk-go"
   packages = [
@@ -1133,6 +1141,7 @@
   analyzer-name = "dep"
   analyzer-version = 1
   input-imports = [
+    "github.com/avast/retry-go",
     "github.com/aws/aws-sdk-go/aws",
     "github.com/aws/aws-sdk-go/aws/awserr",
     "github.com/aws/aws-sdk-go/aws/credentials",
@@ -1163,6 +1172,7 @@
     "github.com/operator-framework/operator-sdk/pkg/leader",
     "github.com/operator-framework/operator-sdk/pkg/log/zap",
     "github.com/operator-framework/operator-sdk/version",
+    "github.com/pkg/errors",
     "github.com/prometheus/client_golang/prometheus",
     "github.com/prometheus/client_golang/prometheus/promhttp",
     "github.com/spf13/pflag",

--- a/pkg/controller/account/account_controller.go
+++ b/pkg/controller/account/account_controller.go
@@ -271,6 +271,7 @@ func (r *ReconcileAccount) Reconcile(request reconcile.Request) (reconcile.Resul
 			}
 			return reconcile.Result{}, err
 		}
+
 		currentAcctInstance.Spec.IAMUserSecret = *secretName
 		err = r.Client.Update(context.TODO(), currentAcctInstance)
 		if err != nil {

--- a/vendor/github.com/avast/retry-go/LICENSE
+++ b/vendor/github.com/avast/retry-go/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2017 Avast
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/vendor/github.com/avast/retry-go/options.go
+++ b/vendor/github.com/avast/retry-go/options.go
@@ -1,0 +1,172 @@
+package retry
+
+import (
+	"math"
+	"math/rand"
+	"time"
+)
+
+// Function signature of retry if function
+type RetryIfFunc func(error) bool
+
+// Function signature of OnRetry function
+// n = count of attempts
+type OnRetryFunc func(n uint, err error)
+
+type DelayTypeFunc func(n uint, config *Config) time.Duration
+
+type Config struct {
+	attempts      uint
+	delay         time.Duration
+	maxDelay      time.Duration
+	maxJitter     time.Duration
+	onRetry       OnRetryFunc
+	retryIf       RetryIfFunc
+	delayType     DelayTypeFunc
+	lastErrorOnly bool
+
+	maxBackOffN uint
+}
+
+// Option represents an option for retry.
+type Option func(*Config)
+
+// return the direct last error that came from the retried function
+// default is false (return wrapped errors with everything)
+func LastErrorOnly(lastErrorOnly bool) Option {
+	return func(c *Config) {
+		c.lastErrorOnly = lastErrorOnly
+	}
+}
+
+// Attempts set count of retry
+// default is 10
+func Attempts(attempts uint) Option {
+	return func(c *Config) {
+		c.attempts = attempts
+	}
+}
+
+// Delay set delay between retry
+// default is 100ms
+func Delay(delay time.Duration) Option {
+	return func(c *Config) {
+		c.delay = delay
+	}
+}
+
+// MaxDelay set maximum delay between retry
+// does not apply by default
+func MaxDelay(maxDelay time.Duration) Option {
+	return func(c *Config) {
+		c.maxDelay = maxDelay
+	}
+}
+
+// MaxJitter sets the maximum random Jitter between retries for RandomDelay
+func MaxJitter(maxJitter time.Duration) Option {
+	return func(c *Config) {
+		c.maxJitter = maxJitter
+	}
+}
+
+// DelayType set type of the delay between retries
+// default is BackOff
+func DelayType(delayType DelayTypeFunc) Option {
+	return func(c *Config) {
+		c.delayType = delayType
+	}
+}
+
+// BackOffDelay is a DelayType which increases delay between consecutive retries
+func BackOffDelay(n uint, config *Config) time.Duration {
+	// 1 << 63 would overflow signed int64 (time.Duration), thus 62.
+	const max uint = 62
+
+	if config.maxBackOffN == 0 {
+		if config.delay <= 0 {
+			config.delay = 1
+		}
+		config.maxBackOffN = max - uint(math.Floor(math.Log2(float64(config.delay))))
+	}
+
+	if n > config.maxBackOffN {
+		n = config.maxBackOffN
+	}
+	return config.delay << n
+}
+
+// FixedDelay is a DelayType which keeps delay the same through all iterations
+func FixedDelay(_ uint, config *Config) time.Duration {
+	return config.delay
+}
+
+// RandomDelay is a DelayType which picks a random delay up to config.maxJitter
+func RandomDelay(_ uint, config *Config) time.Duration {
+	return time.Duration(rand.Int63n(int64(config.maxJitter)))
+}
+
+// CombineDelay is a DelayType the combines all of the specified delays into a new DelayTypeFunc
+func CombineDelay(delays ...DelayTypeFunc) DelayTypeFunc {
+	const maxInt64 = uint64(math.MaxInt64)
+
+	return func(n uint, config *Config) time.Duration {
+		var total uint64
+		for _, delay := range delays {
+			total += uint64(delay(n, config))
+			if total > maxInt64 {
+				total = maxInt64
+			}
+		}
+		return time.Duration(total)
+	}
+}
+
+// OnRetry function callback are called each retry
+//
+// log each retry example:
+//
+//	retry.Do(
+//		func() error {
+//			return errors.New("some error")
+//		},
+//		retry.OnRetry(func(n uint, err error) {
+//			log.Printf("#%d: %s\n", n, err)
+//		}),
+//	)
+func OnRetry(onRetry OnRetryFunc) Option {
+	return func(c *Config) {
+		c.onRetry = onRetry
+	}
+}
+
+// RetryIf controls whether a retry should be attempted after an error
+// (assuming there are any retry attempts remaining)
+//
+// skip retry if special error example:
+//
+//	retry.Do(
+//		func() error {
+//			return errors.New("special error")
+//		},
+//		retry.RetryIf(func(err error) bool {
+//			if err.Error() == "special error" {
+//				return false
+//			}
+//			return true
+//		})
+//	)
+//
+// By default RetryIf stops execution if the error is wrapped using `retry.Unrecoverable`,
+// so above example may also be shortened to:
+//
+//	retry.Do(
+//		func() error {
+//			return retry.Unrecoverable(errors.New("special error"))
+//		}
+//	)
+func RetryIf(retryIf RetryIfFunc) Option {
+	return func(c *Config) {
+		c.retryIf = retryIf
+	}
+}

--- a/vendor/github.com/avast/retry-go/retry.go
+++ b/vendor/github.com/avast/retry-go/retry.go
@@ -1,0 +1,206 @@
+/*
+Simple library for retry mechanism
+
+slightly inspired by [Try::Tiny::Retry](https://metacpan.org/pod/Try::Tiny::Retry)
+
+SYNOPSIS
+
+http get with retry:
+
+	url := "http://example.com"
+	var body []byte
+
+	err := retry.Do(
+		func() error {
+			resp, err := http.Get(url)
+			if err != nil {
+				return err
+			}
+			defer resp.Body.Close()
+			body, err = ioutil.ReadAll(resp.Body)
+			if err != nil {
+				return err
+			}
+
+			return nil
+		},
+	)
+
+	fmt.Println(body)
+
+[next examples](https://github.com/avast/retry-go/tree/master/examples)
+
+
+SEE ALSO
+
+* [giantswarm/retry-go](https://github.com/giantswarm/retry-go) - slightly complicated interface.
+
+* [sethgrid/pester](https://github.com/sethgrid/pester) - only http retry for http calls with retries and backoff
+
+* [cenkalti/backoff](https://github.com/cenkalti/backoff) - Go port of the exponential backoff algorithm from Google's HTTP Client Library for Java. Really complicated interface.
+
+* [rafaeljesus/retry-go](https://github.com/rafaeljesus/retry-go) - looks good, slightly similar as this package, don't have 'simple' `Retry` method
+
+* [matryer/try](https://github.com/matryer/try) - very popular package, nonintuitive interface (for me)
+
+BREAKING CHANGES
+
+1.0.2 -> 2.0.0
+
+* argument of `retry.Delay` is final delay (no multiplication by `retry.Units` anymore)
+
+* function `retry.Units` are removed
+
+* [more about this breaking change](https://github.com/avast/retry-go/issues/7)
+
+
+0.3.0 -> 1.0.0
+
+* `retry.Retry` function are changed to `retry.Do` function
+
+* `retry.RetryCustom` (OnRetry) and `retry.RetryCustomWithOpts` functions are now implement via functions produces Options (aka `retry.OnRetry`)
+
+
+*/
+package retry
+
+import (
+	"fmt"
+	"strings"
+	"time"
+)
+
+// Function signature of retryable function
+type RetryableFunc func() error
+
+var (
+	DefaultAttempts      = uint(10)
+	DefaultDelay         = 100 * time.Millisecond
+	DefaultMaxJitter     = 100 * time.Millisecond
+	DefaultOnRetry       = func(n uint, err error) {}
+	DefaultRetryIf       = IsRecoverable
+	DefaultDelayType     = CombineDelay(BackOffDelay, RandomDelay)
+	DefaultLastErrorOnly = false
+)
+
+func Do(retryableFunc RetryableFunc, opts ...Option) error {
+	var n uint
+
+	//default
+	config := &Config{
+		attempts:      DefaultAttempts,
+		delay:         DefaultDelay,
+		maxJitter:     DefaultMaxJitter,
+		onRetry:       DefaultOnRetry,
+		retryIf:       DefaultRetryIf,
+		delayType:     DefaultDelayType,
+		lastErrorOnly: DefaultLastErrorOnly,
+	}
+
+	//apply opts
+	for _, opt := range opts {
+		opt(config)
+	}
+
+	var errorLog Error
+	if !config.lastErrorOnly {
+		errorLog = make(Error, config.attempts)
+	} else {
+		errorLog = make(Error, 1)
+	}
+
+	lastErrIndex := n
+	for n < config.attempts {
+		err := retryableFunc()
+
+		if err != nil {
+			errorLog[lastErrIndex] = unpackUnrecoverable(err)
+
+			if !config.retryIf(err) {
+				break
+			}
+
+			config.onRetry(n, err)
+
+			// if this is last attempt - don't wait
+			if n == config.attempts-1 {
+				break
+			}
+
+			delayTime := config.delayType(n, config)
+			if config.maxDelay > 0 && delayTime > config.maxDelay {
+				delayTime = config.maxDelay
+			}
+			time.Sleep(delayTime)
+		} else {
+			return nil
+		}
+
+		n++
+		if !config.lastErrorOnly {
+			lastErrIndex = n
+		}
+	}
+
+	if config.lastErrorOnly {
+		return errorLog[lastErrIndex]
+	}
+	return errorLog
+}
+
+// Error type represents list of errors in retry
+type Error []error
+
+// Error method return string representation of Error
+// It is an implementation of error interface
+func (e Error) Error() string {
+	logWithNumber := make([]string, lenWithoutNil(e))
+	for i, l := range e {
+		if l != nil {
+			logWithNumber[i] = fmt.Sprintf("#%d: %s", i+1, l.Error())
+		}
+	}
+
+	return fmt.Sprintf("All attempts fail:\n%s", strings.Join(logWithNumber, "\n"))
+}
+
+func lenWithoutNil(e Error) (count int) {
+	for _, v := range e {
+		if v != nil {
+			count++
+		}
+	}
+
+	return
+}
+
+// WrappedErrors returns the list of errors that this Error is wrapping.
+// It is an implementation of the `errwrap.Wrapper` interface
+// in package [errwrap](https://github.com/hashicorp/errwrap) so that
+// `retry.Error` can be used with that library.
+func (e Error) WrappedErrors() []error {
+	return e
+}
+
+type unrecoverableError struct {
+	error
+}
+
+// Unrecoverable wraps an error in `unrecoverableError` struct
+func Unrecoverable(err error) error {
+	return unrecoverableError{err}
+}
+
+// IsRecoverable checks if error is an instance of `unrecoverableError`
+func IsRecoverable(err error) bool {
+	_, isUnrecoverable := err.(unrecoverableError)
+	return !isUnrecoverable
+}
+
+func unpackUnrecoverable(err error) error {
+	if unrecoverable, isUnrecoverable := err.(unrecoverableError); isUnrecoverable {
+		return unrecoverable.error
+	}
+
+	return err
+}


### PR DESCRIPTION
This adds a conditional, retry with exponential backoff to the CreateAccessKey request, to handle specific errors that may be recoverable with a retry, to address InvalidClientTokenID errors that appear under load in some cases.

It also removes a duplicate setting of account state:

The `RotateIAMAccessKeys` function called `utils.SetAccountStatus` to set the account to failed if creating a new IAM user access key failed, but if that function returns an error to `BuildIAMUser`, `BuildIAMUser` will return an error to the reconcile loop, which also attempts to set the state to failed.

This removes the duplicate from `RotateIAMAccess Keys`, and reformats the error log message that is generated to make use of the searchable/indexable fields.

Signed-off-by: Christopher Collins <collins.christopher@gmail.com>
