### PR TITLE
Preview gosec lint rule

### DIFF
--- a/.golangci-extras.yml
+++ b/.golangci-extras.yml
@@ -1,0 +1,4 @@
+linters:
+  disable-all: true
+  enable:
+  - gosec

--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,9 @@ boilerplate-update:
 
 # Extend Makefile after here
 
+# Enable additional golangci-lint rules
+GOLANGCI_OPTIONAL_CONFIG := .golangci-extras.yml
+
 .PHONY: help
 help: ## Display this help
 	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m<target>\033[0m\n"} /^[a-zA-Z_0-9-]+:.*?##/ { printf "  \033[36m%-15s\033[0m %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)


### PR DESCRIPTION
https://github.com/openshift/boilerplate/pull/206 intends to add `gosec` linting to consumers of the golang-osd-operator convention. This PR shows what impact that change will have once boilerplate in this repo is updated to include it. Addressing the reported issues ahead of time will smooth the update process. In particular, if the update is triggered by a change that's urgent, we don't want to be blocked having to fix linting issues at that time.