### PR TITLE
Make local log output human friendly

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -284,7 +284,7 @@ predeploy: predeploy-aws-account-operator deploy-aws-account-operator-credential
 
 .PHONY: deploy-local
 deploy-local: ## Deploy Operator locally
-	@FORCE_DEV_MODE=local operator-sdk run --local --namespace=$(OPERATOR_NAMESPACE)
+	@FORCE_DEV_MODE=local operator-sdk run --local --namespace=$(OPERATOR_NAMESPACE) --operator-flags "--zap-devel"
 
 .PHONY: deploy-local-debug
 deploy-local-debug: ## Deploy Operator locally with Delve enabled


### PR DESCRIPTION
This PR turns the log messages of the aao from json based:
```
{"level":"info","ts":1636103590.8215709,"logger":"controller-runtime.metrics","msg":"metrics server is starting to listen","addr":"0.0.0.0:8081"}
{"level":"info","ts":1636103590.8217633,"logger":"cmd","msg":"Registering Components."}
{"level":"error","ts":1636103590.822052,"logger":"controller_account","msg":"failed retrieving configmap","error":"the cache is not started, can not read objects","stacktrace":"github.com/go-logr/zapr.(*zapLogger).Error\n\t/home/maschulz/go/pkg/mod/github.com/go-logr/zapr@v0.1.1/zapr.go:128\ngithub.com/openshift/aws-account-operator/pkg/controller/account.newReconciler\n\t/home/path/to/operators/aws-account-operator/pkg/controller/account/account_controller.go:94\ngithub.com/openshift/aws-account-operator/pkg/controller/account.Add\n\t/home/path/to/operators/aws-account-operator/pkg/controller/account/account_controller.go:81\ngithub.com/openshift/aws-account-operator/pkg/controller.AddToManager\n\t/home/path/to/operators/aws-account-operator/pkg/controller/controller.go:13\nmain.main\n\t/home/path/to/operators/aws-account-operator/cmd/manager/main.go:134\nruntime.main\n\t/usr/local/go/src/runtime/proc.go:255"}
```
into more easily digestible log messages looking like this:

```
2021-11-05T10:13:28.460+0100    INFO    controller-runtime.metrics      metrics server is starting to listen    {"addr": "0.0.0.0:8081"}
2021-11-05T10:13:28.461+0100    INFO    cmd     Registering Components.
2021-11-05T10:13:28.461+0100    ERROR   controller_account      failed retrieving configmap     {"error": "the cache is not started, can not read objects"}
github.com/go-logr/zapr.(*zapLogger).Error
        /home/maschulz/go/pkg/mod/github.com/go-logr/zapr@v0.1.1/zapr.go:128
github.com/openshift/aws-account-operator/pkg/controller/account.newReconciler
        /home/maschulz/code/operators/aws-account-operator/pkg/controller/account/account_controller.go:94
github.com/openshift/aws-account-operator/pkg/controller/account.Add
        /home/maschulz/code/operators/aws-account-operator/pkg/controller/account/account_controller.go:81
github.com/openshift/aws-account-operator/pkg/controller.AddToManager
        /home/maschulz/code/operators/aws-account-operator/pkg/controller/controller.go:13
main.main
        /home/maschulz/code/operators/aws-account-operator/cmd/manager/main.go:134
runtime.main
        /usr/local/go/src/runtime/proc.go:255
2021-11-05T10:13:28.462+0100    ERROR   controller_account      shard-name key not available in configmap       {"error": "the cache is not started, can not read objects"}
github.com/go-logr/zapr.(*zapLogger).Error
        /home/maschulz/go/pkg/mod/github.com/go-logr/zapr@v0.1.1/zapr.go:128
github.com/openshift/aws-account-operator/pkg/controller/account.newReconciler
        /home/maschulz/code/operators/aws-account-operator/pkg/controller/account/account_controller.go:99
github.com/openshift/aws-account-operator/pkg/controller/account.Add
        /home/maschulz/code/operators/aws-account-operator/pkg/controller/account/account_controller.go:81
github.com/openshift/aws-account-operator/pkg/controller.AddToManager
        /home/maschulz/code/operators/aws-account-operator/pkg/controller/controller.go:13
main.main
        /home/maschulz/code/operators/aws-account-operator/cmd/manager/main.go:134
runtime.main
        /usr/local/go/src/runtime/proc.go:255
```

This only affects the `deploy-local` make target and has no influence on any other deployment methods.