### PR TITLE
Add depandabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,30 @@
+# Configuration options for dependency updates
+# See: https://help.github.com/en/github/administering-a-repository/configuration-options-for-dependency-updates
+# To make it work install: https://github.com/marketplace/dependabot-preview
+
+version: 2
+updates:
+
+  # Maintain dependencies for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "ci:"
+
+  # Maintain Go dependencies
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "ci:"
+
+  # Maintain Go dependencies for API
+  - package-ecosystem: "gomod"
+    directory: "/pkg/apis"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "ci:"


### PR DESCRIPTION
Whenever there is a new version of the 3rd party dependencies
used by the project (namely whatever is inside go.mod and go.sum)
then let the project update itself without developer's intervention.

Do the same for the APIs, as now, it's a separate isolated pkg.

The configuration makes sure this check runs on weekly basis.

Note: To make this work you need an admin for AAO to install https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/upgrading-from-dependabotcom-to-github-native-dependabot#upgrading-to-github-native-dependabot

REF: [OSD-6207](https://issues.redhat.com/browse/OSD-6207)