### PR TITLE
Add tags to non-ccs accounts on creation

### DIFF
--- a/hack/olm-registry/olm-artifacts-template.yaml
+++ b/hack/olm-registry/olm-artifacts-template.yaml
@@ -24,6 +24,8 @@ parameters:
   required: true
 - name: SUPPORT_JUMP_ROLE
   required: true
+- name: SHARD_NAME
+  required: true
 - name: AWS_MANAGED_TAGS
   required: false
 
@@ -67,6 +69,7 @@ objects:
     base: ${BASE_OU_ID}
     sts-jump-role: ${STS_JUMP_ROLE}
     support-jump-role: ${SUPPORT_JUMP_ROLE}
+    shard-name: ${SHARD_NAME}
     aws-managed-tags: "${AWS_MANAGED_TAGS}"
     regions: |
       us-east-1:ami-000db10762d0c4c05:t2.micro

--- a/pkg/awsclient/client.go
+++ b/pkg/awsclient/client.go
@@ -16,9 +16,9 @@ package awsclient
 import (
 	"context"
 	"fmt"
-	"github.com/aws/aws-sdk-go/aws/endpoints"
 	"time"
 
+	"github.com/aws/aws-sdk-go/aws/endpoints"
 	"github.com/aws/aws-sdk-go/service/route53/route53iface"
 	"github.com/aws/aws-sdk-go/service/s3/s3manager"
 	"github.com/aws/aws-sdk-go/service/servicequotas"
@@ -103,6 +103,7 @@ type Client interface {
 	CreateOrganizationalUnit(*organizations.CreateOrganizationalUnitInput) (*organizations.CreateOrganizationalUnitOutput, error)
 	ListOrganizationalUnitsForParent(*organizations.ListOrganizationalUnitsForParentInput) (*organizations.ListOrganizationalUnitsForParentOutput, error)
 	ListChildren(*organizations.ListChildrenInput) (*organizations.ListChildrenOutput, error)
+	TagResource(*organizations.TagResourceInput) (*organizations.TagResourceOutput, error)
 
 	//sts
 	AssumeRole(*sts.AssumeRoleInput) (*sts.AssumeRoleOutput, error)
@@ -316,6 +317,10 @@ func (c *awsClient) ListChildren(input *organizations.ListChildrenInput) (*organ
 	return c.orgClient.ListChildren(input)
 }
 
+func (c *awsClient) TagResource(input *organizations.TagResourceInput) (*organizations.TagResourceOutput, error) {
+	return c.orgClient.TagResource(input)
+}
+
 func (c *awsClient) AssumeRole(input *sts.AssumeRoleInput) (*sts.AssumeRoleOutput, error) {
 	return c.stsClient.AssumeRole(input)
 }
@@ -422,9 +427,9 @@ func newClient(controllerName, awsAccessID, awsAccessSecret, token, region strin
 		}, nil
 	}
 	ec2AwsConfig := &aws.Config{
-		Region:      		aws.String(region),
-		Credentials: 		credentials.NewStaticCredentials(awsAccessID, awsAccessSecret, token),
-		EndpointResolver: 	endpoints.ResolverFunc(resolver),
+		Region:           aws.String(region),
+		Credentials:      credentials.NewStaticCredentials(awsAccessID, awsAccessSecret, token),
+		EndpointResolver: endpoints.ResolverFunc(resolver),
 		Retryer: client.DefaultRetryer{
 			NumMaxRetries:    10,
 			MinThrottleDelay: 2 * time.Second,

--- a/pkg/awsclient/mock/zz_generated.mock_client.go
+++ b/pkg/awsclient/mock/zz_generated.mock_client.go
@@ -656,6 +656,21 @@ func (mr *MockClientMockRecorder) ListChildren(arg0 interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListChildren", reflect.TypeOf((*MockClient)(nil).ListChildren), arg0)
 }
 
+// TagResource mocks base method
+func (m *MockClient) TagResource(arg0 *organizations.TagResourceInput) (*organizations.TagResourceOutput, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "TagResource", arg0)
+	ret0, _ := ret[0].(*organizations.TagResourceOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// TagResource indicates an expected call of TagResource
+func (mr *MockClientMockRecorder) TagResource(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TagResource", reflect.TypeOf((*MockClient)(nil).TagResource), arg0)
+}
+
 // AssumeRole mocks base method
 func (m *MockClient) AssumeRole(arg0 *sts.AssumeRoleInput) (*sts.AssumeRoleOutput, error) {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
This adds tags to non-ccs accounts on creation. This contains their respective shard names. [OSD-7360](https://issues.redhat.com/browse/OSD-7360)