### PR TITLE
OSD-6975: Only evaluate AWS_IAM_ARN when needed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,8 +6,6 @@ REUSE_BUCKET_NAME=test-reuse-bucket-${REUSE_UUID}
 
 include hack/scripts/test_envs
 
-export AWS_IAM_ARN := $(shell aws sts get-caller-identity --profile=osd-staging-2 | jq -r '.Arn')
-
 # Boilerplate
 include boilerplate/generated-includes.mk
 
@@ -30,7 +28,8 @@ ifndef OSD_STAGING_2_AWS_ACCOUNT_ID
 	$(error OSD_STAGING_2_AWS_ACCOUNT_ID is undefined)
 endif
 ifndef AWS_IAM_ARN
-	$(error AWS_IAM_ARN is undefined)
+	$(eval export AWS_IAM_ARN := $(shell aws sts get-caller-identity --profile=osd-staging-2 | jq -r '.Arn'))
+	@if [[ -z "$(AWS_IAM_ARN)" ]]; then echo "AWS_IAM_ARN unset and could not be calculated!"; exit 1; fi
 endif
 
 .PHONY: check-ou-mapping-configmap-env


### PR DESCRIPTION
Move the evaluation of `AWS_IAM_ARN` into the `check-aws-account-id-env` target to avoid it being evaluated a) for targets where it's unused; and b) for autocomplete (where it's also unused).

Tested the following permutations:
- Unset in the environment
  - Autocomplete doesn't attempt to set it
  - `check-aws-account-id-env` attempts to set it. On failure, an error is output and the value is empty; so the `check-aws-account-id-env` target fails as desired.
- Set in the environment
  - Autocomplete doesn't attempt to set it
  - `check aws-account-id-env` succeeds with "nothing to do" (because the `ifndef` directives end us up with an empty target).

[OSD-6975](https://issues.redhat.com/browse/OSD-6975)