### PR TITLE
Update OWNERS

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -2,12 +2,14 @@ reviewers:
 - jharrington22
 - fahlmant
 - iamkirkbater
-- rogbas
-- ArielLima
 - drpaneas
 - dastergon
 - dkeohane
+- katherinelc321
+- mrWinston
+- NautiluX
 approvers:
 - jharrington22
 - iamkirkbater
+- NautiluX
 maintainers:


### PR DESCRIPTION
Updates the Owners to reflect current team status.

Adding Manuel as an additional approver for the cases where I might not be around where something needs to urgently be merged.