### PR TITLE
allow network-mgmt to dowload the VPN configs

### DIFF
--- a/hack/olm-registry/olm-artifacts-template.yaml
+++ b/hack/olm-registry/olm-artifacts-template.yaml
@@ -149,8 +149,6 @@ objects:
             - "ec2:ModifyVpcPeeringConnectionOptions"
             - "ec2:RejectVpcPeeringConnection"
             - "ec2:DisableVgwRoutePropagation"
-            - "ec2:GetVpnConnectionDeviceTypes"
-            - "ec2:GetVpnConnectionDeviceSampleConfiguration"
             - "ec2:EnableVgwRoutePropagation"
             - "ec2:CreateNetworkInterface"
             - "ec2:ModifyNetworkInterfaceAttribute"

--- a/hack/olm-registry/olm-artifacts-template.yaml
+++ b/hack/olm-registry/olm-artifacts-template.yaml
@@ -149,6 +149,8 @@ objects:
             - "ec2:ModifyVpcPeeringConnectionOptions"
             - "ec2:RejectVpcPeeringConnection"
             - "ec2:DisableVgwRoutePropagation"
+            - "ec2:GetVpnConnectionDeviceTypes"
+            - "ec2:GetVpnConnectionDeviceSampleConfiguration"
             - "ec2:EnableVgwRoutePropagation"
             - "ec2:CreateNetworkInterface"
             - "ec2:ModifyNetworkInterfaceAttribute"
@@ -221,6 +223,8 @@ objects:
             - "ec2:DeleteVpnConnection"
             - "ec2:EnableVgwRoutePropagation"
             - "ec2:DisableVgwRoutePropagation"
+            - "ec2:GetVpnConnectionDeviceTypes"
+            - "ec2:GetVpnConnectionDeviceSampleConfiguration"
           resource:
             - "*"
         - effect: Allow

--- a/test/deploy/aws.managed.openshift.io_v1alpha1_awsfederatedrole_networkmgmt_cr.yaml
+++ b/test/deploy/aws.managed.openshift.io_v1alpha1_awsfederatedrole_networkmgmt_cr.yaml
@@ -123,6 +123,8 @@ spec:
           - "ec2:DeleteVpnConnection"
           - "ec2:EnableVgwRoutePropagation"
           - "ec2:DisableVgwRoutePropagation"
+          - "ec2:GetVpnConnectionDeviceTypes"
+          - "ec2:GetVpnConnectionDeviceSampleConfiguration"
         resource:
           - "*"
 


### PR DESCRIPTION
The permissions required to download a VPN config from AWS appear to have changed, which is preventing customers from downloading it themselves using network-mgmt. This adds the missing permissions.

This is generating toil, as documented in OHSS-6964, [OHSS-7075](https://issues.redhat.com/browse/OHSS-7075) and [OHSS-7264](https://issues.redhat.com/browse/OHSS-7264) where we had to manually provide the configs for the customers.

This should resolve OSD-8599.