### PR TITLE
Add config for todo bot to convert Todo's to issues

### DIFF
--- a/.github/config.yml
+++ b/.github/config.yml
@@ -1,0 +1,9 @@
+# Integrate todo bot (https://github.com/probot/probot)
+# https://todo.jasonet.co/
+todo:
+  keyword: ["@todo", "TODO"] # string|string[]
+  bodyKeyword: ["@body", "BODY"] # string|string[]
+  blobLines: 5                # number|boolean, 0 or false to disable
+  autoAssign: true            # string|string[]|boolean
+  label: true                 # boolean|string|string[]
+  reopenClosed: false         # boolean


### PR DESCRIPTION
Sometimes devs use the keyword TODO in the source code in order to
remind themselves to come back and fix that. Let's have a bot
looking for that and creating a GH issue for it automatically.

Note: An admin of AAO repo needs to install the TODO bot https://github.com/marketplace/actions/todo-actions

REF: [OSD-6207](https://issues.redhat.com/browse/OSD-6207)