### PR TITLE
PoC for Post Manager Init

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -28,6 +28,8 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 
+	"github.com/openshift/aws-account-operator/pkg/controller/account"
+
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/spf13/pflag"
@@ -190,6 +192,9 @@ func main() {
 		log.Error(err, "Manager exited non-zero")
 		os.Exit(1)
 	}
+
+	// Post-manager reconcile initialization
+	account.Reconciler.PostManagerInit()
 }
 
 func initOperatorConfigMapVars(kubeClient client.Client) {

--- a/pkg/controller/account/account_controller.go
+++ b/pkg/controller/account/account_controller.go
@@ -151,6 +151,11 @@ func (r *ReconcileAccount) PostManagerInit() {
 // The Controller will requeue the Request to be processed again if the returned error is non-nil or
 // Result.Requeue is true, otherwise upon completion it will remove the work from the queue.
 func (r *ReconcileAccount) Reconcile(request reconcile.Request) (reconcile.Result, error) {
+	if !r.postInitHasRun {
+		log.Info("PostInit has not run yet. Requeueing.")
+		return reconcile.Result{Requeue: true}, nil
+	}
+
 	reqLogger := log.WithValues("Controller", controllerName, "Request.Namespace", request.Namespace, "Request.Name", request.Name)
 
 	// Fetch the Account instance

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -7,6 +7,9 @@ import (
 // AddToManagerFuncs is a list of functions to add all Controllers to the Manager
 var AddToManagerFuncs []func(manager.Manager) error
 
+// PostInitFuncs is a list of functions to run after the manager has started
+var PostInitFuncs []func()
+
 // AddToManager adds all Controllers to the Manager
 func AddToManager(m manager.Manager) error {
 	for _, f := range AddToManagerFuncs {


### PR DESCRIPTION
Proof of concept for adding a Post-Manager-Init function that will allow us to pull data from the ConfigMap and inject it into the reconciler.

I haven't had a chance to actually test this because CRC hates my computer.  This is just a jumping-off point.