### PR TITLE
Add namespace to test accountpool CR

### DIFF
--- a/hack/files/aws.managed.openshift.io_v1alpha1_zero_size_accountpool.yaml
+++ b/hack/files/aws.managed.openshift.io_v1alpha1_zero_size_accountpool.yaml
@@ -2,5 +2,6 @@ apiVersion: aws.managed.openshift.io/v1alpha1
 kind: AccountPool
 metadata:
   name: zero-size-accountpool
+  namespace: aws-account-operator
 spec:
   poolSize: 0


### PR DESCRIPTION
When running  "make deploy-cluster" the accountpool CR in hack/files/aws.managed.openshift.io_v1alpha1_zero_size_accountpool.yaml is getting deployed to the default namespace. This PR fixes that by adding in the namespace field in the metadata