### PR TITLE
[OSD-9894] Add condition when account is claimed.

### DIFF
--- a/pkg/apis/aws/v1alpha1/account_types.go
+++ b/pkg/apis/aws/v1alpha1/account_types.go
@@ -90,6 +90,9 @@ const (
 	AccountPending AccountConditionType = "Pending"
 	// AccountPendingVerification is set when account creation is pending
 	AccountPendingVerification AccountConditionType = "PendingVerification"
+	// FIXME: Have to call this different than "AccountClaimed", as that clashes
+	// with the AccountClaimConditionType
+	AccountIsClaimed AccountConditionType = "Claimed"
 	// AccountReused is set when account is reused
 	AccountReused AccountConditionType = "Reused"
 	// AccountClientError is set when there was an issue getting a client

--- a/pkg/controller/account/byoc.go
+++ b/pkg/controller/account/byoc.go
@@ -35,8 +35,8 @@ func newBYOCAccount(currentAcctInstance *awsv1alpha1.Account) bool {
 func claimBYOCAccount(r *ReconcileAccount, reqLogger logr.Logger, currentAcctInstance *awsv1alpha1.Account) error {
 	if !currentAcctInstance.IsClaimed() {
 		reqLogger.Info("Marking BYOC account claimed")
-		currentAcctInstance.Status.Claimed = true
-		return r.statusUpdate(currentAcctInstance)
+		err := ClaimAccount(r, currentAcctInstance)
+		return err
 	}
 
 	return nil


### PR DESCRIPTION
The condition is added when the Status.Claimed is set to true.

This happens for regular and byoc accounts.

Fixes OSD-9894.