### PR TITLE
OSD-7582: Deploy Account Shredder Service Account in Account Operator

### DIFF
--- a/deploy/aas_role.yaml
+++ b/deploy/aas_role.yaml
@@ -1,0 +1,34 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  namespace: aws-account-operator
+  name: aws-account-shredder
+rules:
+- apiGroups:
+  - route.openshift.io
+  resources:
+  - routes
+  verbs:
+  - '*'
+- apiGroups:
+  - ""
+  resources:
+  - services
+  verbs:
+  - '*'
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - 'get'
+  - 'list'
+- apiGroups:
+    - aws.managed.openshift.io
+  resources:
+    - accounts
+    - accounts/status
+  verbs:
+    - 'get'
+    - 'list'
+    - 'update'

--- a/deploy/aas_role_binding.yaml
+++ b/deploy/aas_role_binding.yaml
@@ -1,0 +1,14 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: aws-account-shredder
+  namespace: aws-account-operator
+subjects:
+- kind: ServiceAccount
+  name: aws-account-shredder
+  namespace: aws-account-operator
+roleRef:
+  kind: Role
+  name: aws-account-shredder
+  apiGroup: rbac.authorization.k8s.io
+  namespace: aws-account-operator

--- a/deploy/aas_service_account.yaml
+++ b/deploy/aas_service_account.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: aws-account-shredder
+  namespace: aws-account-operator


### PR DESCRIPTION
This PR makes sure that the service account and accompanying roles for the aws-account-*shredder* are deployed alongside the aws-account-*operator*.

Jira: [OSD-7582](https://issues.redhat.com/browse/OSD-7582)