### PR TITLE
[OSD-7460] check against pre-defined account states 

### DIFF
--- a/pkg/controller/accountpool/accountpool_controller.go
+++ b/pkg/controller/accountpool/accountpool_controller.go
@@ -114,7 +114,7 @@ func (r *ReconcileAccountPool) Reconcile(request reconcile.Request) (reconcile.R
 	for _, account := range accountList.Items {
 		// We don't want to count reused accounts here, filter by LegalEntity.ID
 		if !account.Status.Claimed && account.Spec.LegalEntity.ID == "" {
-			if account.Status.State != "Failed" {
+			if !account.IsFailed() {
 				unclaimedAccountCount++
 			}
 		} else {


### PR DESCRIPTION
 Instead of checking for a wide range of states in Account Pool controller, I use an already existing func that checks against pre-defined account states and tells us whether an Account operation has failed or not, depending on the state. That way we avoid the case of blocking the controller because a random state doesn't conform with Account operations.

PTAL @iamkirkbater @rogbas @lisa 

See https://issues.redhat.com/browse/OSD-7460