### PR TITLE
Update deprecated operator-sdk commands 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -290,7 +290,7 @@ predeploy: predeploy-aws-account-operator deploy-aws-account-operator-credential
 
 .PHONY: deploy-local
 deploy-local:
-	@FORCE_DEV_MODE=local operator-sdk run --local --namespace=$(OPERATOR_NAMESPACE)
+	@FORCE_DEV_MODE=local operator-sdk run local --watch-namespace $(OPERATOR_NAMESPACE)
 
 .PHONY: deploy-cluster
 deploy-cluster: FORCE_DEV_MODE?=cluster

--- a/Makefile
+++ b/Makefile
@@ -273,7 +273,7 @@ test-secrets:
 
 # Deploy the operator secrets, CRDs and namesapce.
 .PHONY: deploy-aws-account-operator-credentials
-deploy-aws-account-operator-credentials: 
+deploy-aws-account-operator-credentials:
 	hack/scripts/set_operator_credentials.sh osd-staging-1
 
 .PHONY: predeploy-aws-account-operator
@@ -336,10 +336,10 @@ test-aws-ou-logic: check-ou-mapping-configmap-env create-accountclaim-namespace 
 
 #s Test all
 .PHONY: test-all
-test-all: lint clean-operator test test-account-creation test-ccs test-reuse test-awsfederatedaccountaccess test-awsfederatedrole test-aws-ou-logic 
+test-all: lint clean-operator test test-account-creation test-ccs test-reuse test-awsfederatedaccountaccess test-awsfederatedrole test-aws-ou-logic
 
 .PHONY: clean-operator
-clean-operator: 
+clean-operator:
 	$(MAKE) delete-accountclaim-namespace || true
 	$(MAKE) delete-ccs-namespace || true
 	$(MAKE) delete-ccs-2-namespace || true

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ OPERATOR_SECRET_ACCESS_KEY
 
 These only need to be set the first time you deploy the operator locally.  Then, run `make predeploy`.
 
-Then, you should be able to run `operator-sdk run local --watch-namespace aws-account-operator`, and you're up and running.
+Then, you should be able to run either `make deploy-local` or `operator-sdk run local --watch-namespace aws-account-operator`, and you're up and running.
 
 ## Testing
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ OPERATOR_SECRET_ACCESS_KEY
 
 These only need to be set the first time you deploy the operator locally.  Then, run `make predeploy`.
 
-Then, you should be able to run `operator-sdk run --local --namespace aws-account-operator`, and you're up and running.
+Then, you should be able to run `operator-sdk run local --watch-namespace aws-account-operator`, and you're up and running.
 
 ## Testing
 


### PR DESCRIPTION
The flag `--local` has been deprecated in the last release of operator-sdk (0.19.x) before 1.0 and we should use `run local` instead. Also, flag `--namespace` has been deprecated as well, and we should use `--watch-namespace` instead.

PTAL