### PR TITLE
[OSD-9246] Block gaps in our AccountClaim finalizer handling

### DIFF
--- a/pkg/controller/accountclaim/accountclaim_controller.go
+++ b/pkg/controller/accountclaim/accountclaim_controller.go
@@ -306,14 +306,16 @@ func (r *ReconcileAccountClaim) handleAccountClaimDeletion(reqLogger logr.Logger
 			failedReusedAccount, accountErr := r.getClaimedAccount(accountClaim.Spec.AccountLink, awsv1alpha1.AccountCrNamespace)
 			if accountErr != nil {
 				reqLogger.Error(accountErr, "Failed to get claimed account")
-				return err
+				return errors.Wrap(err, "failed to get claimed account")
 			}
 			// Update account status and add "Reuse Failed" condition
 			accountErr = r.resetAccountSpecStatus(reqLogger, failedReusedAccount, accountClaim, awsv1alpha1.AccountFailed, "Failed")
 			if accountErr != nil {
 				reqLogger.Error(accountErr, "Failed updating account status for failed reuse")
-				return err
+				return errors.Wrap(err, "failed updating account status for failed reuse")
 			}
+
+			return err
 		}
 	}
 


### PR DESCRIPTION
While investigating dangling accounts I looked through our accountclaim finalize functionality to try identify areas where we may not be returning errors

Previous behaviours which have been addressed as part of this PR: 
- If the accountclaim `finalizeAccountClaim` function encountered an error, we would still proceed to remove the finalizer.
- If the `cleanUpAwsAccount` func encountered an error, we simply logged it instead of returning it.

Additions:
- Added some more unit tests. 
- Made errors from AWS visible in our logging, as debugging why we can't clean up an AWS resource without the context from AWS was impossible.

Ticket ref: [OSD-9246](https://issues.redhat.com/browse/OSD-9246)