### PR TITLE
Removes clcollins from reviewers

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -2,7 +2,6 @@ reviewers:
 - jharrington22
 - fahlmant
 - iamkirkbater
-- clcollins
 - rogbas
 - ArielLima
 - lisa


### PR DESCRIPTION
This removes me from the reviewers group in the `OWNERS` file, since I'm
not involved with the project directly anymore.

Signed-off-by: Christopher Collins <collins.christopher@gmail.com>
