### PR TITLE
Updates operator to have STS Mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,12 +15,13 @@ This Quick Start assumes that you are working on a team that already has AWS Acc
 First, set up your required environment variables:
 
 ```bash
-export AWS_PAGER=
-export FORCE_DEV_MODE=local
-export OSD_STAGING_1_AWS_ACCOUNT_ID=
-export OSD_STAGING_2_AWS_ACCOUNT_ID=
-export OSD_STAGING_1_OU_ROOT_ID=
-export OSD_STAGING_1_OU_BASE_ID=
+export AWS_PAGER= # This is set so that it doesn't page out to less and block integration testing
+export FORCE_DEV_MODE=local # This flags the operator for local development for some code paths
+export OSD_STAGING_1_AWS_ACCOUNT_ID= # Your assigned osd-staging-1 account ID
+export OSD_STAGING_2_AWS_ACCOUNT_ID= # Your assigned osd-staging-2 account ID
+export OSD_STAGING_1_OU_ROOT_ID= # Your assigned osd-staging-1 OU Root ID
+export OSD_STAGING_1_OU_BASE_ID= # Your assigned osd-staging-1 OU Base ID
+export STS_ROLE_ARN= # A role you create in your osd-staging-2 account with minimal STS permissions
 ```
 
 [direnv](https://direnv.net) is what some team members use, and you can add the above block (with variables filled in) into a `.envrc` file (make sure `.envrc` is in your global git ignore as well) and upon entry to the `aws-account-operator` folder the env vars inside the file will be loaded automatically, and unset when you leave the folder.

--- a/deploy/crds/aws.managed.openshift.io_accountclaims_crd.yaml
+++ b/deploy/crds/aws.managed.openshift.io_accountclaims_crd.yaml
@@ -97,6 +97,10 @@ spec:
                 - id
                 - name
               type: object
+            manualSTSMode:
+              type: boolean
+            stsRoleARN:
+              type: string
           required:
             - accountLink
             - aws

--- a/deploy/crds/aws.managed.openshift.io_accounts_crd.yaml
+++ b/deploy/crds/aws.managed.openshift.io_accounts_crd.yaml
@@ -66,6 +66,8 @@ spec:
                 - id
                 - name
               type: object
+            manualSTSMode:
+              type: boolean
           required:
             - awsAccountID
             - iamUserSecret

--- a/docs/1.0-Installation.md
+++ b/docs/1.0-Installation.md
@@ -1,5 +1,13 @@
 # 1.0 Installation
 
+### 1.0.1 - Glossary
+
+Terms used in this guide and what they mean for this guide:
+
+* Payer Account - AWS Organizations give you a "unified bill" so to speak under a single account. Sub accounts are created under this "Payer Account", which is the highest-level account in this organization. SREs all should also have an IAM user with credentials on each payer account, which has AssumeRole Permissions as administrator into each of these sub-accounts.
+* Jump Role - Using AWS Assume-Role Chaining, a Jump Role is an intermediary role that sits between a given IAM user and a customer's access role, providing a single point of entry.
+* Access Role - A role inside the cluster's account that we assume to perform tasks.
+
 ## 1.1 - Prerequisites
 
 ### 1.1.1 - IAM User and Secret
@@ -48,7 +56,99 @@ OPERATOR_SECRET_ACCESS_KEY
 
 Alternatively, if you have the credentials stored in your `~/.aws/credentials` file, you can use the script in `scripts/set_operator_credentials.sh` to create the secret from that profile: `./scripts/set_operator_credentials.sh my-aws-profile`
 
-### 1.1.2 Config Map
+### 1.1.2 AWS Accounts
+
+As you're working on the operator you should have two accounts dedicated for your use of this operator, under each of the osd-staging payer accounts.  Work with your manager or functional team lead to figure out what these account numbers are and save them, you'll need them later.
+
+### 1.1.3 STS Roles
+
+To run the operator tests for STS mode you will need to create two roles &mdash; one in each of the AWS accounts you have been assigned.  The name of these roles doesn't matter when you create it, however you will need to know the ARN of both in order to configure the operator to use them.
+
+#### 1.1.3.1 - Jump Role
+
+The Jump Role will be a simulation of the role that we use as a bastion of sorts. For the STS Architecture, we have an IAM user that assumes a specific role in a specific account, and then using that role they can assume role into the cluster's account in order to run operations as necessary.
+
+You will need to create this jump role in the first osd-staging aws account assigned to you. You will need to add your Payer Account IAM user credentials as the the Principal in the Trust Relationship. This user should also be the same user that you use to create the AWS Account Operator credentials.
+
+The Jump role should only require the permissions to assume-roles.  No other permissions should be necessary. You will probably need to create the IAM policy first before the Role.
+
+Example Assume Role Policy:
+```
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Action": "sts:AssumeRole",
+            "Resource": "*"
+        }
+    ]
+}
+```
+
+Example Trust Relationship for role:
+```
+{
+    "Version": "2012-10-17",
+        "Statement": [
+        {
+            "Effect": "Allow",
+            "Principal": {
+                "AWS": "arn:aws:iam::[payer-account-id]:user/[your-username]"
+            },
+            "Action": "sts:AssumeRole",
+            "Condition": {}
+        }
+        ]
+}
+```
+
+You will need to put the ARN for this jump role into the Operator Config Map created later.
+
+#### 1.1.3.2 - Access Role
+
+The Access Role will be a simulation of a role on a customer's account that gives us access to initalize the regions and initialize a cluster.  On external customer accounts this is assumed to be a very locked-down role with ONLY the necessary permissions needed to run the operator or install the cluster resources. Minimal permissions required for the role are provided below.
+
+Example Trust Relationship:
+```
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": "arn:aws:iam::[jump-role-account-id]:role/[jump-role-name]"
+      },
+      "Action": "sts:AssumeRole",
+      "Condition": {}
+    }
+  ]
+}
+```
+
+Example minimal permissions Policy Document
+```
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "ec2:RunInstances",
+        "ec2:TerminateInstances",
+        "ec2:DescribeInstanceStatus",
+        "ec2:CreateTags",
+        "ec2:DeleteTags"
+      ],
+      "Resource": "*"
+    }
+  ]
+}
+```
+
+You will need to put the ARN for this access role into your environment in order for this to be used to create accountclaims within the make tests.
+
+### 1.1.3 Config Map
 
 The operator also needs a ConfigMap that has:
 
@@ -56,13 +156,15 @@ Account Limit: The soft limit of AWS Accounts which is the number compared again
 Base: Base OU ID to place accounts in when claimed
 Root: Root OU ID to create new OUs under
 
+
 ```json
 {
     "apiVersion": "v1",
     "data": {
         "account-limit": "4801",
         "base": "ou-0wd6-tmsbvahq",
-        "root": "r-0wd6"
+        "root": "r-0wd6",
+        "sts-jump-role": "[arn from the jump role created above]"
     },
     "kind": "ConfigMap",
     "metadata": {

--- a/hack/olm-registry/olm-artifacts-template.yaml
+++ b/hack/olm-registry/olm-artifacts-template.yaml
@@ -20,6 +20,8 @@ parameters:
   required: true
 - name: ACCOUNT_POOL_NAME
   required: true
+- name: STS_JUMP_ROLE
+  required: true
 
 objects:
 - apiVersion: operators.coreos.com/v1alpha1
@@ -59,6 +61,7 @@ objects:
     account-limit: "${ACCOUNT_LIMIT}"
     root: ${ROOT_OU_ID}
     base: ${BASE_OU_ID}
+    sts-jump-role: ${STS_JUMP_ROLE}
 
 - apiVersion: aws.managed.openshift.io/v1alpha1
   kind: AccountPool

--- a/hack/scripts/test_envs
+++ b/hack/scripts/test_envs
@@ -10,3 +10,6 @@ FED_USER=test-federated-user
 CCS_CLAIM_NAME=test-ccs
 CCS_NAMESPACE_NAME=test-ccs-namespace
 CCS_NAMESPACE_NAME_2=test-ccs-2-namespace
+STS_CLAIM_NAME=test-sts
+STS_NAMESPACE_NAME=test-sts-namespace
+STSMODE=false

--- a/hack/templates/aws.managed.openshift.io_v1alpha1_sts_accountclaim_cr.tmpl
+++ b/hack/templates/aws.managed.openshift.io_v1alpha1_sts_accountclaim_cr.tmpl
@@ -1,0 +1,30 @@
+apiVersion: v1
+kind: Template
+parameters:
+- name: NAME
+- name: NAMESPACE
+- name: STS_ACCOUNT_ID
+- name: STS_ROLE_ARN
+metadata:
+  name: test-aws-sts-accountclaim-template
+objects:
+- apiVersion: aws.managed.openshift.io/v1alpha1
+  kind: AccountClaim
+  metadata:
+    name: ${NAME}
+    namespace: ${NAMESPACE}
+  spec:
+    accountLink: ""
+    aws:
+      regions:
+      - name: us-east-1
+    awsCredentialSecret:
+      name: aws
+      namespace: ${NAMESPACE}
+    byoc: true
+    byocAWSAccountID: ${STS_ACCOUNT_ID}
+    legalEntity:
+      id: "111111"
+      name: ${NAME}
+    manualSTSMode: true
+    stsRoleARN: ${STS_ROLE_ARN}

--- a/pkg/apis/aws/v1alpha1/account_types.go
+++ b/pkg/apis/aws/v1alpha1/account_types.go
@@ -42,6 +42,7 @@ type AccountSpec struct {
 	// +optional
 	ClaimLinkNamespace string      `json:"claimLinkNamespace,omitempty"`
 	LegalEntity        LegalEntity `json:"legalEntity,omitempty"`
+	ManualSTSMode      bool        `json:"manualSTSMode,omitempty"`
 }
 
 // AccountStatus defines the observed state of Account

--- a/pkg/apis/aws/v1alpha1/accountclaim_types.go
+++ b/pkg/apis/aws/v1alpha1/accountclaim_types.go
@@ -22,6 +22,8 @@ type AccountClaimSpec struct {
 	BYOC                bool        `json:"byoc,omitempty"`
 	BYOCSecretRef       SecretRef   `json:"byocSecretRef,omitempty"`
 	BYOCAWSAccountID    string      `json:"byocAWSAccountID,omitempty"`
+	ManualSTSMode       bool        `json:"manualSTSMode,omitempty"`
+	STSRoleARN          string      `json:"stsRoleARN,omitempty"`
 }
 
 // AccountClaimStatus defines the observed state of AccountClaim

--- a/pkg/apis/aws/v1alpha1/zz_generated.openapi.go
+++ b/pkg/apis/aws/v1alpha1/zz_generated.openapi.go
@@ -439,6 +439,18 @@ func schema_pkg_apis_aws_v1alpha1_AccountClaimSpec(ref common.ReferenceCallback)
 							Format: "",
 						},
 					},
+					"manualSTSMode": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"boolean"},
+							Format: "",
+						},
+					},
+					"stsRoleARN": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"string"},
+							Format: "",
+						},
+					},
 				},
 				Required: []string{"legalEntity", "awsCredentialSecret", "aws", "accountLink"},
 			},
@@ -628,6 +640,12 @@ func schema_pkg_apis_aws_v1alpha1_AccountSpec(ref common.ReferenceCallback) comm
 					"legalEntity": {
 						SchemaProps: spec.SchemaProps{
 							Ref: ref("github.com/openshift/aws-account-operator/pkg/apis/aws/v1alpha1.LegalEntity"),
+						},
+					},
+					"manualSTSMode": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"boolean"},
+							Format: "",
 						},
 					},
 				},

--- a/pkg/controller/account/iam.go
+++ b/pkg/controller/account/iam.go
@@ -69,18 +69,12 @@ func (r *ReconcileAccount) CreateSecret(reqLogger logr.Logger, account *awsv1alp
 	return nil
 }
 
-// getStsCredentials returns STS credentials for the specified account ARN
+// getSTSCredentials returns STS credentials for the specified account ARN
 // Takes a logger, an awsClient, a role name to assume, and the target AWS account ID
-func getStsCredentials(reqLogger logr.Logger, client awsclient.Client, iamRoleName string, awsAccountID string) (*sts.AssumeRoleOutput, error) {
-	// Use the role session name to uniquely identify a session when the same role
-	// is assumed by different principals or for different reasons.
-	var roleSessionName = "awsAccountOperator"
+func getSTSCredentials(reqLogger logr.Logger, client awsclient.Client, roleArn string, roleSessionName string) (*sts.AssumeRoleOutput, error) {
 	// Default duration in seconds of the session token 3600. We need to have the roles policy
 	// changed if we want it to be longer than 3600 seconds
 	var roleSessionDuration int64 = 3600
-	// The role ARN made up of the account number and the role which is the default role name
-	// created in child accounts
-	var roleArn = fmt.Sprintf("arn:aws:iam::%s:role/%s", awsAccountID, iamRoleName)
 	reqLogger.Info(fmt.Sprintf("Creating STS credentials for AWS ARN: %s", roleArn))
 	// Build input for AssumeRole
 	assumeRoleInput := sts.AssumeRoleInput{

--- a/pkg/controller/accountclaim/reuse.go
+++ b/pkg/controller/accountclaim/reuse.go
@@ -46,6 +46,15 @@ func (r *ReconcileAccountClaim) finalizeAccountClaim(reqLogger logr.Logger, acco
 
 		return nil
 	}
+
+	// If the reused account is STS, then we don't have to clean up
+	if reusedAccount.Spec.ManualSTSMode {
+		err := r.client.Delete(context.TODO(), reusedAccount)
+		if err != nil {
+			reqLogger.Error(err, "Failed to delete STS account from accountclaim cleanup")
+		}
+	}
+
 	var awsClientInput awsclient.NewAwsClientInput
 
 	// Region comes from accountClaim


### PR DESCRIPTION
After some quick experimentation this PR adds "STSMode" to the operator. Fulfills [OSD-6555](https://issues.redhat.com/browse/OSD-6555)

This still depends on some upstream dependencies.

To test:
* Follow the instructions in the updated Install docs to create the jump role and access role.
    * Create the Jump Role and Policy
    * Create the Access Role and attach Admin policy
    * Update the aws-account-operator configmap
    * Add the required environment variable `STS_ROLE_ARN`
* I've found it's just easier to manually verify through the CLI you can use your payer-account user creds to assume role into the jump role, and then assume the access role.
* start the operator and run `make test-sts-accountclaim`

TODO/TO CARD:

- [x] We need to create the Jump roles and accounts (should we have more than one? one for Prod, one for staging, etc?)
- [x] We need to deploy the jump roles into the existing config maps
- [x] Ensure the CRDs get updated (is that done automatically or is that a manual step?)
- [x] Write an integration test for this (for `make test-all`)
- [x] There are some opportunities for refactoring in here