### PR TITLE
Add Route53 VPC Zone Association Rules

### DIFF
--- a/deploy/crds/aws.managed.openshift.io_v1alpha1_awsfederatedrole_networkmgmt_cr.yaml
+++ b/deploy/crds/aws.managed.openshift.io_v1alpha1_awsfederatedrole_networkmgmt_cr.yaml
@@ -52,6 +52,7 @@ spec:
           - "ec2:ModifyNetworkInterfaceAttribute"
           - "ec2:DeleteNetworkInterface"
           - "ec2:CreateNetworkInterfacePermission"
+          - "ec2:DescribeVpcs"
         resource:
           - "*"
 
@@ -82,6 +83,8 @@ spec:
           - "route53resolver:GetResolverRuleAssociation"
           - "route53resolver:ListResolverRuleAssociations"
           - "route53resolver:ListResolverRules"
+          - "route53:AssociateVPCWithHostedZone"
+          - "route53:DisassociateVPCFromHostedZone"
         resource:
           - "*"
       - effect: Allow

--- a/hack/olm-registry/olm-artifacts-template.yaml
+++ b/hack/olm-registry/olm-artifacts-template.yaml
@@ -152,6 +152,8 @@ objects:
             - "route53resolver:GetResolverRuleAssociation"
             - "route53resolver:ListResolverRuleAssociations"
             - "route53resolver:ListResolverRules"
+            - "route53:AssociateVPCWithHostedZone"
+            - "route53:DisassociateVPCFromHostedZone"
             - "directconnect:*"
           resource:
             - "*"


### PR DESCRIPTION
Actions needed for PrivateLink and VPC to private zone associations.

https://issues.redhat.com/browse/OSD-6928

Ref: 
https://docs.aws.amazon.com/Route53/latest/APIReference/API_AssociateVPCWithHostedZone.html
https://github.com/openshift/hive/blob/master/docs/awsprivatelink.md#using-aws-private-link