### PR TITLE
Ignore .envrc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -83,3 +83,6 @@ tags
 
 # Python venv directory in use by Boilerplate golang-osd-operator/ensure.sh
 .venv/*
+
+# used with direnv
+.envrc


### PR DESCRIPTION
`.envrc` is used with `direnv`.

PTAL