### PR TITLE
Avoids nil pointer dereference

### DIFF
--- a/pkg/controller/account/byoc.go
+++ b/pkg/controller/account/byoc.go
@@ -47,16 +47,20 @@ func (r *ReconcileAccount) initializeNewCCSAccount(reqLogger logr.Logger, accoun
 	if acctClaimErr != nil {
 		// TODO: Unrecoverable
 		// TODO: set helpful error message
-		utils.SetAccountClaimStatus(
-			accountClaim,
-			"Failed to get AccountClaim for CSS account",
-			"FailedRetrievingAccountClaim",
-			awsv1alpha1.ClientError,
-			awsv1alpha1.ClaimStatusError,
-		)
-		err := r.Client.Status().Update(context.TODO(), accountClaim)
-		if err != nil {
-			reqLogger.Error(err, "failed to update accountclaim status")
+		if accountClaim != nil {
+			utils.SetAccountClaimStatus(
+				accountClaim,
+				"Failed to get AccountClaim for CSS account",
+				"FailedRetrievingAccountClaim",
+				awsv1alpha1.ClientError,
+				awsv1alpha1.ClaimStatusError,
+			)
+			err := r.Client.Status().Update(context.TODO(), accountClaim)
+			if err != nil {
+				reqLogger.Error(err, "failed to update accountclaim status")
+			}
+		} else {
+			reqLogger.Error(acctClaimErr, "accountclaim is nil")
 		}
 		return "", reconcile.Result{}, acctClaimErr
 

--- a/pkg/controller/utils/status.go
+++ b/pkg/controller/utils/status.go
@@ -21,6 +21,9 @@ func SetAccountStatus(awsAccount *awsv1alpha1.Account, message string, ctype aws
 
 // SetAccountClaimStatus sets the condition and state of an accountClaim
 func SetAccountClaimStatus(awsAccountClaim *awsv1alpha1.AccountClaim, message string, reason string, ctype awsv1alpha1.AccountClaimConditionType, state awsv1alpha1.ClaimStatus) {
+	if awsAccountClaim == nil {
+		return
+	}
 	awsAccountClaim.Status.Conditions = SetAccountClaimCondition(
 		awsAccountClaim.Status.Conditions,
 		ctype,


### PR DESCRIPTION
This should avoid our nil pointer dereference we found this morning.  We're attempting to update the status when we cannot get the accountclaim object, so therefore it's probably always nil here.

Fixes [OSD-7226](https://issues.redhat.com/browse/OSD-7226)