### PR TITLE
make predeploy work with kind cluster

### DIFF
--- a/hack/scripts/set_operator_credentials.sh
+++ b/hack/scripts/set_operator_credentials.sh
@@ -20,4 +20,4 @@ ID="$(awk -F " " '($1=="aws_access_key_id") {printf "%s", $3}' <<< "$rawCredenti
 SECRET="$(awk -F " " '($1=="aws_secret_access_key") {printf "%s", $3}' <<< "$rawCredentials" | base64)"
 
 echo "Deploying AWS Account Operator Credentials using AWS Profile $profile"
-oc process -p OPERATOR_ACCESS_KEY_ID=${ID} -p OPERATOR_SECRET_ACCESS_KEY=${SECRET} -p OPERATOR_NAMESPACE=aws-account-operator -f hack/templates/aws.managed.openshift.io_v1alpha1_aws_account_operator_credentials.tmpl | oc apply -f -
+oc process -p OPERATOR_ACCESS_KEY_ID=${ID} -p OPERATOR_SECRET_ACCESS_KEY=${SECRET} -p OPERATOR_NAMESPACE=aws-account-operator -f hack/templates/aws.managed.openshift.io_v1alpha1_aws_account_operator_credentials.tmpl --local -o yaml | oc apply -f -


### PR DESCRIPTION
Running `make predeploy`  with a `Kind` cluster in the background returns the following error:
```
hack/scripts/set_operator_credentials.sh osd-staging-1
Deploying AWS Account Operator Credentials using AWS Profile osd-staging-1
error: failed to read input object (not a Template?): unable to recognize "hack/templates/aws.managed.openshift.io_v1alpha1_aws_account_operator_credentials.tmpl": no matches for kind "Template" in version "template.openshift.io/v1"
error: no objects passed to apply
make: *** [deploy-aws-account-operator-credentials] Error 1
```

`Template` is an OpenShift concept and that's why it's not being found in `Kind`. A workaround that @rogbas suggested was to use `oc` to process a template in `local-mode`, and pipe the output to `oc apply`.

Based on @rogbas' recommendations, I updated the Makefile to make it work with `Kind `as well. 

PTAL
