### PR TITLE
OSD-7210: Move AccountClaim Validation into the AccountClaim controller

### DIFF
--- a/pkg/controller/account/byoc.go
+++ b/pkg/controller/account/byoc.go
@@ -64,27 +64,6 @@ func (r *ReconcileAccount) initializeNewCCSAccount(reqLogger logr.Logger, accoun
 		return reconcile.Result{}, acctClaimErr
 	}
 
-	validateErr := accountClaim.Validate()
-	if validateErr != nil {
-		// Figure the reason for our failure
-		errReason := validateErr.Error()
-		// Update AccountClaim status
-		utils.SetAccountClaimStatus(
-			accountClaim,
-			"Invalid AccountClaim",
-			errReason,
-			awsv1alpha1.InvalidAccountClaim,
-			awsv1alpha1.ClaimStatusError,
-		)
-		err := r.Client.Status().Update(context.TODO(), accountClaim)
-		if err != nil {
-			reqLogger.Error(err, "Failed to Update AccountClaim Status")
-		}
-
-		// TODO: Recoverable?
-		return reconcile.Result{}, validateErr
-	}
-
 	claimErr := claimBYOCAccount(r, reqLogger, account)
 	if claimErr != nil {
 		reqLogger.Error(claimErr, "Could not claim BYOC Account")

--- a/pkg/controller/account/byoc_test.go
+++ b/pkg/controller/account/byoc_test.go
@@ -459,36 +459,6 @@ func TestInitializeNewCCSAccount(t *testing.T) {
 		},
 
 		{
-			name: "accountClaim validation fails",
-			acct: &awsv1alpha1.Account{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "AccName",
-					Namespace: awsv1alpha1.AccountCrNamespace,
-				},
-				Spec: awsv1alpha1.AccountSpec{
-					BYOC: true,
-				},
-				Status: awsv1alpha1.AccountStatus{
-					Claimed: false,
-				},
-			},
-			localObjects: []runtime.Object{
-				&awsv1alpha1.AccountClaim{
-					ObjectMeta: metav1.ObjectMeta{
-						Namespace: awsv1alpha1.AccountCrNamespace,
-					},
-					Spec: awsv1alpha1.AccountClaimSpec{
-						BYOC:                true,
-						BYOCAWSAccountID:    "1234",
-						BYOCSecretRef:       awsv1alpha1.SecretRef{},
-						AwsCredentialSecret: awsv1alpha1.SecretRef{},
-					},
-				},
-			},
-			errExpected:    true,
-			expectedResult: awsv1alpha1.ErrBYOCSecretRefMissing,
-		},
-		{
 			name: "claimBYOCAccount returned error",
 			acct: &awsv1alpha1.Account{
 				ObjectMeta: metav1.ObjectMeta{

--- a/pkg/controller/accountclaim/accountclaim_controller.go
+++ b/pkg/controller/accountclaim/accountclaim_controller.go
@@ -323,7 +323,29 @@ func (r *ReconcileAccountClaim) handleBYOCAccountClaim(reqLogger logr.Logger, ac
 		}
 	}
 
+	// Check, if already associated with an Account
 	if accountClaim.Spec.AccountLink == "" {
+		validateErr := accountClaim.Validate()
+		if validateErr != nil {
+			// Figure the reason for our failure
+			errReason := validateErr.Error()
+			// Update AccountClaim status
+			utils.SetAccountClaimStatus(
+				accountClaim,
+				"Invalid AccountClaim",
+				errReason,
+				awsv1alpha1.InvalidAccountClaim,
+				awsv1alpha1.ClaimStatusError,
+			)
+			err := r.client.Status().Update(context.TODO(), accountClaim)
+			if err != nil {
+				reqLogger.Error(err, "Failed to Update AccountClaim Status")
+			}
+
+			// TODO: Recoverable?
+			return reconcile.Result{}, validateErr
+		}
+
 		// Create a new account with BYOC flag
 		err := r.createAccountForBYOCClaim(accountClaim)
 		if err != nil {


### PR DESCRIPTION
This PR makes sure, that the accountclaim validation happens before any account is even created by moving the validation code to `pkg/controller/accountclaim/accountclaim_controller.go`.

Additional unit tests are also added to cover the basics of creating a byoc accountclaim.