### PR TITLE
naming the ec2 test instance that is created in each aws region

### DIFF
--- a/pkg/awsclient/tags.go
+++ b/pkg/awsclient/tags.go
@@ -42,6 +42,10 @@ func (t *AWSAccountOperatorTags) GetEC2Tags() []*ec2.Tag {
 	for _, tag := range t.Tags {
 		tags = append(tags, &ec2.Tag{Key: aws.String(tag.Key), Value: aws.String(tag.Value)})
 	}
+
+	//make sure the ec2 instance has a descriptive name to avoid customer confusion
+	tags = append(tags, &ec2.Tag{Key: aws.String("Name"), Value: aws.String("red-hat-region-init")})
+
 	return tags
 }
 


### PR DESCRIPTION
Closes [OSD-7011](https://issues.redhat.com/browse/OSD-7011) - provide a name for the AWS ec2 region test instances.