### PR TITLE
Encrypt AWS instance EBS volume by default

### DIFF
--- a/pkg/controller/account/ec2.go
+++ b/pkg/controller/account/ec2.go
@@ -603,6 +603,16 @@ func CreateEC2Instance(reqLogger logr.Logger, account *awsv1alpha1.Account, clie
 					Tags:         tags,
 				},
 			},
+			// We specify block devices mainly to enable EBS encryption
+			BlockDeviceMappings: []*ec2.BlockDeviceMapping{
+				{
+					DeviceName: aws.String("/dev/xvda"),
+					Ebs: &ec2.EbsBlockDevice{
+						DeleteOnTermination: aws.Bool(true),
+						Encrypted:           aws.Bool(true),
+					},
+				},
+			},
 		}
 
 		// If fedramp, create subnet and set value for RunInstancesInput

--- a/pkg/controller/account/ec2.go
+++ b/pkg/controller/account/ec2.go
@@ -606,8 +606,9 @@ func CreateEC2Instance(reqLogger logr.Logger, account *awsv1alpha1.Account, clie
 			// We specify block devices mainly to enable EBS encryption
 			BlockDeviceMappings: []*ec2.BlockDeviceMapping{
 				{
-					DeviceName: aws.String("/dev/xvda"),
+					DeviceName: aws.String("/dev/sda1"),
 					Ebs: &ec2.EbsBlockDevice{
+						VolumeSize:          aws.Int64(10),
 						DeleteOnTermination: aws.Bool(true),
 						Encrypted:           aws.Bool(true),
 					},


### PR DESCRIPTION
Added a `BlockDeviceMapping` specification to `createEC2Instance()` such that all instances created by this operator use encrypted EBS volumes by default. Volumes are encrypted with the AWS Managed KMS key and are automatically deleted upon instance termination.

This addresses OSD-10219, where the verifier fails on clusters that mandate encrypted storage universally.