### PR TITLE
Handle Region Initialization for FedRAMP

### DIFF
--- a/hack/olm-registry/olm-artifacts-template.yaml
+++ b/hack/olm-registry/olm-artifacts-template.yaml
@@ -98,6 +98,8 @@ objects:
       sa-east-1:ami-05c1c16cac05a7c0b:t2.micro
       af-south-1:ami-0f4b49fefef9be45a:t3.micro
       me-south-1:ami-0b41a37a62a4296fc:t3.micro
+      us-gov-west-1:ami-2c74214d:t2.micro
+      us-gov-east-1:ami-9e10f0ef:t2.micro
 
 - apiVersion: aws.managed.openshift.io/v1alpha1
   kind: AccountPool

--- a/hack/templates/aws.managed.openshift.io_v1alpha1_configmap.tmpl
+++ b/hack/templates/aws.managed.openshift.io_v1alpha1_configmap.tmpl
@@ -44,5 +44,7 @@ objects:
       sa-east-1:ami-05c1c16cac05a7c0b:t2.micro
       af-south-1:ami-0f4b49fefef9be45a:t3.micro
       me-south-1:ami-0b41a37a62a4296fc:t3.micro
+      us-gov-west-1:ami-2c74214d:t2.micro
+      us-gov-east-1:ami-9e10f0ef:t2.micro
     sts-jump-role: ${STS_JUMP_ARN}
     support-jump-role: ${SUPPORT_JUMP_ROLE}

--- a/pkg/apis/aws/v1alpha1/shared_types.go
+++ b/pkg/apis/aws/v1alpha1/shared_types.go
@@ -74,6 +74,18 @@ var ErrInvalidToken = errors.New("InvalidClientTokenId")
 // ErrAccessDenied indicates an AWS error from an API call
 var ErrAccessDenied = errors.New("AuthorizationError")
 
+// ErrFailedToCreateVpc indicates that there was a failure while trying to create a VPC
+var ErrFailedToCreateVpc = errors.New("FailedToCreateVpc")
+
+// ErrFailedToDeleteVpc indicates that there was a failure while trying to delete a VPC
+var ErrFailedToDeleteVpc = errors.New("FailedToDeleteVpc")
+
+// ErrFailedToCreateSubnet indicates that there was a failure while trying to create subnet
+var ErrFailedToCreateSubnet = errors.New("FailedToCreateSubnet")
+
+// ErrFailedToDeleteSubnet indicates that there was a failure while trying to delete subnet
+var ErrFailedToDeleteSubnet = errors.New("FailedToDeleteSubnet")
+
 // Shared variables
 
 // UIDLabel is the string for the uid label on AWS Federated Account Access CRs
@@ -105,6 +117,12 @@ var InstanceResourceType = "instance"
 
 // VolumeResourceType is the resource type used when building Volume tags
 var VolumeResourceType = "volume"
+
+// VpcResourceType is the resource type used when building Vpc tags
+var VpcResourceType = "vpc"
+
+// SubnetResourceType is the resource type used when building Subnet tags
+var SubnetResourceType = "subnet"
 
 // DefaultConfigMap holds the expected name for the operator's ConfigMap
 var DefaultConfigMap = "aws-account-operator-configmap"

--- a/pkg/awsclient/client.go
+++ b/pkg/awsclient/client.go
@@ -69,6 +69,12 @@ type Client interface {
 	DescribeRegions(input *ec2.DescribeRegionsInput) (*ec2.DescribeRegionsOutput, error)
 	DescribeVpcEndpointServiceConfigurations(input *ec2.DescribeVpcEndpointServiceConfigurationsInput) (*ec2.DescribeVpcEndpointServiceConfigurationsOutput, error)
 	DeleteVpcEndpointServiceConfigurations(*ec2.DeleteVpcEndpointServiceConfigurationsInput) (*ec2.DeleteVpcEndpointServiceConfigurationsOutput, error)
+	DescribeVpcs(*ec2.DescribeVpcsInput) (*ec2.DescribeVpcsOutput, error)
+	CreateVpc(*ec2.CreateVpcInput) (*ec2.CreateVpcOutput, error)
+	DeleteVpc(*ec2.DeleteVpcInput) (*ec2.DeleteVpcOutput, error)
+	DescribeSubnets(*ec2.DescribeSubnetsInput) (*ec2.DescribeSubnetsOutput, error)
+	CreateSubnet(*ec2.CreateSubnetInput) (*ec2.CreateSubnetOutput, error)
+	DeleteSubnet(*ec2.DeleteSubnetInput) (*ec2.DeleteSubnetOutput, error)
 
 	//IAM
 	CreateAccessKey(*iam.CreateAccessKeyInput) (*iam.CreateAccessKeyOutput, error)
@@ -198,6 +204,30 @@ func (c *awsClient) DescribeInstances(input *ec2.DescribeInstancesInput) (*ec2.D
 
 func (c *awsClient) DescribeRegions(input *ec2.DescribeRegionsInput) (*ec2.DescribeRegionsOutput, error) {
 	return c.ec2Client.DescribeRegions(input)
+}
+
+func (c *awsClient) DescribeVpcs(input *ec2.DescribeVpcsInput) (*ec2.DescribeVpcsOutput, error) {
+	return c.ec2Client.DescribeVpcs(input)
+}
+
+func (c *awsClient) CreateVpc(input *ec2.CreateVpcInput) (*ec2.CreateVpcOutput, error) {
+	return c.ec2Client.CreateVpc(input)
+}
+
+func (c *awsClient) DeleteVpc(input *ec2.DeleteVpcInput) (*ec2.DeleteVpcOutput, error) {
+	return c.ec2Client.DeleteVpc(input)
+}
+
+func (c *awsClient) DescribeSubnets(input *ec2.DescribeSubnetsInput) (*ec2.DescribeSubnetsOutput, error) {
+	return c.ec2Client.DescribeSubnets(input)
+}
+
+func (c *awsClient) CreateSubnet(input *ec2.CreateSubnetInput) (*ec2.CreateSubnetOutput, error) {
+	return c.ec2Client.CreateSubnet(input)
+}
+
+func (c *awsClient) DeleteSubnet(input *ec2.DeleteSubnetInput) (*ec2.DeleteSubnetOutput, error) {
+	return c.ec2Client.DeleteSubnet(input)
 }
 
 func (c *awsClient) CreateAccessKey(input *iam.CreateAccessKeyInput) (*iam.CreateAccessKeyOutput, error) {

--- a/pkg/awsclient/mock/zz_generated.mock_client.go
+++ b/pkg/awsclient/mock/zz_generated.mock_client.go
@@ -207,6 +207,96 @@ func (mr *MockClientMockRecorder) DeleteVpcEndpointServiceConfigurations(arg0 in
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteVpcEndpointServiceConfigurations", reflect.TypeOf((*MockClient)(nil).DeleteVpcEndpointServiceConfigurations), arg0)
 }
 
+// DescribeVpcs mocks base method
+func (m *MockClient) DescribeVpcs(arg0 *ec2.DescribeVpcsInput) (*ec2.DescribeVpcsOutput, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DescribeVpcs", arg0)
+	ret0, _ := ret[0].(*ec2.DescribeVpcsOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DescribeVpcs indicates an expected call of DescribeVpcs
+func (mr *MockClientMockRecorder) DescribeVpcs(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeVpcs", reflect.TypeOf((*MockClient)(nil).DescribeVpcs), arg0)
+}
+
+// CreateVpc mocks base method
+func (m *MockClient) CreateVpc(arg0 *ec2.CreateVpcInput) (*ec2.CreateVpcOutput, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CreateVpc", arg0)
+	ret0, _ := ret[0].(*ec2.CreateVpcOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CreateVpc indicates an expected call of CreateVpc
+func (mr *MockClientMockRecorder) CreateVpc(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateVpc", reflect.TypeOf((*MockClient)(nil).CreateVpc), arg0)
+}
+
+// DeleteVpc mocks base method
+func (m *MockClient) DeleteVpc(arg0 *ec2.DeleteVpcInput) (*ec2.DeleteVpcOutput, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteVpc", arg0)
+	ret0, _ := ret[0].(*ec2.DeleteVpcOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DeleteVpc indicates an expected call of DeleteVpc
+func (mr *MockClientMockRecorder) DeleteVpc(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteVpc", reflect.TypeOf((*MockClient)(nil).DeleteVpc), arg0)
+}
+
+// DescribeSubnets mocks base method
+func (m *MockClient) DescribeSubnets(arg0 *ec2.DescribeSubnetsInput) (*ec2.DescribeSubnetsOutput, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DescribeSubnets", arg0)
+	ret0, _ := ret[0].(*ec2.DescribeSubnetsOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DescribeSubnets indicates an expected call of DescribeSubnets
+func (mr *MockClientMockRecorder) DescribeSubnets(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeSubnets", reflect.TypeOf((*MockClient)(nil).DescribeSubnets), arg0)
+}
+
+// CreateSubnet mocks base method
+func (m *MockClient) CreateSubnet(arg0 *ec2.CreateSubnetInput) (*ec2.CreateSubnetOutput, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CreateSubnet", arg0)
+	ret0, _ := ret[0].(*ec2.CreateSubnetOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CreateSubnet indicates an expected call of CreateSubnet
+func (mr *MockClientMockRecorder) CreateSubnet(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateSubnet", reflect.TypeOf((*MockClient)(nil).CreateSubnet), arg0)
+}
+
+// DeleteSubnet mocks base method
+func (m *MockClient) DeleteSubnet(arg0 *ec2.DeleteSubnetInput) (*ec2.DeleteSubnetOutput, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteSubnet", arg0)
+	ret0, _ := ret[0].(*ec2.DeleteSubnetOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DeleteSubnet indicates an expected call of DeleteSubnet
+func (mr *MockClientMockRecorder) DeleteSubnet(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteSubnet", reflect.TypeOf((*MockClient)(nil).DeleteSubnet), arg0)
+}
+
 // CreateAccessKey mocks base method
 func (m *MockClient) CreateAccessKey(arg0 *iam.CreateAccessKeyInput) (*iam.CreateAccessKeyOutput, error) {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
On non-govcloud account the operator expects there to be a default subnet to be used when creating and terminating ec2 instances. Per https://docs.aws.amazon.com/govcloud-us/latest/UserGuide/govcloud-ec2.html#govcloud-ec2-vpc govcloud accounts may or may not have a default subnet. Therefore, when in govcloud env, AAO needs to create a vpc, one subnet, run the ec2 instance, tear it all down.