### PR TITLE
Don't wait for accounts to succeed if they are missing permissions to complete operation in the first place

### DIFF
--- a/pkg/controller/account/account_controller.go
+++ b/pkg/controller/account/account_controller.go
@@ -650,6 +650,7 @@ func (r *ReconcileAccount) initializeRegions(reqLogger logr.Logger, currentAcctI
 	if err != nil {
 		connErr := fmt.Sprintf("unable to connect to default region %s", awsv1alpha1.AwsUSEastOneRegion)
 		reqLogger.Error(err, connErr)
+		return err
 	}
 
 	// Get a list of regions enabled in the current account

--- a/pkg/controller/account/ec2.go
+++ b/pkg/controller/account/ec2.go
@@ -199,10 +199,10 @@ func (r *ReconcileAccount) BuildAndDestroyEC2Instances(reqLogger logr.Logger, ac
 		time.Sleep(time.Duration(currentWait) * time.Second)
 		var code int
 		code, DescError = DescribeEC2Instances(reqLogger, awsClient, instanceID)
-		if code == 16 {
+		if code == 16 { // 16 represents a successful region initialization
 			reqLogger.Info(fmt.Sprintf("EC2 Instance: %s Running", instanceID))
 			break
-		} else if code == 401 {
+		} else if code == 401 { // 401 represents an UnauthorizedOperation error
 			// Missing permission to perform operations, account needs to fail
 			reqLogger.Error(DescError, fmt.Sprintf("Missing required permissions for account %s", account.Name))
 			return err

--- a/pkg/controller/account/ec2.go
+++ b/pkg/controller/account/ec2.go
@@ -202,6 +202,10 @@ func (r *ReconcileAccount) BuildAndDestroyEC2Instances(reqLogger logr.Logger, ac
 		if code == 16 {
 			reqLogger.Info(fmt.Sprintf("EC2 Instance: %s Running", instanceID))
 			break
+		} else if code == 401 {
+			// Missing permission to perform operations, account needs to fail
+			reqLogger.Error(DescError, fmt.Sprintf("Missing required permissions for account %s", account.Name))
+			return err
 		}
 
 	}
@@ -301,6 +305,7 @@ func DescribeEC2Instances(reqLogger logr.Logger, client awsclient.Client, instan
 	// 48 : terminated
 	// 64 : stopping
 	// 80 : stopped
+	// 401 : failed
 
 	result, err := client.DescribeInstanceStatus(&ec2.DescribeInstanceStatusInput{
 		InstanceIds: aws.StringSlice([]string{instanceID}),
@@ -308,6 +313,11 @@ func DescribeEC2Instances(reqLogger logr.Logger, client awsclient.Client, instan
 
 	if err != nil {
 		controllerutils.LogAwsError(reqLogger, "New AWS Error while describing EC2 instance", nil, err)
+		if aerr, ok := err.(awserr.Error); ok {
+			if aerr.Code() == "UnauthorizedOperation" {
+				return 401, err
+			}
+		}
 		return 0, err
 	}
 


### PR DESCRIPTION
This piece of code causes a client without permission to attempt region initialization multiple times even though it is not possible. This PR will simply raise the error up to a higher level where the account can be put into an error state.

This should be merged after https://github.com/openshift/aws-account-operator/pull/599 which is the PR that will actually fail accounts on failure to initialize a given region.

Card: https://issues.redhat.com/browse/OSD-7431