### PR TITLE
[create_image_bundle] query app-interface instead of gitlab

### DIFF
--- a/hack/app_sre_create_image_catalog.sh
+++ b/hack/app_sre_create_image_catalog.sh
@@ -29,9 +29,9 @@ if [[ "$REMOVE_UNDEPLOYED" == true ]]; then
     # this will need to be modified if at any point we move to a canary like deployment
     # where not all environments are deployed with the same operator version
     DEPLOYED_HASH=$(
-        curl -s -H "Authorization: Basic $(echo ${APP_INTERFACE_USERNAME}:${APP_INTERFACE_PASSWORD} | base64)" \
+        curl -s -H "Authorization: Basic $(echo -n ${APP_INTERFACE_USERNAME}:${APP_INTERFACE_PASSWORD} | base64)" \
             -g "https://${APP_INTERFACE_BASE_URL}/graphql?query={saas_files:saas_files_v1{name,resourceTemplates{name,targets{namespace{environment{name,labels}},ref}}}}" | \
-            jq -r ".data.saas_files[] | select(.name==\"saas-${_OPERATOR_NAME}\") | .resourceTemplates[].targets[] | select(.namespace.environment.labels | contains('\"type\":\"production\"')) | .ref" | \
+            jq -r '.data.saas_files[] | select(.name=="saas-'${_OPERATOR_NAME}'") | .resourceTemplates[].targets[] | select(.namespace.environment.labels | contains("\"type\":\"production\"")) | .ref' | \
             uniq
     )
 


### PR DESCRIPTION
This PR introduces a new way to get the deployed hash - by querying the graphql endpoint of app-interface.

This will allow us to decouple the create_image_bundle script logic from the saas file structure in app-interface (the API should remain consistent).