### PR TITLE
Created more account and accountclaim conditions

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,6 @@ require (
 	github.com/evanphx/json-patch v4.5.0+incompatible // indirect
 	github.com/fsnotify/fsnotify v1.4.9 // indirect
 	github.com/go-logr/logr v0.1.0
-	github.com/go-openapi/spec v0.19.0
 	github.com/golang/mock v1.3.1-0.20190508161146-9fa652df1129
 	github.com/gregjones/httpcache v0.0.0-20190212212710-3befbb6ad0cc // indirect
 	github.com/onsi/ginkgo v1.12.0
@@ -18,6 +17,7 @@ require (
 	github.com/operator-framework/operator-sdk v0.8.1
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v0.9.4
+	github.com/rkt/rkt v1.30.0
 	github.com/spf13/pflag v1.0.3
 	github.com/stretchr/testify v1.5.1
 	golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 // indirect
@@ -25,7 +25,6 @@ require (
 	k8s.io/api v0.0.0-20190612125737-db0771252981
 	k8s.io/apimachinery v0.0.0-20190612125636-6a5db36e93ad
 	k8s.io/client-go v11.0.0+incompatible
-	k8s.io/kube-openapi v0.0.0-20190320154901-5e45bb682580
 	sigs.k8s.io/controller-runtime v0.1.12
 )
 

--- a/go.sum
+++ b/go.sum
@@ -311,6 +311,8 @@ github.com/prometheus/procfs v0.0.0-20190403104016-ea9eea638872/go.mod h1:TjEm7z
 github.com/prometheus/procfs v0.0.2 h1:6LJUbpNm42llc4HRCuvApCSWB/WfhuNo9K98Q9sNGfs=
 github.com/prometheus/procfs v0.0.2/go.mod h1:TjEm7ze935MbeOT/UhFTIMYKhuLP4wbCsTZCD3I8kEA=
 github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
+github.com/rkt/rkt v1.30.0 h1:ZI5RQtSibfjicSttV/HLiHuWreYClEJA2Or5XKAdJb0=
+github.com/rkt/rkt v1.30.0/go.mod h1:V5VwmwHe6x1kflB4uXl1XJwXTgRISEMt2lZE6m6lXd0=
 github.com/robfig/cron v0.0.0-20170526150127-736158dc09e1/go.mod h1:JGuDeoQd7Z6yL4zQhZ3OPEVHB7fL6Ka6skscFHfmt2k=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
 github.com/rogpeppe/go-charset v0.0.0-20180617210344-2471d30d28b4/go.mod h1:qgYeAmZ5ZIpBWTGllZSQnw97Dj+woV0toclVaRGI8pc=

--- a/pkg/apis/aws/v1alpha1/account_types.go
+++ b/pkg/apis/aws/v1alpha1/account_types.go
@@ -89,12 +89,24 @@ const (
 	AccountReady AccountConditionType = "Ready"
 	// AccountFailed is set when account creation has failed
 	AccountFailed AccountConditionType = "Failed"
+	// AccountCreationFailed is set during AWS account creation
+	AccountCreationFailed AccountConditionType = "AccountCreationFailed"
 	// AccountPending is set when account creation is pending
 	AccountPending AccountConditionType = "Pending"
 	// AccountPendingVerification is set when account creation is pending
 	AccountPendingVerification AccountConditionType = "PendingVerification"
 	// AccountReused is set when account is reused
 	AccountReused AccountConditionType = "Reused"
+	// AccountClientError is set when there was an issue getting a client
+	AccountClientError AccountConditionType = "AccountClientError"
+	// AccountAuthorizationError indicates an autherization error occured
+	AccountAuthorizationError AccountConditionType = "AuthorizationError"
+	// AccountAuthenticationError indicates an authentication error occured
+	AccountAuthenticationError AccountConditionType = "AuthenticationError"
+	// AccountUnhandledError indicates a error that isn't handled, probably a go error
+	AccountUnhandledError AccountConditionType = "UnhandledError"
+	// AccountInternalError is set when a serious internal issue arrises
+	AccountInternalError AccountConditionType = "InternalError"
 	// AccountInitializingRegions indicates we've kicked off the process of creating and terminating
 	// instances in all supported regions
 	AccountInitializingRegions = "InitializingRegions"
@@ -137,7 +149,21 @@ func init() {
 
 //IsFailed returns true if an account is in a failed state
 func (a *Account) IsFailed() bool {
-	return a.Status.State == string(AccountFailed)
+	failedStates := [7]string{
+		string(AccountFailed),
+		string(AccountCreationFailed),
+		string(AccountClientError),
+		string(AccountAuthorizationError),
+		string(AccountAuthenticationError),
+		string(AccountUnhandledError),
+		string(AccountInternalError),
+	}
+	for _, state := range failedStates {
+		if a.Status.State == state {
+			return true
+		}
+	}
+	return false
 }
 
 //HasState returns true if an account has a state set at all

--- a/pkg/apis/aws/v1alpha1/accountclaim_types.go
+++ b/pkg/apis/aws/v1alpha1/accountclaim_types.go
@@ -66,6 +66,14 @@ const (
 	AccountUnclaimed AccountClaimConditionType = "Unclaimed"
 	// BYOCAWSAccountInUse is set when a BYOC AWS Account is in use
 	BYOCAWSAccountInUse AccountClaimConditionType = "BYOCAWSAccountInUse"
+	// ClientError is set when an Error regarding the client occured
+	ClientError AccountClaimConditionType = "ClientError"
+	// AuthenticationFailed is set when we get an AWS error from STS role assumption
+	AuthenticationFailed AccountClaimConditionType = "AuthenticationFailed"
+	// InvalidAccountClaim is set when the account claim CR is missing required values
+	InvalidAccountClaim AccountClaimConditionType = "InvalidAccountClaim"
+	// InternalError is set when a serious internal issue arrises
+	InternalError AccountClaimConditionType = "InternalError"
 )
 
 // ClaimStatus is a valid value from AccountClaim.Status

--- a/pkg/apis/aws/v1alpha1/shared_types.go
+++ b/pkg/apis/aws/v1alpha1/shared_types.go
@@ -112,6 +112,12 @@ var ErrChildNotFound = errors.New("ChildNotFoundInOU")
 // ErrUnexpectedValue indicates that a given variable has an unespected nil value
 var ErrUnexpectedValue = errors.New("UnexpectedValue")
 
+// ErrInvalidToken indiacates an invalid token
+var ErrInvalidToken = errors.New("InvalidClientTokenId")
+
+// ErrAccessDenied indicates an AWS error from an API call
+var ErrAccessDenied = errors.New("AuthorizationError")
+
 // Shared variables
 
 // UIDLabel is the string for the uid label on AWS Federated Account Access CRs

--- a/pkg/awsclient/iam.go
+++ b/pkg/awsclient/iam.go
@@ -102,7 +102,7 @@ func CheckIAMUserExists(reqLogger logr.Logger, client Client, userName string) (
 					invalidTokenMsg := fmt.Sprintf("Invalid Token error from AWS when attempting get IAM user %s, trying again", userName)
 					reqLogger.Info(invalidTokenMsg)
 					if i == 10 {
-						return false, nil, err
+						return false, nil, awsv1alpha1.ErrInvalidToken
 					}
 				case "AccessDenied":
 					checkUserMsg := fmt.Sprintf("AWS Error while checking IAM user %s exists, trying again", userName)
@@ -113,7 +113,7 @@ func CheckIAMUserExists(reqLogger logr.Logger, client Client, userName string) (
 					}
 				default:
 					utils.LogAwsError(reqLogger, "checkIAMUserExists: Unexpected AWS Error when checking IAM user exists", nil, err)
-					return false, nil, err
+					return false, nil, awsv1alpha1.ErrAccessDenied
 				}
 				time.Sleep(time.Duration(time.Duration(i*5) * time.Second))
 			} else {

--- a/pkg/controller/accountclaim/accountclaim_controller.go
+++ b/pkg/controller/accountclaim/accountclaim_controller.go
@@ -226,7 +226,6 @@ func (r *ReconcileAccountClaim) Reconcile(request reconcile.Request) (reconcile.
 			waitMsg := fmt.Sprintf("%s is not Ready yet requeuing in %d seconds", byocAccount.Name, waitPeriod)
 			reqLogger.Info(waitMsg)
 			return reconcile.Result{RequeueAfter: time.Second * waitPeriod}, nil
-
 		}
 
 		if byocAccount.Status.State == string(awsv1alpha1.AccountReady) && accountClaim.Status.State != awsv1alpha1.ClaimStatusReady {

--- a/pkg/controller/utils/status.go
+++ b/pkg/controller/utils/status.go
@@ -18,3 +18,17 @@ func SetAccountStatus(awsAccount *awsv1alpha1.Account, message string, ctype aws
 	)
 	awsAccount.Status.State = state
 }
+
+// SetAccountClaimStatus sets the condition and state of an accountClaim
+func SetAccountClaimStatus(awsAccountClaim *awsv1alpha1.AccountClaim, message string, reason string, ctype awsv1alpha1.AccountClaimConditionType, state awsv1alpha1.ClaimStatus) {
+	awsAccountClaim.Status.Conditions = SetAccountClaimCondition(
+		awsAccountClaim.Status.Conditions,
+		ctype,
+		corev1.ConditionTrue,
+		reason,
+		message,
+		UpdateConditionNever,
+		awsAccountClaim.Spec.BYOC,
+	)
+	awsAccountClaim.Status.State = state
+}


### PR DESCRIPTION
Each existing code path that leads to a failed account has a new, representative condition with a descriptive TYPE, REASON and MESSAGE.

Card -> https://issues.redhat.com/browse/OSD-5396