### PR TITLE
Adds necessary field for Support ARN

### DIFF
--- a/deploy/crds/aws.managed.openshift.io_accountclaims_crd.yaml
+++ b/deploy/crds/aws.managed.openshift.io_accountclaims_crd.yaml
@@ -101,6 +101,8 @@ spec:
               type: boolean
             stsRoleARN:
               type: string
+            supportRoleARN:
+              type: string
           required:
             - accountLink
             - aws

--- a/hack/olm-registry/olm-artifacts-template.yaml
+++ b/hack/olm-registry/olm-artifacts-template.yaml
@@ -24,6 +24,8 @@ parameters:
   required: true
 - name: STS_JUMP_ROLE
   required: true
+- name: SUPPORT_JUMP_ROLE
+  required: true
 
 objects:
 - apiVersion: operators.coreos.com/v1alpha1
@@ -64,6 +66,7 @@ objects:
     root: ${ROOT_OU_ID}
     base: ${BASE_OU_ID}
     sts-jump-role: ${STS_JUMP_ROLE}
+    support-jump-role: ${SUPPORT_JUMP_ROLE}
 
 - apiVersion: aws.managed.openshift.io/v1alpha1
   kind: AccountPool

--- a/pkg/apis/aws/v1alpha1/accountclaim_types.go
+++ b/pkg/apis/aws/v1alpha1/accountclaim_types.go
@@ -26,6 +26,7 @@ type AccountClaimSpec struct {
 	BYOCAWSAccountID    string      `json:"byocAWSAccountID,omitempty"`
 	ManualSTSMode       bool        `json:"manualSTSMode,omitempty"`
 	STSRoleARN          string      `json:"stsRoleARN,omitempty"`
+	SupportRoleARN      string      `json:"supportRoleARN,omitempty"`
 }
 
 // AccountClaimStatus defines the observed state of AccountClaim

--- a/pkg/apis/aws/v1alpha1/zz_generated.openapi.go
+++ b/pkg/apis/aws/v1alpha1/zz_generated.openapi.go
@@ -451,6 +451,12 @@ func schema_pkg_apis_aws_v1alpha1_AccountClaimSpec(ref common.ReferenceCallback)
 							Format: "",
 						},
 					},
+					"supportRoleARN": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"string"},
+							Format: "",
+						},
+					},
 				},
 				Required: []string{"legalEntity", "awsCredentialSecret", "aws", "accountLink"},
 			},


### PR DESCRIPTION
Reverts openshift/aws-account-operator#566

Adds back in the supportRoleARN fields now that the change freeze is (almost) lifted.

Originally was PR #564.  Satisfies the same OSD requirements.