### PR TITLE
Document additional iam permissions for dev setup

### DIFF
--- a/docs/1.1-InstallationPrerequisites.md
+++ b/docs/1.1-InstallationPrerequisites.md
@@ -138,6 +138,31 @@ You will need to note the `ARN` for this `Jump Role` as it's required for the ne
 
 **Note:** You will need to put the ARN for this `Jump Role` into the Operator Config Map created later - in the `STS_JUMP_ARN` environment variable.
 
+**Note 2:** Make sure your iam user in the `Payer Account` has sufficient permissions to assume the role. To do so, log in to your `Payer Account` again and go to `AWS Console > IAM > Users > [Username] > + Add inline policy`. Click on `JSON` and paste the following policy json:
+
+```json
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Sid": "VisualEditor0",
+            "Effect": "Allow",
+            "Action": "sts:AssumeRole",
+            "Resource": "arn:aws:iam::[assigned-osd-staging-1-account]:role/*"
+        }
+    ]
+}
+```
+
+Replace `[assigned-osd-staging-1-account]` with the ID of the Account you created the Jump Role in. Verify your permissions by assuming the role from your awscli:
+
+```
+$> aws sts assume-role --role-arn ${STS_JUMP_ARN} --role-session-name "STSCredsCheck"
+{
+    "Credentials": {
+...
+```
+
 #### 1.1.3.2 - Access Role
 
 The `Access Role` will be a simulation of a role on a customer's account that gives us access to initialize the regions and initialize a cluster.  On external customer accounts this is assumed to be a very locked-down role with ONLY the necessary permissions needed to run the operator or install the cluster resources. Minimal permissions required for the role are provided below.


### PR DESCRIPTION
This PR just adds a small section to the prerequisites docs explaining the additional iam policies need to run the operator in local dev mode.

