### PR TITLE
We don't need to output the error because it is expected behavior

### DIFF
--- a/pkg/controller/account/account_controller.go
+++ b/pkg/controller/account/account_controller.go
@@ -1114,7 +1114,10 @@ func (r *ReconcileAccount) getCustomTags(log logr.Logger, account *awsv1alpha1.A
 
 	accountClaim, err := r.getAccountClaim(account)
 	if err != nil {
-		log.Error(err, "Error getting AccountClaim to get custom tags")
+		// We expect this error for non-ccs accounts
+		if account.IsBYOC() {
+			log.Error(err, "Error getting AccountClaim to get custom tags")
+		}
 		return tags
 	}
 


### PR DESCRIPTION
Card: https://issues.redhat.com/browse/OSD-7820