### PR TITLE
Adds Managed Tags to AAO Created Resources

### DIFF
--- a/hack/olm-registry/olm-artifacts-template.yaml
+++ b/hack/olm-registry/olm-artifacts-template.yaml
@@ -67,6 +67,7 @@ objects:
     base: ${BASE_OU_ID}
     sts-jump-role: ${STS_JUMP_ROLE}
     support-jump-role: ${SUPPORT_JUMP_ROLE}
+    aws-managed-tags: "${AWS_MANAGED_TAGS}"
 
 - apiVersion: aws.managed.openshift.io/v1alpha1
   kind: AccountPool

--- a/pkg/apis/aws/v1alpha1/shared_types.go
+++ b/pkg/apis/aws/v1alpha1/shared_types.go
@@ -152,3 +152,6 @@ var DefaultConfigMap = "aws-account-operator-configmap"
 
 // DefaultConfigMapAccountLimit holds the fallback limit of aws-accounts
 var DefaultConfigMapAccountLimit = 100
+
+// ManagedTagsConfigMapKey defines the default key for the configmap to add the defined tags to AWS resources
+var ManagedTagsConfigMapKey = "aws-managed-tags"

--- a/pkg/awsclient/iam.go
+++ b/pkg/awsclient/iam.go
@@ -129,8 +129,7 @@ func CheckIAMUserExists(reqLogger logr.Logger, client Client, userName string) (
 }
 
 // CreateIAMUser creates a new IAM user in the target AWS account
-// Takes a logger, an AWS client for the target account, and the desired IAM username
-func CreateIAMUser(reqLogger logr.Logger, client Client, account *awsv1alpha1.Account, userName string) (*iam.CreateUserOutput, error) {
+func CreateIAMUser(reqLogger logr.Logger, client Client, account *awsv1alpha1.Account, userName string, managedTags []AWSTag) (*iam.CreateUserOutput, error) {
 	var createUserOutput = &iam.CreateUserOutput{}
 	var err error
 
@@ -138,7 +137,7 @@ func CreateIAMUser(reqLogger logr.Logger, client Client, account *awsv1alpha1.Ac
 
 		createUserOutput, err = client.CreateUser(&iam.CreateUserInput{
 			UserName: aws.String(userName),
-			Tags:     AWSTags.BuildTags(account).GetIAMTags(),
+			Tags:     AWSTags.BuildTags(account, managedTags).GetIAMTags(),
 		})
 
 		// handle errors

--- a/pkg/awsclient/tags.go
+++ b/pkg/awsclient/tags.go
@@ -46,25 +46,36 @@ func (t *AWSAccountOperatorTags) GetEC2Tags() []*ec2.Tag {
 }
 
 // BuildTags initializes AWSTags with required tags
-func (t *AWSAccountOperatorTags) BuildTags(account *awsv1alpha1.Account) AWSTagBuilder {
-	ClusterAccountNameTag := AWSTag{
+func (t *AWSAccountOperatorTags) BuildTags(account *awsv1alpha1.Account, managedTags []AWSTag) AWSTagBuilder {
+	tags := []AWSTag{}
+
+	// Adds a tag for the cluster's Account Name
+	tags = append(tags, AWSTag{
 		Key:   awsv1alpha1.ClusterAccountNameTagKey,
 		Value: account.Name,
-	}
-	ClusterNamespaceTag := AWSTag{
+	})
+	// Add a tag with the cluster's Namespace
+	tags = append(tags, AWSTag{
 		Key:   awsv1alpha1.ClusterNamespaceTagKey,
 		Value: account.Namespace,
-	}
-	ClusterClaimLinkTag := AWSTag{
+	})
+
+	// Add a tag for the cluster's ClaimLink
+	tags = append(tags, AWSTag{
 		Key:   awsv1alpha1.ClusterClaimLinkTagKey,
 		Value: account.Spec.ClaimLink,
-	}
-	ClusterClaimLinkNamespaceTag := AWSTag{
+	})
+
+	// Add a tag for the cluster's ClaimLink Namespace
+	tags = append(tags, AWSTag{
 		Key:   awsv1alpha1.ClusterClaimLinkNamespaceTagKey,
 		Value: account.Spec.ClaimLinkNamespace,
+	})
+
+	// Adds all of the "managed tags" passed in (typically through the configmap)
+	tags = append(tags, managedTags...)
+
+	return &AWSAccountOperatorTags{
+		Tags: tags,
 	}
-	AWSTags = &AWSAccountOperatorTags{
-		Tags: []AWSTag{ClusterAccountNameTag, ClusterNamespaceTag, ClusterClaimLinkTag, ClusterClaimLinkNamespaceTag},
-	}
-	return AWSTags
 }

--- a/pkg/controller/account/byoc.go
+++ b/pkg/controller/account/byoc.go
@@ -157,11 +157,14 @@ func (r *ReconcileAccount) initializeNewCCSAccount(reqLogger logr.Logger, accoun
 		return "", reconcile.Result{}, cmErr
 	}
 
+	// Get list of managed tags to add to resources
+	managedTags := r.getManagedTags(reqLogger)
+
 	// Create access key and role for BYOC account
 	var roleID string
 	var roleErr error
 	if !account.HasState() {
-		tags := awsclient.AWSTags.BuildTags(account).GetIAMTags()
+		tags := awsclient.AWSTags.BuildTags(account, managedTags).GetIAMTags()
 		roleID, roleErr = createBYOCAdminAccessRole(reqLogger, awsSetupClient, client, adminAccessArn, accountID, tags, SREAccessARN)
 
 		if roleErr != nil {

--- a/pkg/controller/account/ec2.go
+++ b/pkg/controller/account/ec2.go
@@ -38,9 +38,11 @@ func (r *ReconcileAccount) InitializeSupportedRegions(reqLogger logr.Logger, acc
 	vCPUQuota, _ := r.getDesiredVCPUValue(reqLogger)
 	reqLogger.Info("retrieved desired vCPU quota value from configMap", "quota.vcpu", vCPUQuota)
 
+	managedTags := r.getManagedTags(reqLogger)
+
 	// Create go routines to initialize regions in parallel
 	for region := range regions {
-		go r.InitializeRegion(reqLogger, account, region, regions[region]["initializationAMI"], vCPUQuota, ec2Notifications, ec2Errors, creds) //nolint:errcheck // Unable to do anything with the returned error
+		go r.InitializeRegion(reqLogger, account, region, regions[region]["initializationAMI"], vCPUQuota, ec2Notifications, ec2Errors, creds, managedTags) //nolint:errcheck // Unable to do anything with the returned error
 	}
 
 	// Wait for all go routines to send a message or error to notify that the region initialization has finished
@@ -66,6 +68,7 @@ func (r *ReconcileAccount) InitializeRegion(
 	ec2Notifications chan string,
 	ec2Errors chan string,
 	creds *sts.AssumeRoleOutput,
+	managedTags []awsclient.AWSTag,
 ) error {
 	var quotaIncreaseRequired bool
 	var caseID string
@@ -143,7 +146,7 @@ func (r *ReconcileAccount) InitializeRegion(
 		}
 	}
 
-	err = r.BuildAndDestroyEC2Instances(reqLogger, account, awsClient, ami)
+	err = r.BuildAndDestroyEC2Instances(reqLogger, account, awsClient, ami, managedTags)
 
 	if err != nil {
 		createErr := fmt.Sprintf("Unable to create instance in region: %s", region)
@@ -163,9 +166,9 @@ func (r *ReconcileAccount) InitializeRegion(
 }
 
 // BuildAndDestroyEC2Instances runs an ec2 instance and terminates it
-func (r *ReconcileAccount) BuildAndDestroyEC2Instances(reqLogger logr.Logger, account *awsv1alpha1.Account, awsClient awsclient.Client, ami string) error {
+func (r *ReconcileAccount) BuildAndDestroyEC2Instances(reqLogger logr.Logger, account *awsv1alpha1.Account, awsClient awsclient.Client, ami string, managedTags []awsclient.AWSTag) error {
 
-	instanceID, err := CreateEC2Instance(reqLogger, account, awsClient, ami)
+	instanceID, err := CreateEC2Instance(reqLogger, account, awsClient, ami, managedTags)
 	if err != nil {
 		// Terminate instance id if it exists
 		if instanceID != "" {
@@ -225,7 +228,7 @@ func (r *ReconcileAccount) BuildAndDestroyEC2Instances(reqLogger logr.Logger, ac
 }
 
 // CreateEC2Instance creates ec2 instance and returns its instance ID
-func CreateEC2Instance(reqLogger logr.Logger, account *awsv1alpha1.Account, client awsclient.Client, ami string) (string, error) {
+func CreateEC2Instance(reqLogger logr.Logger, account *awsv1alpha1.Account, client awsclient.Client, ami string, managedTags []awsclient.AWSTag) (string, error) {
 
 	// Retain instance id
 	var timeoutInstanceID string
@@ -249,7 +252,7 @@ func CreateEC2Instance(reqLogger logr.Logger, account *awsv1alpha1.Account, clie
 			TagSpecifications: []*ec2.TagSpecification{
 				{
 					ResourceType: &awsv1alpha1.InstanceResourceType,
-					Tags:         awsclient.AWSTags.BuildTags(account).GetEC2Tags(),
+					Tags:         awsclient.AWSTags.BuildTags(account, managedTags).GetEC2Tags(),
 				},
 			},
 		})

--- a/pkg/controller/account/iam.go
+++ b/pkg/controller/account/iam.go
@@ -313,12 +313,15 @@ func (r *ReconcileAccount) BuildIAMUser(reqLogger logr.Logger, awsClient awsclie
 		return nil, err
 	}
 
+	// Get list of managed tags.
+	managedTags := r.getManagedTags(reqLogger)
+
 	// Create IAM user in AWS if it doesn't exist
 	if iamUserExists {
 		// If user exists extract iam.User pointer
 		createdIAMUser = iamUserExistsOutput.User
 	} else {
-		CreateUserOutput, err := awsclient.CreateIAMUser(reqLogger, awsClient, account, iamUserName)
+		CreateUserOutput, err := awsclient.CreateIAMUser(reqLogger, awsClient, account, iamUserName, managedTags)
 		// Err is handled within the function and returns a error message
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
Adds a configmap lookup to add a custom list of tags to AAO created resources.

Satisfies [OSD-6926](https://issues.redhat.com/browse/OSD-6926)

To Test:

• Add a new Configmap entry under data named `AWS-Managed-Tags` in the following format:

```
data:
  AWS-Managed-Tags: |
    red-hat-managed=true
    another-tag=anotherthing
    some-base64=soembasec6t324aslkreoweaskleDIasdjMIT==
```

And create an account.  IAM User `OSDManagedAdmin` and EC2 instances created for account init should have the 3 additional tags defined in the configmap.  If `OSDManagedAdmin` is already created inside of your AWS account, it will _not_ get the additional tags, and you will need to delete the IAM user and create the account.

`OSDManagedAdminSRE` has been found to get no tags, and a bug card has been created for that.