### PR TITLE
OSD-6906: Relocate fields from .status to .spec

### DIFF
--- a/deploy/crds/aws.managed.openshift.io_accounts_crd.yaml
+++ b/deploy/crds/aws.managed.openshift.io_accounts_crd.yaml
@@ -84,10 +84,8 @@ spec:
         status:
           description: AccountStatus defines the observed state of Account
           properties:
-            claimed:
-              description: 'INSERT ADDITIONAL STATUS FIELD - define observed state of cluster Important: Run "operator-sdk generate k8s" to regenerate code after modifying this file Add custom validation using kubebuilder tags: https://book.kubebuilder.io/beyond_basics/generating_crd.html'
-              type: boolean
             conditions:
+              description: 'INSERT ADDITIONAL STATUS FIELD - define observed state of cluster Important: Run "operator-sdk generate k8s" to regenerate code after modifying this file Add custom validation using kubebuilder tags: https://book.kubebuilder.io/beyond_basics/generating_crd.html'
               items:
                 description: AccountCondition contains details for the current condition of a AWS account
                 properties:
@@ -113,16 +111,10 @@ spec:
                     type: string
                 type: object
               type: array
-            reused:
-              type: boolean
             rotateConsoleCredentials:
               type: boolean
             rotateCredentials:
               type: boolean
-            state:
-              type: string
-            supportCaseID:
-              type: string
           type: object
   version: v1alpha1
   versions:

--- a/deploy/crds/aws.managed.openshift.io_accounts_crd.yaml
+++ b/deploy/crds/aws.managed.openshift.io_accounts_crd.yaml
@@ -53,6 +53,9 @@ spec:
               type: string
             claimLinkNamespace:
               type: string
+            claimed:
+              description: Backup status
+              type: boolean
             iamUserSecret:
               type: string
             legalEntity:
@@ -68,6 +71,12 @@ spec:
               type: object
             manualSTSMode:
               type: boolean
+            reused:
+              type: boolean
+            state:
+              type: string
+            supportCaseID:
+              type: string
           required:
             - awsAccountID
             - iamUserSecret

--- a/deploy/crds/aws.managed.openshift.io_accounts_crd.yaml
+++ b/deploy/crds/aws.managed.openshift.io_accounts_crd.yaml
@@ -4,11 +4,11 @@ metadata:
   name: accounts.aws.managed.openshift.io
 spec:
   additionalPrinterColumns:
-    - JSONPath: .status.state
+    - JSONPath: .spec.state
       description: Status the account
       name: State
       type: string
-    - JSONPath: .status.claimed
+    - JSONPath: .spec.claimed
       description: True if the account has been claimed
       name: Claimed
       type: boolean

--- a/pkg/apis/aws/v1alpha1/account_types.go
+++ b/pkg/apis/aws/v1alpha1/account_types.go
@@ -124,8 +124,8 @@ const (
 // Account is the Schema for the accounts API
 // +k8s:openapi-gen=true
 // +kubebuilder:subresource:status
-// +kubebuilder:printcolumn:name="State",type="string",JSONPath=".status.state",description="Status the account"
-// +kubebuilder:printcolumn:name="Claimed",type="boolean",JSONPath=".status.claimed",description="True if the account has been claimed"
+// +kubebuilder:printcolumn:name="State",type="string",JSONPath=".spec.state",description="Status the account"
+// +kubebuilder:printcolumn:name="Claimed",type="boolean",JSONPath=".spec.claimed",description="True if the account has been claimed"
 // +kubebuilder:printcolumn:name="Claim",type="string",JSONPath=".spec.claimLink",description="Link to the account claim CR"
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp",description="Age since the account was created"
 // +kubebuilder:resource:path=accounts,scope=Namespaced

--- a/pkg/apis/aws/v1alpha1/account_types.go
+++ b/pkg/apis/aws/v1alpha1/account_types.go
@@ -56,15 +56,11 @@ type AccountStatus struct {
 	// INSERT ADDITIONAL STATUS FIELD - define observed state of cluster
 	// Important: Run "operator-sdk generate k8s" to regenerate code after modifying this file
 	// Add custom validation using kubebuilder tags: https://book.kubebuilder.io/beyond_basics/generating_crd.html
-	Claimed       bool   `json:"claimed,omitempty"`
-	SupportCaseID string `json:"supportCaseID,omitempty"`
 	// +listType=map
 	// +listMapKey=type
 	Conditions               []AccountCondition `json:"conditions,omitempty"`
-	State                    string             `json:"state,omitempty"`
 	RotateCredentials        bool               `json:"rotateCredentials,omitempty"`
 	RotateConsoleCredentials bool               `json:"rotateConsoleCredentials,omitempty"`
-	Reused                   bool               `json:"reused,omitempty"`
 }
 
 // AccountCondition contains details for the current condition of a AWS account
@@ -168,7 +164,7 @@ func (a *Account) IsFailed() bool {
 		string(AccountInternalError),
 	}
 	for _, state := range failedStates {
-		if a.Status.State == state {
+		if a.Spec.State == state {
 			return true
 		}
 	}
@@ -177,27 +173,27 @@ func (a *Account) IsFailed() bool {
 
 //HasState returns true if an account has a state set at all
 func (a *Account) HasState() bool {
-	return a.Status.State != ""
+	return a.Spec.State != ""
 }
 
 //HasSupportCaseID returns true if an account has a SupportCaseID Set
 func (a *Account) HasSupportCaseID() bool {
-	return a.Status.SupportCaseID != ""
+	return a.Spec.SupportCaseID != ""
 }
 
 //IsPendingVerification returns true if the account is in a PendingVerification state
 func (a *Account) IsPendingVerification() bool {
-	return a.Status.State == string(AccountPendingVerification)
+	return a.Spec.State == string(AccountPendingVerification)
 }
 
 //IsReady returns true if an account is ready
 func (a *Account) IsReady() bool {
-	return a.Status.State == string(AccountReady)
+	return a.Spec.State == string(AccountReady)
 }
 
 //IsCreating returns true if an account is creating
 func (a *Account) IsCreating() bool {
-	return a.Status.State == string(AccountCreating)
+	return a.Spec.State == string(AccountCreating)
 }
 
 //HasClaimLink returns true if an accounts claim link is not empty
@@ -207,7 +203,7 @@ func (a *Account) HasClaimLink() bool {
 
 //IsClaimed returns true if account Status.Claimed is false
 func (a *Account) IsClaimed() bool {
-	return a.Status.Claimed
+	return a.Spec.Claimed
 }
 
 //IsPendingDeletion returns true if a DeletionTimestamp has been set
@@ -282,7 +278,7 @@ func (a *Account) IsUnclaimedAndIsCreating() bool {
 
 //IsInitializingRegions returns true if the account state is InitalizingRegions
 func (a *Account) IsInitializingRegions() bool {
-	return a.Status.State == AccountInitializingRegions
+	return a.Spec.State == AccountInitializingRegions
 }
 
 // GetCondition finds the condition that has the

--- a/pkg/apis/aws/v1alpha1/account_types.go
+++ b/pkg/apis/aws/v1alpha1/account_types.go
@@ -43,6 +43,11 @@ type AccountSpec struct {
 	ClaimLinkNamespace string      `json:"claimLinkNamespace,omitempty"`
 	LegalEntity        LegalEntity `json:"legalEntity,omitempty"`
 	ManualSTSMode      bool        `json:"manualSTSMode,omitempty"`
+	// Backup status
+	Claimed            bool        `json:"claimed,omitempty"`
+	State              string      `json:"state,omitempty"`
+	Reused             bool        `json:"reused,omitempty"`
+	SupportCaseID      string      `json:"supportCaseID,omitempty"`
 }
 
 // AccountStatus defines the observed state of Account

--- a/pkg/apis/aws/v1alpha1/zz_generated.openapi.go
+++ b/pkg/apis/aws/v1alpha1/zz_generated.openapi.go
@@ -707,19 +707,6 @@ func schema_pkg_apis_aws_v1alpha1_AccountStatus(ref common.ReferenceCallback) co
 				Description: "AccountStatus defines the observed state of Account",
 				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
-					"claimed": {
-						SchemaProps: spec.SchemaProps{
-							Description: "INSERT ADDITIONAL STATUS FIELD - define observed state of cluster Important: Run \"operator-sdk generate k8s\" to regenerate code after modifying this file Add custom validation using kubebuilder tags: https://book.kubebuilder.io/beyond_basics/generating_crd.html",
-							Type:        []string{"boolean"},
-							Format:      "",
-						},
-					},
-					"supportCaseID": {
-						SchemaProps: spec.SchemaProps{
-							Type:   []string{"string"},
-							Format: "",
-						},
-					},
 					"conditions": {
 						VendorExtensible: spec.VendorExtensible{
 							Extensions: spec.Extensions{
@@ -730,7 +717,8 @@ func schema_pkg_apis_aws_v1alpha1_AccountStatus(ref common.ReferenceCallback) co
 							},
 						},
 						SchemaProps: spec.SchemaProps{
-							Type: []string{"array"},
+							Description: "INSERT ADDITIONAL STATUS FIELD - define observed state of cluster Important: Run \"operator-sdk generate k8s\" to regenerate code after modifying this file Add custom validation using kubebuilder tags: https://book.kubebuilder.io/beyond_basics/generating_crd.html",
+							Type:        []string{"array"},
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
@@ -740,12 +728,6 @@ func schema_pkg_apis_aws_v1alpha1_AccountStatus(ref common.ReferenceCallback) co
 							},
 						},
 					},
-					"state": {
-						SchemaProps: spec.SchemaProps{
-							Type:   []string{"string"},
-							Format: "",
-						},
-					},
 					"rotateCredentials": {
 						SchemaProps: spec.SchemaProps{
 							Type:   []string{"boolean"},
@@ -753,12 +735,6 @@ func schema_pkg_apis_aws_v1alpha1_AccountStatus(ref common.ReferenceCallback) co
 						},
 					},
 					"rotateConsoleCredentials": {
-						SchemaProps: spec.SchemaProps{
-							Type:   []string{"boolean"},
-							Format: "",
-						},
-					},
-					"reused": {
 						SchemaProps: spec.SchemaProps{
 							Type:   []string{"boolean"},
 							Format: "",

--- a/pkg/apis/aws/v1alpha1/zz_generated.openapi.go
+++ b/pkg/apis/aws/v1alpha1/zz_generated.openapi.go
@@ -666,6 +666,31 @@ func schema_pkg_apis_aws_v1alpha1_AccountSpec(ref common.ReferenceCallback) comm
 							Format: "",
 						},
 					},
+					"claimed": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Backup status",
+							Type:        []string{"boolean"},
+							Format:      "",
+						},
+					},
+					"state": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"string"},
+							Format: "",
+						},
+					},
+					"reused": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"boolean"},
+							Format: "",
+						},
+					},
+					"supportCaseID": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"string"},
+							Format: "",
+						},
+					},
 				},
 				Required: []string{"awsAccountID", "iamUserSecret"},
 			},

--- a/pkg/controller/account/account_controller.go
+++ b/pkg/controller/account/account_controller.go
@@ -661,9 +661,7 @@ func (r *ReconcileAccount) initializeRegions(reqLogger logr.Logger, currentAcctI
 
 	// We're about to kick off region init in a goroutine. This status makes subsequent
 	// Reconciles ignore the Account (unless it stays in this state for too long).
-	utils.SetAccountStatus(currentAcctInstance, "Initializing Regions", awsv1alpha1.AccountInitializingRegions, AccountInitializingRegions)
-	if err := r.accountInstanceUpdate(currentAcctInstance); err != nil {
-		// statusUpdate logs
+	if err := r.accountInstanceUpdate(currentAcctInstance, "Initializing Regions", awsv1alpha1.AccountInitializingRegions, AccountInitializingRegions); err != nil {
 		return err
 	}
 

--- a/pkg/controller/account/account_controller_test.go
+++ b/pkg/controller/account/account_controller_test.go
@@ -28,11 +28,11 @@ func newTestAccountBuilder() *testAccountBuilder {
 					Time: time.Now().Add(-(5 * time.Minute)), // default tests to 5 minute old acct
 				},
 			},
-			Status: awsv1alpha1.AccountStatus{
+			Status: awsv1alpha1.AccountStatus{},
+			Spec: awsv1alpha1.AccountSpec{
 				State:   string(awsv1alpha1.AccountReady),
 				Claimed: false,
 			},
-			Spec: awsv1alpha1.AccountSpec{},
 		},
 	}
 }
@@ -87,25 +87,25 @@ func (t *testAccountBuilder) WithLabels(labels map[string]string) *testAccountBu
 
 // Add a state string
 func (t *testAccountBuilder) WithState(state awsv1alpha1.AccountConditionType) *testAccountBuilder {
-	t.acct.Status.State = string(state)
+	t.acct.Spec.State = string(state)
 	return t
 }
 
 // Delete state
 func (t *testAccountBuilder) WithoutState() *testAccountBuilder {
-	t.acct.Status.State = ""
+	t.acct.Spec.State = ""
 	return t
 }
 
 // Set account claimed or not
 func (t *testAccountBuilder) Claimed(claimed bool) *testAccountBuilder {
-	t.acct.Status.Claimed = claimed
+	t.acct.Spec.Claimed = claimed
 	return t
 }
 
 // Add supportCaseID
 func (t *testAccountBuilder) WithSupportCaseID(id string) *testAccountBuilder {
-	t.acct.Status.SupportCaseID = id
+	t.acct.Spec.SupportCaseID = id
 	return t
 }
 

--- a/pkg/controller/account/byoc.go
+++ b/pkg/controller/account/byoc.go
@@ -35,8 +35,8 @@ func newBYOCAccount(currentAcctInstance *awsv1alpha1.Account) bool {
 func claimBYOCAccount(r *ReconcileAccount, reqLogger logr.Logger, currentAcctInstance *awsv1alpha1.Account) error {
 	if !currentAcctInstance.IsClaimed() {
 		reqLogger.Info("Marking BYOC account claimed")
-		currentAcctInstance.Status.Claimed = true
-		return r.statusUpdate(currentAcctInstance)
+		currentAcctInstance.Spec.Claimed = true
+		return r.acountInstanceUpdate(currentAcctInstance)
 	}
 
 	return nil

--- a/pkg/controller/account/byoc.go
+++ b/pkg/controller/account/byoc.go
@@ -36,7 +36,7 @@ func claimBYOCAccount(r *ReconcileAccount, reqLogger logr.Logger, currentAcctIns
 	if !currentAcctInstance.IsClaimed() {
 		reqLogger.Info("Marking BYOC account claimed")
 		currentAcctInstance.Spec.Claimed = true
-		return r.acountInstanceUpdate(currentAcctInstance)
+		return r.accountInstanceSpecUpdate(currentAcctInstance)
 	}
 
 	return nil

--- a/pkg/controller/account/byoc_test.go
+++ b/pkg/controller/account/byoc_test.go
@@ -162,30 +162,27 @@ var _ = Describe("Byoc", func() {
 var testNewBYOCAccountInstances = []*awsv1alpha1.Account{
 	{
 		Spec: awsv1alpha1.AccountSpec{
-			BYOC: true,
-		},
-		Status: awsv1alpha1.AccountStatus{
+			BYOC:    true,
 			Claimed: true,
 			State:   "",
 		},
+		Status: awsv1alpha1.AccountStatus{},
 	},
 	{
 		Spec: awsv1alpha1.AccountSpec{
-			BYOC: true,
-		},
-		Status: awsv1alpha1.AccountStatus{
+			BYOC:    true,
 			Claimed: false,
 			State:   "",
 		},
+		Status: awsv1alpha1.AccountStatus{},
 	},
 	{
 		Spec: awsv1alpha1.AccountSpec{
-			BYOC: true,
-		},
-		Status: awsv1alpha1.AccountStatus{
+			BYOC:    true,
 			Claimed: false,
 			State:   "test state",
 		},
+		Status: awsv1alpha1.AccountStatus{},
 	},
 }
 
@@ -193,39 +190,35 @@ var testNewBYOCAccountInstances = []*awsv1alpha1.Account{
 var testNotNewBYOCAccountInstances = []*awsv1alpha1.Account{
 	{
 		Spec: awsv1alpha1.AccountSpec{
-			BYOC: true,
-		},
-		Status: awsv1alpha1.AccountStatus{
+			BYOC:    true,
 			Claimed: true,
 			State:   "test state",
 		},
+		Status: awsv1alpha1.AccountStatus{},
 	},
 	{
 		Spec: awsv1alpha1.AccountSpec{
-			BYOC: false,
-		},
-		Status: awsv1alpha1.AccountStatus{
+			BYOC:    false,
 			Claimed: true,
 			State:   "",
 		},
+		Status: awsv1alpha1.AccountStatus{},
 	},
 	{
 		Spec: awsv1alpha1.AccountSpec{
-			BYOC: false,
-		},
-		Status: awsv1alpha1.AccountStatus{
+			BYOC:    false,
 			Claimed: false,
 			State:   "",
 		},
+		Status: awsv1alpha1.AccountStatus{},
 	},
 	{
 		Spec: awsv1alpha1.AccountSpec{
-			BYOC: false,
-		},
-		Status: awsv1alpha1.AccountStatus{
+			BYOC:    false,
 			Claimed: false,
 			State:   "test state",
 		},
+		Status: awsv1alpha1.AccountStatus{},
 	},
 }
 

--- a/pkg/controller/account/iam.go
+++ b/pkg/controller/account/iam.go
@@ -57,8 +57,7 @@ func (r *ReconcileAccount) CreateSecret(reqLogger logr.Logger, account *awsv1alp
 	createErr := r.Client.Create(context.TODO(), secret)
 	if createErr != nil {
 		failedToCreateUserSecretMsg := fmt.Sprintf("Failed to create secret %s", secret.Name)
-		utils.SetAccountStatus(account, failedToCreateUserSecretMsg, awsv1alpha1.AccountFailed, "Failed")
-		err := r.Client.Status().Update(context.TODO(), account)
+		err := r.accountInstanceUpdate(account, failedToCreateUserSecretMsg, awsv1alpha1.AccountFailed, "Failed")
 		if err != nil {
 			return err
 		}

--- a/pkg/controller/accountclaim/accountclaim_controller.go
+++ b/pkg/controller/accountclaim/accountclaim_controller.go
@@ -209,8 +209,8 @@ func (r *ReconcileAccountClaim) Reconcile(request reconcile.Request) (reconcile.
 			return reconcile.Result{}, err
 		}
 
-		if byocAccount.Status.State != string(awsv1alpha1.AccountReady) {
-			if byocAccount.Status.State == string(awsv1alpha1.AccountFailed) {
+		if byocAccount.Spec.State != string(awsv1alpha1.AccountReady) {
+			if byocAccount.Spec.State == string(awsv1alpha1.AccountFailed) {
 				accountClaim.Status.State = awsv1alpha1.ClaimStatusError
 				message := "CCS Account Failed"
 				accountClaim.Status.Conditions = controllerutils.SetAccountClaimCondition(
@@ -226,11 +226,11 @@ func (r *ReconcileAccountClaim) Reconcile(request reconcile.Request) (reconcile.
 				return reconcile.Result{}, r.statusUpdate(reqLogger, accountClaim)
 			}
 			waitMsg := fmt.Sprintf("%s is not Ready yet, requeuing in %d seconds", byocAccount.Name, waitPeriod)
-			reqLogger.Info(waitMsg, "Account Status", byocAccount.Status.State)
+			reqLogger.Info(waitMsg, "Account Status", byocAccount.Spec.State)
 			return reconcile.Result{RequeueAfter: time.Second * waitPeriod}, nil
 		}
 
-		if byocAccount.Status.State == string(awsv1alpha1.AccountReady) && accountClaim.Status.State != awsv1alpha1.ClaimStatusReady {
+		if byocAccount.Spec.State == string(awsv1alpha1.AccountReady) && accountClaim.Status.State != awsv1alpha1.ClaimStatusReady {
 			accountClaim.Status.State = awsv1alpha1.ClaimStatusReady
 			message := "BYOC account ready"
 			accountClaim.Status.Conditions = controllerutils.SetAccountClaimCondition(
@@ -375,9 +375,9 @@ func getUnclaimedAccount(reqLogger logr.Logger, accountList *awsv1alpha1.Account
 	// Range through accounts and select the first one that doesn't have a claim link
 	for _, account := range accountList.Items {
 
-		if !account.Status.Claimed && account.Spec.ClaimLink == "" && account.Status.State == "Ready" {
+		if !account.Spec.Claimed && account.Spec.ClaimLink == "" && account.Spec.State == "Ready" {
 			// Check for a reused account with matching legalEntity
-			if account.Status.Reused {
+			if account.Spec.Reused {
 				if matchAccountForReuse(&account, accountClaim) {
 					reusedAccountFound = true
 					reusedAccount = account

--- a/pkg/controller/accountclaim/reuse.go
+++ b/pkg/controller/accountclaim/reuse.go
@@ -157,9 +157,9 @@ func (r *ReconcileAccountClaim) resetAccountSpecStatus(reqLogger logr.Logger, re
 	reusedAccount.Status.RotateCredentials = true
 
 	// Update account status and add conditions indicating account reuse
-	reusedAccount.Status.State = conditionStatus
-	reusedAccount.Status.Claimed = false
-	reusedAccount.Status.Reused = true
+	reusedAccount.Spec.State = conditionStatus
+	reusedAccount.Spec.Claimed = false
+	reusedAccount.Spec.Reused = true
 	conditionMsg := fmt.Sprintf("Account Reuse - %s", conditionStatus)
 	utils.SetAccountStatus(reusedAccount, conditionMsg, accountState, conditionStatus)
 	err = r.accountStatusUpdate(reqLogger, reusedAccount)

--- a/pkg/controller/accountpool/accountpool_controller.go
+++ b/pkg/controller/accountpool/accountpool_controller.go
@@ -113,7 +113,7 @@ func (r *ReconcileAccountPool) Reconcile(request reconcile.Request) (reconcile.R
 	claimedAccountCount := 0
 	for _, account := range accountList.Items {
 		// We don't want to count reused accounts here, filter by LegalEntity.ID
-		if !account.Status.Claimed && account.Spec.LegalEntity.ID == "" {
+		if !account.Spec.Claimed && account.Spec.LegalEntity.ID == "" {
 			if !account.IsFailed() {
 				unclaimedAccountCount++
 			}

--- a/pkg/controller/accountpool/accountpool_controller_test.go
+++ b/pkg/controller/accountpool/accountpool_controller_test.go
@@ -78,12 +78,12 @@ func TestReconcileAccountPool(t *testing.T) {
 							ID:   "",
 							Name: "",
 						},
+						Claimed:       false,
+						State:         "Ready",
+						SupportCaseID: "000000",
 					},
 					Status: awsv1alpha1.AccountStatus{
-						Claimed:           false,
-						SupportCaseID:     "000000",
 						Conditions:        []awsv1alpha1.AccountCondition{},
-						State:             "Ready",
 						RotateCredentials: false,
 					},
 				},
@@ -100,12 +100,12 @@ func TestReconcileAccountPool(t *testing.T) {
 							ID:   "",
 							Name: "",
 						},
+						Claimed:       false,
+						State:         "Ready",
+						SupportCaseID: "000000",
 					},
 					Status: awsv1alpha1.AccountStatus{
-						Claimed:           false,
-						SupportCaseID:     "000000",
 						Conditions:        []awsv1alpha1.AccountCondition{},
-						State:             "Ready",
 						RotateCredentials: false,
 					},
 				},
@@ -242,8 +242,8 @@ func verifyAccountCreated(c client.Client, expected *awsv1alpha1.AccountPool) bo
 	unclaimedAccountCount := 0
 	for _, account := range al.Items {
 		// We don't want to count reused accounts here, filter by LegalEntity.ID
-		if account.Status.Claimed == false && account.Spec.LegalEntity.ID == "" {
-			if account.Status.State != "Failed" {
+		if account.Spec.Claimed == false && account.Spec.LegalEntity.ID == "" {
+			if account.Spec.State != "Failed" {
 				unclaimedAccountCount++
 			}
 		}

--- a/pkg/controller/utils/status.go
+++ b/pkg/controller/utils/status.go
@@ -16,7 +16,7 @@ func SetAccountStatus(awsAccount *awsv1alpha1.Account, message string, ctype aws
 		UpdateConditionNever,
 		awsAccount.Spec.BYOC,
 	)
-	awsAccount.Status.State = state
+	awsAccount.Spec.State = state
 }
 
 // SetAccountClaimStatus sets the condition and state of an accountClaim

--- a/pkg/localmetrics/localmetrics.go
+++ b/pkg/localmetrics/localmetrics.go
@@ -226,27 +226,27 @@ func (c *MetricsCollector) collect() {
 	}
 
 	for _, account := range accounts.Items {
-		if account.Status.Claimed {
+		if account.Spec.Claimed {
 			claimed = "true"
 		} else {
 			claimed = "false"
 		}
 
-		if account.Status.Reused {
+		if account.Spec.Reused {
 			reused = "true"
 		} else {
 			reused = "false"
 		}
 
-		if !account.Status.Claimed && account.Status.Reused &&
-			account.Status.State == "Ready" {
+		if !account.Spec.Claimed && account.Spec.Reused &&
+			account.Spec.State == "Ready" {
 			c.accountReuseAvailable.WithLabelValues(account.Spec.LegalEntity.ID).Inc()
 		}
 
 		if account.Spec.BYOC {
-			c.ccsAccounts.WithLabelValues(claimed, reused, account.Status.State).Inc()
+			c.ccsAccounts.WithLabelValues(claimed, reused, account.Spec.State).Inc()
 		} else {
-			c.accounts.WithLabelValues(claimed, reused, account.Status.State).Inc()
+			c.accounts.WithLabelValues(claimed, reused, account.Spec.State).Inc()
 		}
 	}
 

--- a/test/integration/api/create_account.sh
+++ b/test/integration/api/create_account.sh
@@ -7,7 +7,7 @@ source hack/scripts/test_envs
 oc process -p AWS_ACCOUNT_ID=${OSD_STAGING_1_AWS_ACCOUNT_ID} -p ACCOUNT_CR_NAME=${OSD_STAGING_1_ACCOUNT_CR_NAME_OSD} -p NAMESPACE=${NAMESPACE} -f hack/templates/aws.managed.openshift.io_v1alpha1_account.tmpl | oc apply -f -
 # Wait for account to become ready
 while true
-do STATUS=$(oc get account ${OSD_STAGING_1_ACCOUNT_CR_NAME_OSD} -n ${NAMESPACE} -o json | jq -r '.status.state');
+do STATUS=$(oc get account ${OSD_STAGING_1_ACCOUNT_CR_NAME_OSD} -n ${NAMESPACE} -o json | jq -r '.spec.state');
     if [ "$STATUS" == "Ready" ]; then
         break
     elif [ "$STATUS" == "Failed" ]; then

--- a/test/integration/api/create_account.sh
+++ b/test/integration/api/create_account.sh
@@ -3,6 +3,10 @@
 # Load Environment vars
 source hack/scripts/test_envs 
 
+# Delete Account CR (if it exists)
+echo "Delete account if exists"
+oc delete accounts ${OSD_STAGING_1_ACCOUNT_CR_NAME_OSD} -n ${NAMESPACE}
+
 # Create Account CR 
 oc process -p AWS_ACCOUNT_ID=${OSD_STAGING_1_AWS_ACCOUNT_ID} -p ACCOUNT_CR_NAME=${OSD_STAGING_1_ACCOUNT_CR_NAME_OSD} -p NAMESPACE=${NAMESPACE} -f hack/templates/aws.managed.openshift.io_v1alpha1_account.tmpl | oc apply -f -
 # Wait for account to become ready


### PR DESCRIPTION
Move the following fields from .status to .spec in the Account CR. It's not only a best practice on CRD design, but in order to support migrating clusters, we need to have all fields we want to persist as part of the spec object, otherwise they will be lost from the status after migration.