### PR TITLE
Add AWSServiceRoleForVPCTransitGateway Rules Directly

### DIFF
--- a/deploy/crds/aws.managed.openshift.io_v1alpha1_awsfederatedrole_networkmgmt_cr.yaml
+++ b/deploy/crds/aws.managed.openshift.io_v1alpha1_awsfederatedrole_networkmgmt_cr.yaml
@@ -32,6 +32,11 @@ spec:
           - "ec2:DeleteVpnConnectionRoute"
           - "ec2:ModifyVpcPeeringConnectionOptions"
           - "ec2:RejectVpcPeeringConnection"
+          - "ec2:CreateNetworkInterface"
+          - "ec2:DescribeNetworkInterface"
+          - "ec2:ModifyNetworkInterfaceAttribute"
+          - "ec2:DeleteNetworkInterface"
+          - "ec2:CreateNetworkInterfacePermission"
         resource:
           - "*"
 
@@ -143,5 +148,3 @@ spec:
   # list of  AWS managed
   awsManagedPolicies:
     - "AmazonEC2ReadOnlyAccess"
-    - "AWSServiceRoleForVPCTransitGateway"
-

--- a/hack/olm-registry/olm-artifacts-template.yaml
+++ b/hack/olm-registry/olm-artifacts-template.yaml
@@ -116,6 +116,11 @@ objects:
             - "ec2:RejectVpcPeeringConnection"
             - "ec2:DisableVgwRoutePropagation"
             - "ec2:EnableVgwRoutePropagation"
+            - "ec2:CreateNetworkInterface"
+            - "ec2:DescribeNetworkInterface"
+            - "ec2:ModifyNetworkInterfaceAttribute"
+            - "ec2:DeleteNetworkInterface"
+            - "ec2:CreateNetworkInterfacePermission"
             - "guardduty:GetDetector"
             - "guardduty:GetFindings"
             - "guardduty:GetFindingsStatistics"
@@ -213,7 +218,6 @@ objects:
             - "arn:aws:ec2:*:*:vpn-gateway/*"
     awsManagedPolicies:
       - "AmazonEC2ReadOnlyAccess"
-      - "AWSServiceRoleForVPCTransitGateway"
 
 - apiVersion: aws.managed.openshift.io/v1alpha1
   kind: AWSFederatedRole


### PR DESCRIPTION
Follow-up PR to https://github.com/openshift/aws-account-operator/pull/528 to add rules directly.

Reference: https://docs.aws.amazon.com/vpc/latest/tgw/tgw-service-linked-roles.html