### PR TITLE
Disable secret probe

### DIFF
--- a/pkg/controller/account/account_controller.go
+++ b/pkg/controller/account/account_controller.go
@@ -71,6 +71,9 @@ const (
 	iamUserNameUHC               = "osdManagedAdmin"
 
 	controllerName = "account"
+	// probeSecretEnabled
+	// Currently disabled because it significantly increases reconcile time in production
+	probeSecretEnabled = false
 )
 
 // Add creates a new Account Controller and adds it to the Manager. The Manager will set fields on the Controller
@@ -429,7 +432,7 @@ func (r *ReconcileAccount) Reconcile(request reconcile.Request) (reconcile.Resul
 		}
 	}
 
-	if currentAcctInstance.IsReady() {
+	if currentAcctInstance.IsReady() && probeSecretEnabled {
 
 		roleToAssume := getAssumeRole(currentAcctInstance)
 		awsClient, _, err := r.assumeRole(reqLogger, currentAcctInstance, awsSetupClient, roleToAssume, "")


### PR DESCRIPTION
This PR disables the secret probe as it significantly increases the reconcile time in production. We should investigate doing this kind of operation outside of the reconcile loop.

For the moment this PR effectively disables changes in PR #678 