### PR TITLE
Instead of outputting cVPU quota error just log the defaulting value

### DIFF
--- a/pkg/controller/account/ec2.go
+++ b/pkg/controller/account/ec2.go
@@ -346,13 +346,13 @@ func (r *ReconcileAccount) getDesiredVCPUValue(reqLogger logr.Logger) (float64, 
 		err = awsv1alpha1.ErrInvalidConfigMap
 	}
 	if err != nil {
-		reqLogger.Info(fmt.Sprintf("Failed getting desired vCPU quota from configmap data, defaulting quota to: %v", 0))
+		reqLogger.Info("Failed getting desired vCPU quota from configmap data, defaulting quota to 0")
 		return vCPUQuota, err
 	}
 
 	vCPUQuota, err = strconv.ParseFloat(v, 64)
 	if err != nil {
-		reqLogger.Info(fmt.Sprintf("failed converting vCPU quota from configmap string to float64, defaulting quota to: %v", 0))
+		reqLogger.Info("Failed converting vCPU quota from configmap string to float64, defaulting quota to 0")
 		return vCPUQuota, err
 	}
 

--- a/pkg/controller/account/ec2.go
+++ b/pkg/controller/account/ec2.go
@@ -346,13 +346,13 @@ func (r *ReconcileAccount) getDesiredVCPUValue(reqLogger logr.Logger) (float64, 
 		err = awsv1alpha1.ErrInvalidConfigMap
 	}
 	if err != nil {
-		reqLogger.Error(err, "failed getting desired vCPU quota from configmap data")
+		reqLogger.Info(fmt.Sprintf("Failed getting desired vCPU quota from configmap data, defaulting quota to: %v", 0))
 		return vCPUQuota, err
 	}
 
 	vCPUQuota, err = strconv.ParseFloat(v, 64)
 	if err != nil {
-		reqLogger.Error(err, "failed converting vCPU quota from configmap string to float64")
+		reqLogger.Info(fmt.Sprintf("failed converting vCPU quota from configmap string to float64, defaulting quota to: %v", 0))
 		return vCPUQuota, err
 	}
 


### PR DESCRIPTION
Card: https://issues.redhat.com/browse/OSD-6848

Instead of outputting vCPU quota error  simply log that the vCPU value was not found in the configmap and that the value is being defaulted to 0 