### PR TITLE
Updates predeploy step and cleans operator

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,13 +67,14 @@ create-account: check-aws-account-id-env
 .PHONY: delete-account
 delete-account:
 	# Delete Account
-	test/integration/api/delete_account.sh
+	test/integration/api/delete_account.sh || true
 	# Delete Secrets
 	test/integration/api/delete_account_secrets.sh
 
 # Test Account creation
 .PHONY: test-account-creation
-test-account-creation: create-account test-secrets delete-account
+test-account-creation: delete-account create-account test-secrets
+	test/integration/api/delete_account.sh || true
 
 # Create account claim namespace
 .PHONY: create-accountclaim-namespace
@@ -291,12 +292,8 @@ test-secrets:
 
 # Deploy the operator secrets, CRDs and namesapce.
 .PHONY: deploy-aws-account-operator-credentials
-deploy-aws-account-operator-credentials: check-aws-credentials
-# Base64 Encode the AWS Credentials
-	$(eval ID=$(shell echo -n ${OPERATOR_ACCESS_KEY_ID} | base64 ))
-	$(eval KEY=$(shell echo -n ${OPERATOR_SECRET_ACCESS_KEY} | base64))
-# Create the aws-account-operator-credentials secret
-	@oc process --local -p OPERATOR_ACCESS_KEY_ID=${ID} -p OPERATOR_SECRET_ACCESS_KEY=${KEY} -p OPERATOR_NAMESPACE=aws-account-operator -f hack/templates/aws.managed.openshift.io_v1alpha1_aws_account_operator_credentials.tmpl | oc apply -f -
+deploy-aws-account-operator-credentials: 
+	hack/scripts/set_operator_credentials.sh osd-staging-1
 
 .PHONY: predeploy-aws-account-operator
 predeploy-aws-account-operator:
@@ -358,4 +355,13 @@ test-aws-ou-logic: check-ou-mapping-configmap-env create-accountclaim-namespace 
 
 #s Test all
 .PHONY: test-all
-test-all: lint test test-account-creation test-ccs test-reuse test-awsfederatedaccountaccess test-awsfederatedrole test-aws-ou-logic
+test-all: lint clean-operator test test-account-creation test-ccs test-reuse test-awsfederatedaccountaccess test-awsfederatedrole test-aws-ou-logic 
+
+.PHONY: clean-operator
+clean-operator: 
+	$(MAKE) delete-accountclaim-namespace || true
+	$(MAKE) delete-ccs-namespace || true
+	$(MAKE) delete-ccs-2-namespace || true
+	oc delete accounts --all -n ${NAMESPACE}
+	oc delete awsfederatedaccountaccess --all -n ${NAMESPACE}
+	oc delete awsfederatedrole --all -n ${NAMESPACE}

--- a/hack/scripts/set_operator_credentials.sh
+++ b/hack/scripts/set_operator_credentials.sh
@@ -16,8 +16,8 @@ if [ -z "$rawCredentials" ]; then
   exit 2
 fi
 
-export OPERATOR_ACCESS_KEY_ID="$(awk -F " " '($1=="aws_access_key_id") {print $3}' <<< "$rawCredentials")"
-export OPERATOR_SECRET_ACCESS_KEY="$(awk -F " " '($1=="aws_secret_access_key") {print $3}' <<< "$rawCredentials")"
+ID="$(awk -F " " '($1=="aws_access_key_id") {printf "%s", $3}' <<< "$rawCredentials" | base64)"
+SECRET="$(awk -F " " '($1=="aws_secret_access_key") {printf "%s", $3}' <<< "$rawCredentials" | base64)"
 
 echo "Deploying AWS Account Operator Credentials using AWS Profile $profile"
-make deploy-aws-account-operator-credentials
+oc process -p OPERATOR_ACCESS_KEY_ID=${ID} -p OPERATOR_SECRET_ACCESS_KEY=${SECRET} -p OPERATOR_NAMESPACE=aws-account-operator -f hack/templates/aws_v1alpha1_aws_account_operator_credentials.tmpl | oc apply -f - 


### PR DESCRIPTION
This PR updates the Makefile to fix the predeploy step so that it works
with your downloaded AWS Profiles, and also adds a clean step to the
make test-all step so that the tests won't be impacted by any dangling
resources.

Satisfies [OSD-5401](https://issues.redhat.com/browse/OSD-5401)