### PR TITLE
Generate docs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,10 @@ op-generate: ## Generate crd, k8s and openapi
 	@./boilerplate/openshift/golang-osd-operator/ensure.sh operator-sdk
 	@./hack/scripts/generate_crds.sh
 
+.PHONY: serve
+serve: ## Serves the docs locally using docker
+	@docker run --rm -it -p 8000:8000 -v ${PWD}:/docs squidfunk/mkdocs-material
+
 .PHONY: check-aws-account-id-env
 check-aws-account-id-env: ## Check if AWS Account Env vars are set
 ifndef OSD_STAGING_1_AWS_ACCOUNT_ID

--- a/docs/0.1-Glossary.md
+++ b/docs/0.1-Glossary.md
@@ -1,5 +1,5 @@
 
-# 0.1 Glossary
+# Glossary
 This glosary is intended to catalogue and define all terms used in our documentation which may not be evident to new users of the operator.
 
 By extension of this glossary, we may also use terms from the following glossaries:

--- a/docs/1.0-Installation.md
+++ b/docs/1.0-Installation.md
@@ -1,6 +1,7 @@
 # 1.0 Installation
 
 Quick Access:
+
 - [1.0 Installation](#10-installation)
   - [1.1 - Prerequisites](#11---prerequisites)
   - [1.2 Workflow](#12-workflow)

--- a/docs/1.1-InstallationPrerequisites.md
+++ b/docs/1.1-InstallationPrerequisites.md
@@ -2,6 +2,7 @@
 ## 1.1 - Prerequisites
 
 Please ensure you have the following installed, or configured, on your machine before continuing:
+
 * [Golang](https://golang.org/doc/install)
 * [aws-cli](https://aws.amazon.com/cli/)
 * Typically you'll want to use [CRC](https://github.com/code-ready/crc/) for local development, though it's fine if you're running OpenShift another way.

--- a/docs/2.0-Custom-Resources-and-Controllers.md
+++ b/docs/2.0-Custom-Resources-and-Controllers.md
@@ -1,6 +1,7 @@
 # 2.0 Custom Resources and Controllers
 
 Below are the supported Custom Resources and Controllers for the AWS Account Operator.
+
 * [Account Pool](2.1-AccountPool.md)
 * [Account](2.2-Account.md)
 * [Account Claim](2.3-AccountClaim.md)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,23 @@
+site_name: aws-account-operator
+site_description: 'Documentation for aws-account-operator'
+site_url: https://openshift.github.io/aws-account-operator/
+repo_url: https://github.com/openshift/aws-account-operator
+theme:
+  name: material
+markdown_extensions:
+    - toc:
+        permalink: True
+        separator: "_"
+nav:
+  - Home: README.md
+  - Installation: 1.0-Installation.md
+  - Custom Resources: 2.0-Custom-Resources-and-Controllers.md
+  - Controllers:
+    - Account Pool: 2.1-AccountPool.md
+    - Account: 2.2-Account.md
+    - Account Claim: 2.3-AccountClaim.md
+    - AWSFederatedRole: 2.4-AWSFederatedRole.md
+    - AWSFederatedAccountAccess: 2.5-AWSFederatedAccountAccess.md
+  - Special Items in main.go: 4.0-Special-Items-Main-Go.md
+  - Debugging: 5.0-Debugging.md
+  - Glossary: 0.1-Glossary.md


### PR DESCRIPTION
Populate `https://openshift.github.io/aws-account-operator/` with
HTML static files generated automatically from within `docs/` dir.

- New Makefile options `serve` serves the site locally.
- GH Action for publishing the docs on push (master branch)
- Configure `mkdocs` to use `docs` as the source of markdown files.

Note: Configure GH-Pages for AAO to assume that docs reside in `docs`
      dir in the repo root.

REF: [OSD-6207](https://issues.redhat.com/browse/OSD-6207)