### PR TITLE
update openshift template

### DIFF
--- a/hack/olm-registry/olm-artifacts-template.yaml
+++ b/hack/olm-registry/olm-artifacts-template.yaml
@@ -4,14 +4,10 @@ metadata:
   name: olm-artifacts-template
 
 parameters:
-- name: REGISTRY_IMG
-  required: true
 - name: CHANNEL
   value: staging
-- name: IMAGE_TAG
-  value: latest
 - name: REPO_DIGEST
-  value: latest
+  required: true
 - name: ACCOUNT_LIMIT
   required: true
 - name: ROOT_OU_ID


### PR DESCRIPTION
related to https://issues.redhat.com/browse/APPSRE-3265

Right now, you should define REPO_DIGEST in the OpenShift template, and it should be enough. Nothing else needed in the OpenShift template itself.
In the SaaS file, you need to define REGISTRY_IMG, to be able to generate REPO_DIGEST. You don't need to define REGISTRY_IMG in the OpenShift template.
IMAGE_TAG is always generated, and you don't need to define in the SaaS file or in the OpenShift template.
