### PR TITLE
Update create account script to stop nuking existing account

### DIFF
--- a/test/integration/api/create_account.sh
+++ b/test/integration/api/create_account.sh
@@ -1,7 +1,17 @@
 #!/bin/bash
 
 # Load Environment vars
-source hack/scripts/test_envs 
+source hack/scripts/test_envs
+
+ACCOUNT_CR_EXISTS=$(oc get account ${OSD_STAGING_1_ACCOUNT_CR_NAME_OSD} -n ${NAMESPACE})
+ACCOUNT_CR_EXISTS=$?
+
+if [[ ${ACCOUNT_CR_EXISTS} = 0 ]]; then
+    echo "Account ${OSD_STAGING_1_ACCOUNT_CR_NAME_OSD} already exists, skipping creation."
+    exit 0
+else
+    echo "Creating Account ${OSD_STAGING_1_ACCOUNT_CR_NAME_OSD}" 
+fi
 
 # Create Account CR 
 oc process -p AWS_ACCOUNT_ID=${OSD_STAGING_1_AWS_ACCOUNT_ID} -p ACCOUNT_CR_NAME=${OSD_STAGING_1_ACCOUNT_CR_NAME_OSD} -p NAMESPACE=${NAMESPACE} -f hack/templates/aws.managed.openshift.io_v1alpha1_account.tmpl | oc apply -f -


### PR DESCRIPTION
Encountered an issue today when calling `make create-accountclaim` when an account CR with a name of `osd-creds-mgmt-osd-staging-1` already exists, the call nukes the existing account and replaces it with a templated account CR. 

Fixed by adding a check to see if account already exists before applying new account CR.