### PR TITLE
Add CloudWatchReadOnlyAccess managed policy to Read only users

### DIFF
--- a/deploy/crds/aws.managed.openshift.io_v1alpha1_awsfederatedrole_readonly_cr.yaml
+++ b/deploy/crds/aws.managed.openshift.io_v1alpha1_awsfederatedrole_readonly_cr.yaml
@@ -24,3 +24,4 @@ spec:
    - "AmazonEC2ReadOnlyAccess"
    - "AmazonS3ReadOnlyAccess"
    - "IAMReadOnlyAccess"
+   - "CloudWatchReadOnlyAccess"

--- a/hack/olm-registry/olm-artifacts-template.yaml
+++ b/hack/olm-registry/olm-artifacts-template.yaml
@@ -237,3 +237,4 @@ objects:
     - "AmazonEC2ReadOnlyAccess"
     - "AmazonS3ReadOnlyAccess"
     - "IAMReadOnlyAccess"
+    - "CloudWatchReadOnlyAccess"


### PR DESCRIPTION
related to https://issues.redhat.com/browse/OSD-6671

OCM users use the AWS Infrastructure Access feature to gain access to the cluster's AWS account. They can either choose read-only or network-mgmt roles.

To enable OSD users to properly use the new Log Forwarding feature, it is expected that users can go to the cluster's AWS account and get the logs from there. When trying to do that currently, a user gets a permission error (`not
 authorized to perform: logs:DescribeLogGroups`).

This PR adds the `CloudWatchReadOnlyAccess` managed policy to the Read only access policy.