### PR TITLE
AWS Account Operator should check for the condition status of creating rather than the creation timestamp

### DIFF
--- a/pkg/apis/aws/v1alpha1/account_types.go
+++ b/pkg/apis/aws/v1alpha1/account_types.go
@@ -1,8 +1,6 @@
 package v1alpha1
 
 import (
-	"time"
-
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -229,12 +227,6 @@ func (a *Account) HasAwsv1alpha1Finalizer() bool {
 		}
 	}
 	return false
-}
-
-//IsOlderThan takes a parameter of a time and returns true if the creation timestamp is longer than
-//the passed in time.
-func (a *Account) IsOlderThan(maxDuration time.Duration) bool {
-	return time.Since(a.GetCreationTimestamp().Time) > maxDuration
 }
 
 //IsBYOCPendingDeletionWithFinalizer returns true if account is a BYOC Account,

--- a/pkg/controller/account/account_controller.go
+++ b/pkg/controller/account/account_controller.go
@@ -257,7 +257,7 @@ func (r *ReconcileAccount) Reconcile(request reconcile.Request) (reconcile.Resul
 		}
 
 		// see if in creating for longer than default wait time
-		if currentAcctInstance.IsCreating() && currentAcctInstance.IsOlderThan(createPendTime) {
+		if currentAcctInstance.IsCreating() && utils.CreationConditionOlderThan(*currentAcctInstance, createPendTime) {
 			errMsg := fmt.Sprintf("Creation pending for longer than %d minutes", utils.WaitTime)
 			_, stateErr := r.setAccountFailed(
 				reqLogger,

--- a/pkg/controller/account/account_controller_test.go
+++ b/pkg/controller/account/account_controller_test.go
@@ -13,6 +13,7 @@ import (
 	awsv1alpha1 "github.com/openshift/aws-account-operator/pkg/apis/aws/v1alpha1"
 	"github.com/openshift/aws-account-operator/pkg/awsclient/mock"
 	"github.com/openshift/aws-account-operator/pkg/controller/testutils"
+	"github.com/openshift/aws-account-operator/pkg/controller/utils"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/scheme"
@@ -544,7 +545,7 @@ func TestAccountCreatingToolong(t *testing.T) {
 		t.Run(
 			test.name,
 			func(t *testing.T) {
-				result := test.acct.acct.IsCreating() && test.acct.acct.IsOlderThan(createPendTime)
+				result := test.acct.acct.IsCreating() && utils.CreationConditionOlderThan(test.acct.acct, createPendTime)
 				if result != test.expected {
 					t.Error(
 						"for account:", test.acct,

--- a/pkg/controller/account/account_controller_test.go
+++ b/pkg/controller/account/account_controller_test.go
@@ -522,7 +522,8 @@ func TestAccountCreatingToolong(t *testing.T) {
 	}{
 		{
 			name: "Account creating too long",
-			acct: newTestAccountBuilder().WithState(awsv1alpha1.AccountCreating).WithStatus(awsv1alpha1.AccountStatus{
+			acct: newTestAccountBuilder().WithStatus(awsv1alpha1.AccountStatus{
+				State: string(awsv1alpha1.AccountCreating),
 				Conditions: []awsv1alpha1.AccountCondition{
 					{
 						Type:          awsv1alpha1.AccountCreating,
@@ -534,7 +535,8 @@ func TestAccountCreatingToolong(t *testing.T) {
 		},
 		{
 			name: "Account outside timeout threshold, but not creating",
-			acct: newTestAccountBuilder().WithState(awsv1alpha1.AccountReady).WithStatus(awsv1alpha1.AccountStatus{
+			acct: newTestAccountBuilder().WithStatus(awsv1alpha1.AccountStatus{
+				State: string(awsv1alpha1.AccountReady),
 				Conditions: []awsv1alpha1.AccountCondition{
 					{
 						Type:          awsv1alpha1.AccountCreating,
@@ -546,7 +548,8 @@ func TestAccountCreatingToolong(t *testing.T) {
 		},
 		{
 			name: "Account creating within timout threshold",
-			acct: newTestAccountBuilder().WithState(awsv1alpha1.AccountCreating).WithStatus(awsv1alpha1.AccountStatus{
+			acct: newTestAccountBuilder().WithStatus(awsv1alpha1.AccountStatus{
+				State: string(awsv1alpha1.AccountCreating),
 				Conditions: []awsv1alpha1.AccountCondition{
 					{
 						Type:          awsv1alpha1.AccountCreating,

--- a/pkg/controller/account/account_controller_test.go
+++ b/pkg/controller/account/account_controller_test.go
@@ -521,18 +521,39 @@ func TestAccountCreatingToolong(t *testing.T) {
 		acct     *testAccountBuilder
 	}{
 		{
-			name:     "Account creating too long",
-			acct:     newTestAccountBuilder().WithState(awsv1alpha1.AccountCreating).WithCreationTimeStamp(time.Now().Add(-(createPendTime + time.Minute))), // 1 minute longer than the allowed timeout
+			name: "Account creating too long",
+			acct: newTestAccountBuilder().WithState(awsv1alpha1.AccountCreating).WithStatus(awsv1alpha1.AccountStatus{
+				Conditions: []awsv1alpha1.AccountCondition{
+					{
+						Type:          awsv1alpha1.AccountCreating,
+						LastProbeTime: metav1.Time{Time: time.Now().Add(-(createPendTime + time.Minute))},
+					},
+				},
+			}), // 1 minute longer than the allowed timeout
 			expected: true,
 		},
 		{
-			name:     "Account outside timeout threshold, but not creating",
-			acct:     newTestAccountBuilder().WithState(awsv1alpha1.AccountReady).WithCreationTimeStamp(time.Now().Add(-(createPendTime + time.Minute))), // 1 minute longer than the allowed timeout
+			name: "Account outside timeout threshold, but not creating",
+			acct: newTestAccountBuilder().WithState(awsv1alpha1.AccountReady).WithStatus(awsv1alpha1.AccountStatus{
+				Conditions: []awsv1alpha1.AccountCondition{
+					{
+						Type:          awsv1alpha1.AccountCreating,
+						LastProbeTime: metav1.Time{Time: time.Now().Add(-(createPendTime + time.Minute))},
+					},
+				},
+			}), // 1 minute longer than the allowed timeout
 			expected: false,
 		},
 		{
-			name:     "Account creating within timout threshold",
-			acct:     newTestAccountBuilder().WithState(awsv1alpha1.AccountCreating),
+			name: "Account creating within timout threshold",
+			acct: newTestAccountBuilder().WithState(awsv1alpha1.AccountCreating).WithStatus(awsv1alpha1.AccountStatus{
+				Conditions: []awsv1alpha1.AccountCondition{
+					{
+						Type:          awsv1alpha1.AccountCreating,
+						LastProbeTime: metav1.Time{Time: time.Now()},
+					},
+				},
+			}),
 			expected: false,
 		},
 		{

--- a/pkg/controller/utils/conditions.go
+++ b/pkg/controller/utils/conditions.go
@@ -119,10 +119,7 @@ func FindAccountClaimCondition(conditions []awsv1alpha1.AccountClaimCondition, c
 // creationOlderThan returns true if the given account has been in a creation state for longer than the given time, else false
 func CreationConditionOlderThan(account awsv1alpha1.Account, duration time.Duration) bool {
 	createCondition := FindAccountCondition(account.Status.Conditions, awsv1alpha1.AccountCreating)
-	if createCondition != nil {
-		return time.Since(createCondition.LastProbeTime.Time) > duration
-	}
-	return false
+	return time.Since(createCondition.LastProbeTime.Time) > duration
 }
 
 // SetAccountCondition sets a condition on a Account resource's status

--- a/pkg/controller/utils/conditions.go
+++ b/pkg/controller/utils/conditions.go
@@ -118,8 +118,11 @@ func FindAccountClaimCondition(conditions []awsv1alpha1.AccountClaimCondition, c
 
 // creationOlderThan returns true if the given account has been in a creation state for longer than the given time, else false
 func CreationConditionOlderThan(account awsv1alpha1.Account, duration time.Duration) bool {
-	createCondition := account.GetCondition(awsv1alpha1.AccountReady)
-	return time.Since(createCondition.LastProbeTime.Time) > duration
+	createCondition := FindAccountCondition(account.Status.Conditions, awsv1alpha1.AccountCreating)
+	if createCondition != nil {
+		return time.Since(createCondition.LastProbeTime.Time) > duration
+	}
+	return false
 }
 
 // SetAccountCondition sets a condition on a Account resource's status

--- a/pkg/controller/utils/conditions.go
+++ b/pkg/controller/utils/conditions.go
@@ -2,6 +2,7 @@ package utils
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/go-logr/logr"
 	awsv1alpha1 "github.com/openshift/aws-account-operator/pkg/apis/aws/v1alpha1"
@@ -113,6 +114,12 @@ func FindAccountClaimCondition(conditions []awsv1alpha1.AccountClaimCondition, c
 		}
 	}
 	return nil
+}
+
+// creationOlderThan returns true if the given account has been in a creation state for longer than the given time, else false
+func CreationConditionOlderThan(account awsv1alpha1.Account, duration time.Duration) bool {
+	createCondition := account.GetCondition(awsv1alpha1.AccountReady)
+	return time.Since(createCondition.LastProbeTime.Time) > duration
 }
 
 // SetAccountCondition sets a condition on a Account resource's status


### PR DESCRIPTION
Card -> https://issues.redhat.com/browse/OSD-7693

Replaced `IsOlderThan` method  for `CreationConditionOlderThan`, updated tests.