### PR TITLE
Allow ec2:CreateTags on transit-gateway-attachments

### DIFF
--- a/deploy/crds/aws.managed.openshift.io_v1alpha1_awsfederatedrole_networkmgmt_cr.yaml
+++ b/deploy/crds/aws.managed.openshift.io_v1alpha1_awsfederatedrole_networkmgmt_cr.yaml
@@ -159,6 +159,7 @@ spec:
           - "arn:aws:ec2:*:*:vpn-connection/*"
           - "arn:aws:ec2:*:*:vpc-peering-connection/*"
           - "arn:aws:ec2:*:*:vpn-gateway/*"
+          - "arn:aws:ec2:*:*:transit-gateway-attachment/*"
 
   # list of  AWS managed
   awsManagedPolicies:

--- a/hack/olm-registry/olm-artifacts-template.yaml
+++ b/hack/olm-registry/olm-artifacts-template.yaml
@@ -214,6 +214,7 @@ objects:
             - "arn:aws:ec2:*:*:vpn-connection/*"
             - "arn:aws:ec2:*:*:vpc-peering-connection/*"
             - "arn:aws:ec2:*:*:vpn-gateway/*"
+            - "arn:aws:ec2:*:*:transit-gateway-attachment/*"
         - effect: Allow
           action:
             - "iam:CreateServiceLinkedRole"


### PR DESCRIPTION
This will allow tags to be created/deleted for transit-gateway-attachments.

Related card: https://issues.redhat.com/browse/OSD-6748