### PR TITLE
Fix `make coverage`

### DIFF
--- a/test/integration/issue27333.go
+++ b/test/integration/issue27333.go
@@ -1,0 +1,9 @@
+package federatedaccesstesting
+
+/*
+This file exists to work around https://github.com/golang/go/issues/27333
+
+Without it, `make coverage` will fail with:
+
+go build github.com/openshift/aws-account-operator/test/integration: no non-test Go files in /home/efried/go/src/github.com/openshift/aws-account-operator/test/integration
+*/


### PR DESCRIPTION
Adds a workaround for https://github.com/golang/go/issues/27333 to make `make coverage` work.