### PR TITLE
[OSD-7720] Fix AWS Federated Account Access from leaking Policies

### DIFF
--- a/pkg/controller/awsfederatedaccountaccess/awsfederatedaccountaccess_controller.go
+++ b/pkg/controller/awsfederatedaccountaccess/awsfederatedaccountaccess_controller.go
@@ -668,7 +668,9 @@ func (r *ReconcileAWSFederatedAccountAccess) cleanFederatedRoles(reqLogger logr.
 					return err
 				}
 			}
-			if *policy.PolicyName == federatedRoleCR.Spec.AWSCustomPolicy.Name {
+
+			awsCustomPolicyname := federatedRoleCR.Spec.AWSCustomPolicy.Name + "-" + uidLabel
+			if *policy.PolicyName == awsCustomPolicyname {
 				_, err = awsClient.DeletePolicy(&iam.DeletePolicyInput{PolicyArn: policy.PolicyArn})
 				if err != nil {
 					if aerr, ok := err.(awserr.Error); ok {

--- a/pkg/controller/awsfederatedaccountaccess/awsfederatedaccountaccess_controller.go
+++ b/pkg/controller/awsfederatedaccountaccess/awsfederatedaccountaccess_controller.go
@@ -243,7 +243,7 @@ func (r *ReconcileAWSFederatedAccountAccess) Reconcile(request reconcile.Request
 	if err != nil {
 		// if we were unable to create the policy fail this CR.
 		SetStatuswithCondition(currentFAA, "Failed to create custom policy", awsv1alpha1.AWSFederatedAccountFailed, awsv1alpha1.AWSFederatedAccountStateFailed)
-		reqLogger.Error(err, fmt.Sprintf("Unable to create policy resquested by '%s'", currentFAA.Name))
+		reqLogger.Error(err, fmt.Sprintf("Unable to create policy requested by '%s'", currentFAA.Name))
 
 		err := r.client.Status().Update(context.TODO(), currentFAA)
 		if err != nil {

--- a/pkg/controller/awsfederatedrole/awsfederatedrole_controller.go
+++ b/pkg/controller/awsfederatedrole/awsfederatedrole_controller.go
@@ -144,7 +144,6 @@ func (r *ReconcileAWSFederatedRole) Reconcile(request reconcile.Request) (reconc
 	}
 
 	// Validates Custom IAM Policy
-
 	log.Info("Validating Custom Policies")
 	// Build custom policy in AWS-valid JSON and converts to string
 	jsonPolicy, err := utils.MarshalIAMPolicy(*instance)


### PR DESCRIPTION
In the AWS Federated Account Access controller, there was a code for deleting policies after all operations are done, but due to a wrong check between the policy name and the actual attached policy name, the condition was never met and the deletion path was not executed and that lead to leaking policies. The issue was that the attached policy in AWS has a uid label as a suffix appended to the actual policy name. 

Example format:
- BillingReadOnlyAccess-48zkrs
- CustomerAdministratorAccess-6pvv82

But the policy name in the if the condition was just `BillingReadOnlyAccess`. This PR fixes the policy leaking.

PTAL 
See: https://issues.redhat.com/browse/OSD-7720