### PR TITLE
How to find correct OSD_STAGING_1_OU_BASE_ID

### DIFF
--- a/docs/1.1-InstallationPrerequisites.md
+++ b/docs/1.1-InstallationPrerequisites.md
@@ -112,6 +112,14 @@ Do as instructed and add the fields to your local `.envrc`
 - The `Jump Role` will be a simulation of the role that we use as a bastion of sorts. For the STS Architecture, we have an IAM user that assumes a specific role in a specific account, and then using that role they can assume role into the cluster's account in order to run operations as necessary.
 - The `Access Role` will be a simulation of a role on a customer's account that gives us access to initialize the regions and initialize a cluster.  On external customer accounts this is assumed to be a very locked-down role with ONLY the necessary permissions needed to run the operator or install the cluster resources. Minimal permissions required for the role are provided below.
 
+An additional field that must be set in `.envrc` is the `OSD_STAGING_1_OU_BASE_ID`.
+
+You can find it by listing the parents of the `osd-staging-1` account (take the `id` field of the output):
+
+```shell
+aws organizations list-parents --child-id <Assigned AWS Account ID 1> --profile osd-staging-1
+```
+
 ### 1.1.3.4 STS Role Validation
 
 Making sense of the STS role chaining process can be confusing at first, so we've added a script to validate that the role chaining works before you try to run it through the operator. The script is located in the `hack/scripts/aws` directory, but for convenience you can run it from the make target: `make check-sts-setup`


### PR DESCRIPTION
This is needed to have the AAO running and it can differ, depending
where osdctl assigns the account.