### PR TITLE
updating documentation around AccountClaim customTags

### DIFF
--- a/docs/3.3-AccountClaim.md
+++ b/docs/3.3-AccountClaim.md
@@ -21,7 +21,19 @@ spec:
   legalEntity:
     id: 00000000000000
     name: {Legal Entity Name}
+  customTags: |
+    red-hat-managed=true
+    foo=bar
 ```
+
+#### Custom Tags
+
+The `customTags` field on the `AccountClaim` provide tags that external sources want to add to any AWS resources that are created on their behalf. This has two main use cases:
+* higher levels of the OSD stack can specify tags in a centralized way, e.g. `red-hat-managed=true` can be specified in the hive provisioner rather than each cloud vendor operator needing to specify it.
+* allow customers to specify tags which they may require for their own purposes, e.g. reporting, RBAC rules that rely on tags/labels, etc.
+
+`customTags` mixes these use cases so its not currently possible to tell whether the source of a tag is from a customer or from some internal service.
+
 
 ### 3.3.2 AccountClaim Controller
 

--- a/pkg/controller/account/account_controller.go
+++ b/pkg/controller/account/account_controller.go
@@ -1158,7 +1158,8 @@ func (r *ReconcileAccount) getManagedTags(log logr.Logger) []awsclient.AWSTag {
 	return parseTagsFromString(managedTags)
 }
 
-// getCustomerTags retrieves a list of customer-provided tags from the linked accountclaim
+// getCustomTags retrieves a list of tags from the linked accountclaim
+// these tags can be tags specified by the customer or set by other pieces of the OSD stack
 func (r *ReconcileAccount) getCustomTags(log logr.Logger, account *awsv1alpha1.Account) []awsclient.AWSTag {
 	tags := []awsclient.AWSTag{}
 


### PR DESCRIPTION
updating docs to capture some past and recent decisions around `customTags` which are passed to AAO via the `AccountClaim` that we add to AWS resources that we create.

Related to:
* [OSD-9949](https://issues.redhat.com/browse/OSD-9949)
* [OSD-10191](https://issues.redhat.com/browse/OSD-10191)