### PR TITLE
Remove account finalizer for non-STS accounts to fix local testing

### DIFF
--- a/pkg/apis/aws/v1alpha1/account_types.go
+++ b/pkg/apis/aws/v1alpha1/account_types.go
@@ -229,6 +229,16 @@ func (a *Account) HasAwsv1alpha1Finalizer() bool {
 	return false
 }
 
+func (a *Account) IsSTS() bool {
+	return a.Spec.ManualSTSMode
+}
+
+func (a *Account) IsNonSTSPendingDeletionWithFinalizer() bool {
+	return a.IsPendingDeletion() &&
+		!a.IsSTS() &&
+		a.HasAwsv1alpha1Finalizer()
+}
+
 //IsBYOCPendingDeletionWithFinalizer returns true if account is a BYOC Account,
 // has been marked for deletion (deletion timestamp set), and has a finalizer set.
 func (a *Account) IsBYOCPendingDeletionWithFinalizer() bool {

--- a/pkg/controller/account/account_controller.go
+++ b/pkg/controller/account/account_controller.go
@@ -212,9 +212,9 @@ func (r *ReconcileAccount) Reconcile(request reconcile.Request) (reconcile.Resul
 		r.finalizeAccount(reqLogger, awsClient, currentAcctInstance)
 		//return reconcile.Result{}, nil
 
-		// Remove finalizer if account CR is BYOC as the accountclaim controller will delete the account CR
-		// when the accountClaim CR is deleted as its set as the owner reference
-		if currentAcctInstance.IsBYOCPendingDeletionWithFinalizer() {
+		// Remove finalizer if account CR is non STS. For CCS accounts, the accountclaim controller will delete the account CR
+		// when the accountClaim CR is deleted as its set as the owner reference.
+		if currentAcctInstance.IsNonSTSPendingDeletionWithFinalizer() {
 			reqLogger.Info("removing account finalizer")
 			err = r.removeFinalizer(currentAcctInstance, awsv1alpha1.AccountFinalizer)
 			if err != nil {


### PR DESCRIPTION
Fix for a bug introduced:

- Found when local testing `make test-all`
- We recently added finalizers to non-CCS account CRs, but never removed the finalizer on account deletion call. Therefore, the test suite is hanging on account deletion call, as the account CR is never deleted because the finalizer is never removed.