### PR TITLE
Fix yaml formatting in awsfederatedrole_networkmgmt CR

### DIFF
--- a/test/deploy/aws.managed.openshift.io_v1alpha1_awsfederatedrole_networkmgmt_cr.yaml
+++ b/test/deploy/aws.managed.openshift.io_v1alpha1_awsfederatedrole_networkmgmt_cr.yaml
@@ -141,10 +141,10 @@ spec:
       # AWS VPC Endpoint Service
       - effect: Allow
         action:
-          "ec2:CreateVpcEndpointServiceConfiguration",
-          "ec2:DescribeVpcEndpointServiceConfigurations",
-          "ec2:DeleteVpcEndpointServiceConfigurations",
-          "elasticloadbalancing:DescribeLoadBalancers"
+          - "ec2:CreateVpcEndpointServiceConfiguration"
+          - "ec2:DescribeVpcEndpointServiceConfigurations"
+          - "ec2:DeleteVpcEndpointServiceConfigurations"
+          - "elasticloadbalancing:DescribeLoadBalancers"
         resource:
           - "*"
 


### PR DESCRIPTION
Encountered a bug in our formatting for `test/deploy/aws.managed.openshift.io_v1alpha1_awsfederatedrole_networkmgmt_cr.yaml` introduced in https://github.com/openshift/aws-account-operator/pull/673
