### PR TITLE
Fix broken link to the manual STS setup.

### DIFF
--- a/docs/1.0-Installation.md
+++ b/docs/1.0-Installation.md
@@ -23,7 +23,7 @@ When a [Hive](https://github.com/openshift/hive) cluster has a new cluster reque
 The operator links the `AccountClaim` to an `Account` CR in the pool, and creates the required k8s secrets, placing them in the `AccountClaim`'s unique namespace.
 The `AccountPool` is then filled up again by the operator. Hive then uses the secrets to create the AWS resources for the new cluster.
 
-For more information on how this process is done, please refer to the [Custom Resources and Controllers](2.0-Custom-Resources-and-Controllers.md) page.
+For more information on how this process is done, please refer to the [Custom Resources and Controllers](3.0-Custom-Resources-and-Controllers.md) page.
 
 ## 1.3 Testing your AWS account credentials with the CLI
 

--- a/docs/1.1-InstallationPrerequisites.md
+++ b/docs/1.1-InstallationPrerequisites.md
@@ -95,7 +95,7 @@ The following diagram shows the Account relationship
 ![Account Relationship Diagram](images/jump-role-diagram.png)
 
 
-[Here](./1.2-STSSetup.md) are the manual steps to create the above, these go more into the _why_ of each step, but if you're more interested in just getting your account setup, use [this script](../hack/scripts/aws/setup_aws_accounts.sh):
+[Here](./1.2-ManualSTSSetup.md) are the manual steps to create the above, these go more into the _why_ of each step, but if you're more interested in just getting your account setup, use [this script](../hack/scripts/aws/setup_aws_accounts.sh):
 ```
 ./setup_aws_accounts.sh -a <Assigned AWS Account ID 1> -b <Assigned AWS Account ID 2> -u <username>
 ```


### PR DESCRIPTION
The link to the manual STS setup was pointing to non-existent file.