### PR TITLE
adding unit tests for tag builder

### DIFF
--- a/pkg/apis/aws/v1alpha1/shared_types.go
+++ b/pkg/apis/aws/v1alpha1/shared_types.go
@@ -94,6 +94,10 @@ var ClusterClaimLinkTagKey = "clusterClaimLink"
 // ClusterClaimLinkNamespaceTagKey is the AWS key name for cluster claim namespace
 var ClusterClaimLinkNamespaceTagKey = "clusterClaimLinkNamespace"
 
+// Used to name the EC2 instance we spin up when initializing an AWS region
+var EC2InstanceNameTagKey = "Name"
+var EC2InstanceNameTagValue = "red-hat-region-init"
+
 // IAMUserIDLabel label key for IAM user suffix
 var IAMUserIDLabel = "iamUserId"
 

--- a/pkg/awsclient/awsclient_suite_test.go
+++ b/pkg/awsclient/awsclient_suite_test.go
@@ -7,7 +7,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-func TestAccount(t *testing.T) {
+func TestAwsclient(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "awsclient Suite")
 }

--- a/pkg/awsclient/awsclient_suite_test.go
+++ b/pkg/awsclient/awsclient_suite_test.go
@@ -1,0 +1,13 @@
+package awsclient_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestAccount(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "awsclient Suite")
+}

--- a/pkg/awsclient/tags.go
+++ b/pkg/awsclient/tags.go
@@ -44,7 +44,7 @@ func (t *AWSAccountOperatorTags) GetEC2Tags() []*ec2.Tag {
 	}
 
 	//make sure the ec2 instance has a descriptive name to avoid customer confusion
-	tags = append(tags, &ec2.Tag{Key: aws.String("Name"), Value: aws.String("red-hat-region-init")})
+	tags = append(tags, &ec2.Tag{Key: aws.String(awsv1alpha1.EC2InstanceNameTagKey), Value: aws.String(awsv1alpha1.EC2InstanceNameTagValue)})
 
 	return tags
 }

--- a/pkg/awsclient/tags_test.go
+++ b/pkg/awsclient/tags_test.go
@@ -37,12 +37,12 @@ var _ = Describe("AWS Resource Tag Builder", func() {
 			}
 			customTags = []AWSTag{
 				{
-					Key:   "managedTagKey1",
-					Value: "managedTagValue1",
+					Key:   "customTagKey1",
+					Value: "customTagValue1",
 				},
 				{
-					Key:   "managedTagKey2",
-					Value: "managedTagValue2",
+					Key:   "customTagKey2",
+					Value: "customTagValue2",
 				},
 			}
 			tagBuilder = AWSTags.BuildTags(&account, managedTags, customTags)

--- a/pkg/awsclient/tags_test.go
+++ b/pkg/awsclient/tags_test.go
@@ -1,0 +1,157 @@
+package awsclient
+
+import (
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/aws/aws-sdk-go/service/iam"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	awsv1alpha1 "github.com/openshift/aws-account-operator/pkg/apis/aws/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var _ = Describe("AWS Resource Tag Builder", func() {
+
+	When("Building happy path AWS Tags", func() {
+		var (
+			account = awsv1alpha1.Account{
+				TypeMeta: metav1.TypeMeta{},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "tagsTest",
+					Namespace: "tagsTestNamespace",
+				},
+				Spec: awsv1alpha1.AccountSpec{
+					ClaimLink:          "tagsTestClaimLink",
+					ClaimLinkNamespace: "tagsTestClaimLinkNamespace",
+				},
+			}
+			managedTags = []AWSTag{
+				{
+					Key:   "managedTagKey1",
+					Value: "managedTagValue1",
+				},
+				{
+					Key:   "managedTagKey2",
+					Value: "managedTagValue2",
+				},
+			}
+			customTags = []AWSTag{
+				{
+					Key:   "managedTagKey1",
+					Value: "managedTagValue1",
+				},
+				{
+					Key:   "managedTagKey2",
+					Value: "managedTagValue2",
+				},
+			}
+			tagBuilder = AWSTags.BuildTags(&account, managedTags, customTags)
+		)
+
+		When("creating IAM resource tags", func() {
+			var tags []*iam.Tag = tagBuilder.GetIAMTags()
+			var hardCodedTags = 4
+
+			It("Should not add unexpected tags", func() {
+				var expectedCount = len(managedTags) + len(customTags) + hardCodedTags
+				Expect(len(tags)).To(Equal(expectedCount))
+			})
+
+			It("Should add account name tag", func() {
+				Expect(tags).To(ContainElement(iamTag(awsv1alpha1.ClusterAccountNameTagKey, account.Name)))
+			})
+
+			It("Should add cluster namespace tag", func() {
+				Expect(tags).To(ContainElement(iamTag(awsv1alpha1.ClusterNamespaceTagKey, account.Namespace)))
+			})
+
+			It("Should add cluster ClaimLink tag", func() {
+				Expect(tags).To(ContainElement(iamTag(awsv1alpha1.ClusterClaimLinkTagKey, account.Spec.ClaimLink)))
+			})
+
+			It("Should add cluster ClaimLinkNamespace tag", func() {
+				Expect(tags).To(ContainElement(iamTag(awsv1alpha1.ClusterClaimLinkNamespaceTagKey, account.Spec.ClaimLinkNamespace)))
+			})
+
+			It("Should add managed tags", func() {
+				Expect(tags).To(ContainElements(iamTags(managedTags)))
+			})
+
+			It("Should add custom tags", func() {
+				Expect(tags).To(ContainElements(iamTags(customTags)))
+			})
+
+			It("Should set ec2 instance name tag", func() {
+				Expect(tags).NotTo(ContainElement(iamTag(awsv1alpha1.EC2InstanceNameTagKey, awsv1alpha1.EC2InstanceNameTagValue)))
+			})
+		})
+
+		When("creating EC2 resource tags", func() {
+			var tags []*ec2.Tag = tagBuilder.GetEC2Tags()
+			var hardCodedTags = 5
+
+			It("Should not add unexpected tags", func() {
+				var expectedCount = len(managedTags) + len(customTags) + hardCodedTags
+				Expect(len(tags)).To(Equal(expectedCount))
+			})
+
+			It("Should add account name tag", func() {
+				Expect(tags).To(ContainElement(ec2Tag(awsv1alpha1.ClusterAccountNameTagKey, account.Name)))
+			})
+
+			It("Should add cluster namespace tag", func() {
+				Expect(tags).To(ContainElement(ec2Tag(awsv1alpha1.ClusterNamespaceTagKey, account.Namespace)))
+			})
+
+			It("Should add cluster ClaimLink tag", func() {
+				Expect(tags).To(ContainElement(ec2Tag(awsv1alpha1.ClusterClaimLinkTagKey, account.Spec.ClaimLink)))
+			})
+
+			It("Should add cluster ClaimLinkNamespace tag", func() {
+				Expect(tags).To(ContainElement(ec2Tag(awsv1alpha1.ClusterClaimLinkNamespaceTagKey, account.Spec.ClaimLinkNamespace)))
+			})
+
+			It("Should add managed tags", func() {
+				Expect(tags).To(ContainElements(ec2Tags(managedTags)))
+			})
+
+			It("Should add custom tags", func() {
+				Expect(tags).To(ContainElements(ec2Tags(customTags)))
+			})
+
+			It("Should add hard coded machine name so we dont spook customers", func() {
+				Expect(tags).To(ContainElement(ec2Tag(awsv1alpha1.EC2InstanceNameTagKey, awsv1alpha1.EC2InstanceNameTagValue)))
+			})
+		})
+	})
+})
+
+func iamTag(key string, value string) *iam.Tag {
+	return &iam.Tag{
+		Key:   aws.String(key),
+		Value: aws.String(value),
+	}
+}
+
+func iamTags(tags []AWSTag) []*iam.Tag {
+	var convertedTags []*iam.Tag
+	for _, tag := range tags {
+		convertedTags = append(convertedTags, iamTag(tag.Key, tag.Value))
+	}
+	return convertedTags
+}
+
+func ec2Tag(key string, value string) *ec2.Tag {
+	return &ec2.Tag{
+		Key:   aws.String(key),
+		Value: aws.String(value),
+	}
+}
+
+func ec2Tags(tags []AWSTag) []*ec2.Tag {
+	var convertedTags []*ec2.Tag
+	for _, tag := range tags {
+		convertedTags = append(convertedTags, ec2Tag(tag.Key, tag.Value))
+	}
+	return convertedTags
+}


### PR DESCRIPTION
Closes [OSD-9953](https://issues.redhat.com/browse/OSD-9953)

Adds missing unit tests for AWS resource tag builder