### PR TITLE
Revert "naming the ec2 test instance that is created in each aws region"

### DIFF
--- a/pkg/awsclient/tags.go
+++ b/pkg/awsclient/tags.go
@@ -42,10 +42,6 @@ func (t *AWSAccountOperatorTags) GetEC2Tags() []*ec2.Tag {
 	for _, tag := range t.Tags {
 		tags = append(tags, &ec2.Tag{Key: aws.String(tag.Key), Value: aws.String(tag.Value)})
 	}
-
-	//make sure the ec2 instance has a descriptive name to avoid customer confusion
-	tags = append(tags, &ec2.Tag{Key: aws.String("Name"), Value: aws.String("red-hat-region-init")})
-
 	return tags
 }
 


### PR DESCRIPTION
Reverts openshift/aws-account-operator#671

Facepalm, all we needed to do was update the app-interface parameters file with `red-hat-managed=true`, which I had wrongly assumed was already one of the tags being added.