### PR TITLE
Unifies CCS and Non-CCS account naming conventions

### DIFF
--- a/pkg/controller/account/account_controller.go
+++ b/pkg/controller/account/account_controller.go
@@ -297,19 +297,23 @@ func (r *ReconcileAccount) Reconcile(request reconcile.Request) (reconcile.Resul
 			return reconcile.Result{}, nil
 		}
 
-		var roleToAssume string
-		var iamUserUHC = iamUserNameUHC
-		var iamUserSRE = iamUserNameSRE
-
-		if currentAcctInstance.IsBYOC() {
-			// Use the same ID applied to the account name for IAM usernames
-			currentAccInstanceID := currentAcctInstance.Labels[awsv1alpha1.IAMUserIDLabel]
-			iamUserUHC = fmt.Sprintf("%s-%s", iamUserNameUHC, currentAccInstanceID)
-			iamUserSRE = fmt.Sprintf("%s-%s", iamUserNameSRE, currentAccInstanceID)
-			roleToAssume = fmt.Sprintf("%s-%s", byocRole, currentAccInstanceID)
-		} else {
-			roleToAssume = awsv1alpha1.AccountOperatorIAMRole
+		// Set IAMUserIDLabel if not there, and requeue
+		if !utils.AccountCRHasIAMUserIDLabel(currentAcctInstance) {
+			utils.AddLabels(
+				currentAcctInstance,
+				utils.GenerateLabel(
+					awsv1alpha1.IAMUserIDLabel,
+					utils.GenerateShortUID(),
+				),
+			)
+			return reconcile.Result{Requeue: true}, r.Client.Update(context.TODO(), currentAcctInstance)
 		}
+
+		currentAccInstanceID := currentAcctInstance.Labels[awsv1alpha1.IAMUserIDLabel]
+		// Use the same ID applied to the account name for IAM usernames
+		iamUserUHC := fmt.Sprintf("%s-%s", iamUserNameUHC, currentAccInstanceID)
+		iamUserSRE := fmt.Sprintf("%s-%s", iamUserNameSRE, currentAccInstanceID)
+		roleToAssume := getAssumeRole(currentAcctInstance)
 
 		awsAssumedRoleClient, creds, err := r.assumeRole(reqLogger, currentAcctInstance, awsSetupClient, roleToAssume, ccsRoleID)
 		if err != nil {
@@ -912,6 +916,16 @@ func (r *ReconcileAccount) setAccountClaimError(reqLogger logr.Logger, currentAc
 func matchSubstring(roleID, role string) (bool, error) {
 	matched, err := regexp.MatchString(roleID, role)
 	return matched, err
+}
+
+func getAssumeRole(c *awsv1alpha1.Account) string {
+	// If the account is a CCS account, return the CCS role
+	if c.IsBYOC() {
+		return fmt.Sprintf("%s-%s", byocRole, c.Labels[awsv1alpha1.IAMUserIDLabel])
+	}
+
+	// Else return the default role
+	return awsv1alpha1.AccountOperatorIAMRole
 }
 
 func getBuildIAMUserErrorReason(err error) (string, awsv1alpha1.AccountConditionType) {

--- a/pkg/controller/account/account_controller_test.go
+++ b/pkg/controller/account/account_controller_test.go
@@ -22,6 +22,7 @@ func newTestAccountBuilder() *testAccountBuilder {
 		acct: awsv1alpha1.Account{
 			TypeMeta: metav1.TypeMeta{},
 			ObjectMeta: metav1.ObjectMeta{
+				Labels:     map[string]string{},
 				Finalizers: []string{},
 				CreationTimestamp: metav1.Time{
 					Time: time.Now().Add(-(5 * time.Minute)), // default tests to 5 minute old acct
@@ -75,6 +76,12 @@ func (t *testAccountBuilder) WithDeletionTimeStamp(timestamp time.Time) *testAcc
 // Add finalizers
 func (t *testAccountBuilder) WithFinalizers(finalizers []string) *testAccountBuilder {
 	t.acct.ObjectMeta.Finalizers = finalizers
+	return t
+}
+
+// Add labels
+func (t *testAccountBuilder) WithLabels(labels map[string]string) *testAccountBuilder {
+	t.acct.ObjectMeta.Labels = labels
 	return t
 }
 
@@ -953,6 +960,40 @@ func TestAccountIsUnclaimedAndCreating(t *testing.T) {
 			test.name,
 			func(t *testing.T) {
 				result := test.acct.acct.IsUnclaimedAndIsCreating()
+				if result != test.expected {
+					t.Error(
+						"for account:", test.acct,
+						"expected", test.expected,
+						"got", result,
+					)
+				}
+			},
+		)
+	}
+}
+
+func TestGetAssumeRole(t *testing.T) {
+	tests := []struct {
+		name     string
+		expected string
+		acct     *testAccountBuilder
+	}{
+		{
+			name:     "Get role for BYOC Account",
+			acct:     newTestAccountBuilder().BYOC(true).WithLabels(map[string]string{awsv1alpha1.IAMUserIDLabel: "xxxxx"}),
+			expected: fmt.Sprintf("%s-%s", byocRole, "xxxxx"),
+		},
+		{
+			name:     "Get role for Non-BYOC Account",
+			acct:     newTestAccountBuilder(),
+			expected: awsv1alpha1.AccountOperatorIAMRole,
+		},
+	}
+	for _, test := range tests {
+		t.Run(
+			test.name,
+			func(t *testing.T) {
+				result := getAssumeRole(&test.acct.acct)
 				if result != test.expected {
 					t.Error(
 						"for account:", test.acct,

--- a/pkg/controller/accountclaim/reuse.go
+++ b/pkg/controller/accountclaim/reuse.go
@@ -86,8 +86,8 @@ func (r *ReconcileAccountClaim) finalizeAccountClaim(reqLogger logr.Logger, acco
 		return err
 	}
 
-	// Remove IAM user we'll remove the IAM user for CCS
-	if utils.AccountCRHasIAMUserIDLabel(reusedAccount) && accountClaim.Spec.BYOC {
+	// Remove IAM user we'll remove the IAM user
+	if utils.AccountCRHasIAMUserIDLabel(reusedAccount) {
 		err = r.cleanUpIAM(reqLogger, awsClient, reusedAccount, accountClaim)
 		if err != nil {
 			reqLogger.Error(err, "Failed to delete IAM user during finalizer cleanup")

--- a/pkg/controller/utils/utils.go
+++ b/pkg/controller/utils/utils.go
@@ -134,6 +134,12 @@ func AddFinalizer(object metav1.Object, finalizer string) {
 	object.SetFinalizers(finalizers.List())
 }
 
+// AddLabels adds a map of labels to an object
+func AddLabels(object metav1.Object, labels map[string]string) {
+	existingLabels := object.GetLabels()
+	object.SetLabels(JoinLabelMaps(labels, existingLabels))
+}
+
 // LogAwsError formats and logs aws error and returns if err was an awserr
 func LogAwsError(logger logr.Logger, errMsg string, customError error, err error) {
 	if aerr, ok := err.(awserr.Error); ok {


### PR DESCRIPTION
This change updates non-CCS accounts to use the same naming convention as the CCS accounts for the OSDManagedAdmin and OSDManagedAdminSRE usernames, appending the IAMUserIDLabel from the account.

REF: [OSD-5393 - Update non-CCS account management process to unify naming standards with CCS](https://issues.redhat.com/browse/OSD-5393)

Signed-off-by: Christopher Collins <collins.christopher@gmail.com>
