### PR TITLE
Ensure region in the AccountClaim is returned from DescribeRegions API call

### DIFF
--- a/pkg/controller/account/ec2.go
+++ b/pkg/controller/account/ec2.go
@@ -24,7 +24,7 @@ import (
 // This should ensure we don't see any AWS API "PendingVerification" errors when launching instances
 // NOTE: This function does not have any returns. In particular, error conditions from the
 // goroutines are logged, but do not result in a failure up the stack.
-func (r *ReconcileAccount) InitializeSupportedRegions(reqLogger logr.Logger, account *awsv1alpha1.Account, regions []*ec2.Region, creds *sts.AssumeRoleOutput, regionAMIs map[string]awsv1alpha1.AmiSpec) {
+func (r *ReconcileAccount) InitializeSupportedRegions(reqLogger logr.Logger, account *awsv1alpha1.Account, regions []v1alpha1.AwsRegions, creds *sts.AssumeRoleOutput, regionAMIs map[string]awsv1alpha1.AmiSpec) {
 	// Create some channels to listen and error on when creating EC2 instances in all supported regions
 	ec2Notifications, ec2Errors := make(chan string), make(chan string)
 
@@ -44,7 +44,7 @@ func (r *ReconcileAccount) InitializeSupportedRegions(reqLogger logr.Logger, acc
 	// Create go routines to initialize regions in parallel
 
 	for _, region := range regions {
-		go r.InitializeRegion(reqLogger, account, *region.RegionName, regionAMIs[*region.RegionName], vCPUQuota, ec2Notifications, ec2Errors, creds, managedTags, customerTags) //nolint:errcheck // Unable to do anything with the returned error
+		go r.InitializeRegion(reqLogger, account, region.Name, regionAMIs[region.Name], vCPUQuota, ec2Notifications, ec2Errors, creds, managedTags, customerTags) //nolint:errcheck // Unable to do anything with the returned error
 	}
 
 	// Wait for all go routines to send a message or error to notify that the region initialization has finished


### PR DESCRIPTION
The AWS account operator will call `DescribeRegions` to gather a list of regions to initialize when setting up a AWS account.
If a user chooses one of the 4 opt-in regions but hasn't enabled it in AWS the region will not be returned by the DescribeRegions AWS API call and we want to fail.

Card: https://issues.redhat.com/browse/OSD-7417