### PR TITLE
Allow for management of Route53 VPC Association Authorizations

### DIFF
--- a/test/deploy/aws.managed.openshift.io_v1alpha1_awsfederatedrole_networkmgmt_cr.yaml
+++ b/test/deploy/aws.managed.openshift.io_v1alpha1_awsfederatedrole_networkmgmt_cr.yaml
@@ -87,6 +87,15 @@ spec:
           - "route53:DisassociateVPCFromHostedZone"
         resource:
           - "*"
+      # Manage VPC Association Authorizations for 
+      # Ref https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/hosted-zone-private-associate-vpcs-different-accounts.html
+      - effect: Allow
+        action:
+          - "route53:ListHostedZones"
+          - "route53:CreateVPCAssociationAuthorization"
+          - "route53:DeleteVPCAssociationAuthorization"
+        resource:
+          - "*"          
       - effect: Allow
         action:
           - "ram:*"


### PR DESCRIPTION
Alternative to #614 

reference https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/hosted-zone-private-associate-vpcs-different-accounts.html

[OSD-7873](https://issues.redhat.com/browse/OSD-7873)