### PR TITLE
[OSD-5393] Unifies CCS and Non-CCS account naming conventions

### DIFF
--- a/pkg/controller/account/account_controller_test.go
+++ b/pkg/controller/account/account_controller_test.go
@@ -44,6 +44,7 @@ func newTestAccountBuilder() *testAccountBuilder {
 		acct: awsv1alpha1.Account{
 			TypeMeta: metav1.TypeMeta{},
 			ObjectMeta: metav1.ObjectMeta{
+				Labels:     map[string]string{},
 				Finalizers: []string{},
 				CreationTimestamp: metav1.Time{
 					Time: time.Now().Add(-(5 * time.Minute)), // default tests to 5 minute old acct
@@ -97,6 +98,12 @@ func (t *testAccountBuilder) WithDeletionTimeStamp(timestamp time.Time) *testAcc
 // Add finalizers
 func (t *testAccountBuilder) WithFinalizers(finalizers []string) *testAccountBuilder {
 	t.acct.ObjectMeta.Finalizers = finalizers
+	return t
+}
+
+// Add labels
+func (t *testAccountBuilder) WithLabels(labels map[string]string) *testAccountBuilder {
+	t.acct.ObjectMeta.Labels = labels
 	return t
 }
 
@@ -1004,6 +1011,40 @@ func TestAccountIsUnclaimedAndCreating(t *testing.T) {
 			test.name,
 			func(t *testing.T) {
 				result := test.acct.acct.IsUnclaimedAndIsCreating()
+				if result != test.expected {
+					t.Error(
+						"for account:", test.acct,
+						"expected", test.expected,
+						"got", result,
+					)
+				}
+			},
+		)
+	}
+}
+
+func TestGetAssumeRole(t *testing.T) {
+	tests := []struct {
+		name     string
+		expected string
+		acct     *testAccountBuilder
+	}{
+		{
+			name:     "Get role for BYOC Account",
+			acct:     newTestAccountBuilder().BYOC(true).WithLabels(map[string]string{awsv1alpha1.IAMUserIDLabel: "xxxxx"}),
+			expected: fmt.Sprintf("%s-%s", byocRole, "xxxxx"),
+		},
+		{
+			name:     "Get role for Non-BYOC Account",
+			acct:     newTestAccountBuilder(),
+			expected: awsv1alpha1.AccountOperatorIAMRole,
+		},
+	}
+	for _, test := range tests {
+		t.Run(
+			test.name,
+			func(t *testing.T) {
+				result := getAssumeRole(&test.acct.acct)
 				if result != test.expected {
 					t.Error(
 						"for account:", test.acct,

--- a/pkg/controller/utils/utils.go
+++ b/pkg/controller/utils/utils.go
@@ -134,6 +134,12 @@ func AddFinalizer(object metav1.Object, finalizer string) {
 	object.SetFinalizers(finalizers.List())
 }
 
+// AddLabels adds a map of labels to an object
+func AddLabels(object metav1.Object, labels map[string]string) {
+	existingLabels := object.GetLabels()
+	object.SetLabels(JoinLabelMaps(labels, existingLabels))
+}
+
 // LogAwsError formats and logs aws error and returns if err was an awserr
 func LogAwsError(logger logr.Logger, errMsg string, customError error, err error) {
 	if aerr, ok := err.(awserr.Error); ok {


### PR DESCRIPTION
Ref: [OSD-5393](https://issues.redhat.com/browse/OSD-5393)
- PR to reintroduce work originally developed [here](https://github.com/openshift/aws-account-operator/pull/491).
- The original PR for this was reverted [due to the removal of this section in reuse.go](https://github.com/openshift/aws-account-operator/pull/491/files#diff-2c1de2a24d3be327cfb86c6b468dc265bb87f1d3f16cdc020d0c42c41e8bc872L90) which has not been included in this PR.
- This change caused all IAM users to be cleared from CCS and non-CCS accounts, leading to [OSD-7613](https://issues.redhat.com/browse/OSD-7613)

PTAL