### PR TITLE
Add  AWSServiceRoleForVPCTransitGateway AWS Managed Role To Network Mgmt Role

### DIFF
--- a/deploy/crds/aws.managed.openshift.io_v1alpha1_awsfederatedrole_networkmgmt_cr.yaml
+++ b/deploy/crds/aws.managed.openshift.io_v1alpha1_awsfederatedrole_networkmgmt_cr.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   roleDisplayName: Network management
   roleDescription: User can view all AWS resources, and can edit VPC related resources to enable services such as IPsec VPN and VPC peering.
-  # Custom policy definition 
+  # Custom policy definition
   awsCustomPolicy:
     name:  CustomerAdministratorAccess
     description: Description of CustomerAdministratorAccess
@@ -51,7 +51,7 @@ spec:
           - "ram:RejectResourceShareInvitation"
         resource:
           - "*"
-     
+
       # DNS Route Propagation
       - effect: Allow
         action:
@@ -62,7 +62,7 @@ spec:
           - "route53resolver:GetResolverRuleAssociation"
           - "route53resolver:ListResolverRuleAssociations"
           - "route53resolver:ListResolverRules"
-        resource: 
+        resource:
           - "*"
       - effect: Allow
         action:
@@ -90,7 +90,7 @@ spec:
           - "ec2:DeleteVpnConnection"
           - "ec2:EnableVgwRoutePropagation"
           - "ec2:DisableVgwRoutePropagation"
-        resource: 
+        resource:
           - "*"
 
       # AWS VPC Peering
@@ -143,4 +143,5 @@ spec:
   # list of  AWS managed
   awsManagedPolicies:
     - "AmazonEC2ReadOnlyAccess"
+    - "AWSServiceRoleForVPCTransitGateway"
 

--- a/hack/olm-registry/olm-artifacts-template.yaml
+++ b/hack/olm-registry/olm-artifacts-template.yaml
@@ -213,6 +213,7 @@ objects:
             - "arn:aws:ec2:*:*:vpn-gateway/*"
     awsManagedPolicies:
       - "AmazonEC2ReadOnlyAccess"
+      - "AWSServiceRoleForVPCTransitGateway"
 
 - apiVersion: aws.managed.openshift.io/v1alpha1
   kind: AWSFederatedRole


### PR DESCRIPTION
In order for hive accounts to create VPC attachmetns to Transit Gateways in external accounts, the above AWS managed role is required.

Reference:
https://docs.aws.amazon.com/vpc/latest/tgw/tgw-service-linked-roles.html