### PR TITLE
Add TransitGateway Service-Linked Role Permissions

### DIFF
--- a/deploy/crds/aws.managed.openshift.io_v1alpha1_awsfederatedrole_networkmgmt_cr.yaml
+++ b/deploy/crds/aws.managed.openshift.io_v1alpha1_awsfederatedrole_networkmgmt_cr.yaml
@@ -23,6 +23,22 @@ spec:
           - "arn:aws:ec2:*:*:vpc/*"
           - "arn:aws:ec2:*:*:transit-gateway-attachment/*"
 
+      # AWS Transit Gateway Service Linked Role
+      - effect: Allow
+        action:
+          - "iam:CreateServiceLinkedRole"
+        resource:
+          - "arn:aws:iam::*:role/aws-service-role/transitgateway.amazonaws.com/AWSServiceRoleForVPCTransitGateway*"
+        condition:
+          StringLike:
+            iam:AWSServiceName: transitgateway.amazonaws.com
+      - effect: Allow
+        action:
+          - "iam:AttachRolePolicy"
+          - "iam:PutRolePolicy"
+        resource:
+          - "arn:aws:iam::*:role/aws-service-role/transitgateway.amazonaws.com/AWSServiceRoleForVPCTransitGateway*"
+
       # AWS EC2
       - effect: Allow
         action:
@@ -33,7 +49,6 @@ spec:
           - "ec2:ModifyVpcPeeringConnectionOptions"
           - "ec2:RejectVpcPeeringConnection"
           - "ec2:CreateNetworkInterface"
-          - "ec2:DescribeNetworkInterface"
           - "ec2:ModifyNetworkInterfaceAttribute"
           - "ec2:DeleteNetworkInterface"
           - "ec2:CreateNetworkInterfacePermission"

--- a/hack/olm-registry/olm-artifacts-template.yaml
+++ b/hack/olm-registry/olm-artifacts-template.yaml
@@ -117,14 +117,12 @@ objects:
             - "ec2:DisableVgwRoutePropagation"
             - "ec2:EnableVgwRoutePropagation"
             - "ec2:CreateNetworkInterface"
-            - "ec2:DescribeNetworkInterface"
             - "ec2:ModifyNetworkInterfaceAttribute"
             - "ec2:DeleteNetworkInterface"
             - "ec2:CreateNetworkInterfacePermission"
             - "guardduty:GetDetector"
             - "guardduty:GetFindings"
             - "guardduty:GetFindingsStatistics"
-            - "guardduty:GetFreeTrialStatistics"
             - "guardduty:GetIPSet"
             - "guardduty:GetInvitationsCount"
             - "guardduty:GetMasterAccount"
@@ -216,6 +214,20 @@ objects:
             - "arn:aws:ec2:*:*:vpn-connection/*"
             - "arn:aws:ec2:*:*:vpc-peering-connection/*"
             - "arn:aws:ec2:*:*:vpn-gateway/*"
+        - effect: Allow
+          action:
+            - "iam:CreateServiceLinkedRole"
+          resource:
+            - "arn:aws:iam::*:role/aws-service-role/transitgateway.amazonaws.com/AWSServiceRoleForVPCTransitGateway*"
+          condition:
+            StringLike:
+              iam:AWSServiceName: transitgateway.amazonaws.com
+        - effect: Allow
+          action:
+            - "iam:AttachRolePolicy"
+            - "iam:PutRolePolicy"
+          resource:
+            - "arn:aws:iam::*:role/aws-service-role/transitgateway.amazonaws.com/AWSServiceRoleForVPCTransitGateway*"
     awsManagedPolicies:
       - "AmazonEC2ReadOnlyAccess"
 


### PR DESCRIPTION
This adds additional permissions in order for service-linked roles to be created (necessary for creating vpc attachments to transit gateways).

Also removed invalid actions found during testing.

Ref: https://docs.aws.amazon.com/IAM/latest/UserGuide/using-service-linked-roles.html

