### PR TITLE
Adds some new metrics to the accountpool status

### DIFF
--- a/deploy/crds/aws.managed.openshift.io_accountpools.yaml
+++ b/deploy/crds/aws.managed.openshift.io_accountpools.yaml
@@ -29,6 +29,18 @@ spec:
       jsonPath: .status.claimedAccounts
       name: Claimed Accounts
       type: integer
+    - description: Number of ready accounts
+      jsonPath: .status.availableAccounts
+      name: Available Accounts
+      type: integer
+    - description: Number of accounts progressing towards ready
+      jsonPath: .status.accountsProgressing
+      name: Accounts Progressing
+      type: integer
+    - description: Difference between accounts created and soft limit
+      jsonPath: .status.awsLimitDelta
+      name: AWS Limit Delta
+      type: integer
     name: v1alpha1
     schema:
       openAPIV3Schema:
@@ -57,13 +69,36 @@ spec:
           status:
             description: AccountPoolStatus defines the observed state of AccountPool
             properties:
+              accountsProgressing:
+                description: AccountsProgressing shows the approximate value of the
+                  number of accounts that are in the creation workflow (Creating,
+                  PendingVerification, InitializingRegions)
+                type: integer
+              availableAccounts:
+                description: AvailableAccounts denotes accounts that HAVE NEVER BEEN
+                  CLAIMED, so NOT reused, and are READY to be claimed.  This differs
+                  from the UnclaimedAccounts, who similarly HAVE NEVER BEEN CLAIMED,
+                  but include ALL non-FAILED states
+                type: integer
+              awsLimitDelta:
+                description: AWSLimitDelta shows the approximate difference between
+                  the number of AWS accounts currently created and the limit. This
+                  should be the same across all hive shards in an environment
+                type: integer
               claimedAccounts:
+                description: ClaimedAccounts is an approximate value representing
+                  the amount of accounts that are currently claimed
                 type: integer
               poolSize:
                 type: integer
               unclaimedAccounts:
+                description: UnclaimedAccounts is an approximate value representing
+                  the amount of non-failed accounts
                 type: integer
             required:
+            - accountsProgressing
+            - availableAccounts
+            - awsLimitDelta
             - claimedAccounts
             - poolSize
             - unclaimedAccounts

--- a/pkg/apis/aws/v1alpha1/account_types.go
+++ b/pkg/apis/aws/v1alpha1/account_types.go
@@ -266,6 +266,39 @@ func (a *Account) IsInitializingRegions() bool {
 	return a.Status.State == AccountInitializingRegions
 }
 
+//IsProgressing returns true if the account state is Creating, Pending Verification, or InitializingRegions
+func (a *Account) IsProgressing() bool {
+	if a.Status.State == string(AccountCreating) ||
+		a.Status.State == string(AccountPendingVerification) ||
+		a.Status.State == string(AccountInitializingRegions) {
+		return true
+	}
+	return false
+}
+
+// HasBeenClaimed lets us know if an account has been claimed at some point and can only be reused by clusters in the same legal entity
+func (a *Account) HasBeenClaimedAtLeastOnce() bool {
+	return a.Spec.LegalEntity.ID != "" || a.Status.Reused
+}
+
+//HasNeverBeenClaimed returns true if the account is not claimed AND has no legalEntity set, meaning it hasn't been claimed before and is not available for reuse
+func (a *Account) HasNeverBeenClaimed() bool {
+	return !a.Status.Claimed && a.Spec.LegalEntity.ID == ""
+}
+
+//IsOwnedByAccountPool returns true if the account has an ownerreference type that is the accountpool
+func (a *Account) IsOwnedByAccountPool() bool {
+	if a.ObjectMeta.OwnerReferences == nil {
+		return false
+	}
+	for _, ref := range a.ObjectMeta.OwnerReferences {
+		if ref.Kind == "AccountPool" {
+			return true
+		}
+	}
+	return false
+}
+
 // GetCondition finds the condition that has the
 // specified condition type in the given list. If none exists, then returns nil.
 func (a *Account) GetCondition(conditionType AccountConditionType) *AccountCondition {

--- a/pkg/apis/aws/v1alpha1/accountpool_types.go
+++ b/pkg/apis/aws/v1alpha1/accountpool_types.go
@@ -16,9 +16,22 @@ type AccountPoolSpec struct {
 // AccountPoolStatus defines the observed state of AccountPool
 // +k8s:openapi-gen=true
 type AccountPoolStatus struct {
-	PoolSize          int `json:"poolSize"`
+	PoolSize int `json:"poolSize"`
+
+	// UnclaimedAccounts is an approximate value representing the amount of non-failed accounts
 	UnclaimedAccounts int `json:"unclaimedAccounts"`
-	ClaimedAccounts   int `json:"claimedAccounts"`
+
+	// ClaimedAccounts is an approximate value representing the amount of accounts that are currently claimed
+	ClaimedAccounts int `json:"claimedAccounts"`
+
+	// AvailableAccounts denotes accounts that HAVE NEVER BEEN CLAIMED, so NOT reused, and are READY to be claimed.  This differs from the UnclaimedAccounts, who similarly HAVE NEVER BEEN CLAIMED, but include ALL non-FAILED states
+	AvailableAccounts int `json:"availableAccounts"`
+
+	// AccountsProgressing shows the approximate value of the number of accounts that are in the creation workflow (Creating, PendingVerification, InitializingRegions)
+	AccountsProgressing int `json:"accountsProgressing"`
+
+	// AWSLimitDelta shows the approximate difference between the number of AWS accounts currently created and the limit. This should be the same across all hive shards in an environment
+	AWSLimitDelta int `json:"awsLimitDelta"`
 }
 
 // +genclient
@@ -30,6 +43,9 @@ type AccountPoolStatus struct {
 // +kubebuilder:printcolumn:name="Pool Size",type="integer",JSONPath=".status.poolSize",description="Desired pool size"
 // +kubebuilder:printcolumn:name="Unclaimed Accounts",type="integer",JSONPath=".status.unclaimedAccounts",description="Number of unclaimed accounts"
 // +kubebuilder:printcolumn:name="Claimed Accounts",type="integer",JSONPath=".status.claimedAccounts",description="Number of claimed accounts"
+// +kubebuilder:printcolumn:name="Available Accounts",type="integer",JSONPath=".status.availableAccounts",description="Number of ready accounts"
+// +kubebuilder:printcolumn:name="Accounts Progressing",type="integer",JSONPath=".status.accountsProgressing",description="Number of accounts progressing towards ready"
+// +kubebuilder:printcolumn:name="AWS Limit Delta",type="integer",JSONPath=".status.awsLimitDelta",description="Difference between accounts created and soft limit"
 // +kubebuilder:resource:path=accountpools,scope=Namespaced
 type AccountPool struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/pkg/apis/aws/v1alpha1/zz_generated.openapi.go
+++ b/pkg/apis/aws/v1alpha1/zz_generated.openapi.go
@@ -598,18 +598,41 @@ func schema_pkg_apis_aws_v1alpha1_AccountPoolStatus(ref common.ReferenceCallback
 					},
 					"unclaimedAccounts": {
 						SchemaProps: spec.SchemaProps{
-							Type:   []string{"integer"},
-							Format: "int32",
+							Description: "UnclaimedAccounts is an approximate value representing the amount of non-failed accounts",
+							Type:        []string{"integer"},
+							Format:      "int32",
 						},
 					},
 					"claimedAccounts": {
 						SchemaProps: spec.SchemaProps{
-							Type:   []string{"integer"},
-							Format: "int32",
+							Description: "ClaimedAccounts is an approximate value representing the amount of accounts that are currently claimed",
+							Type:        []string{"integer"},
+							Format:      "int32",
+						},
+					},
+					"availableAccounts": {
+						SchemaProps: spec.SchemaProps{
+							Description: "AvailableAccounts denotes accounts that HAVE NEVER BEEN CLAIMED, so NOT reused, and are READY to be claimed.  This differs from the UnclaimedAccounts, who similarly HAVE NEVER BEEN CLAIMED, but include ALL non-FAILED states",
+							Type:        []string{"integer"},
+							Format:      "int32",
+						},
+					},
+					"accountsProgressing": {
+						SchemaProps: spec.SchemaProps{
+							Description: "AccountsProgressing shows the approximate value of the number of accounts that are in the creation workflow (Creating, PendingVerification, InitializingRegions)",
+							Type:        []string{"integer"},
+							Format:      "int32",
+						},
+					},
+					"awsLimitDelta": {
+						SchemaProps: spec.SchemaProps{
+							Description: "AWSLimitDelta shows the approximate difference between the number of AWS accounts currently created and the limit. This should be the same across all hive shards in an environment",
+							Type:        []string{"integer"},
+							Format:      "int32",
 						},
 					},
 				},
-				Required: []string{"poolSize", "unclaimedAccounts", "claimedAccounts"},
+				Required: []string{"poolSize", "unclaimedAccounts", "claimedAccounts", "availableAccounts", "accountsProgressing", "awsLimitDelta"},
 			},
 		},
 	}

--- a/pkg/totalaccountwatcher/totalaccountwatcher_test.go
+++ b/pkg/totalaccountwatcher/totalaccountwatcher_test.go
@@ -200,8 +200,9 @@ func TestAccountLimitsReached(t *testing.T) {
 				objs := []runtime.Object{configMap}
 				mocks := setupDefaultMocks(t, objs)
 				nullLogger := testutils.NullLogger{}
+				taw := newTotalAccountWatcher(mocks.fakeKubeClient, mocks.mockAWSClient, 10)
 
-				result, _ := accountLimitReached(mocks.fakeKubeClient, nullLogger, test.testCount)
+				result, _ := taw.accountLimitReached(nullLogger, test.testCount)
 
 				if result != test.expected {
 					t.Error(


### PR DESCRIPTION
Adds additional status fields and calculations for the same in order to start reporting better metrics on accountPool availability.

Satisfies [OSD-7754](https://issues.redhat.com/browse/OSD-7754)