### PR TITLE
Add `ModifyVpcEndpointServicePermissions` to `network-mgmt` role

### DIFF
--- a/hack/olm-registry/olm-artifacts-template.yaml
+++ b/hack/olm-registry/olm-artifacts-template.yaml
@@ -149,6 +149,7 @@ objects:
             - "ec2:CreateVpnConnectionRoute"
             - "ec2:CreateVpnGateway"
             - "ec2:CreateVpcEndpointServiceConfiguration"
+            - "ec2:ModifyVpcEndpointServicePermissions"
             - "ec2:DeleteVpcPeeringConnection"
             - "ec2:DeleteVpnConnection"
             - "ec2:DeleteVpnConnectionRoute"


### PR DESCRIPTION
In order to create HyperShift clusters whose control planes run inside
OSD clusters it is necessary to configure PrivateLink between the VPC of
the customer where the worker nodes run and the VPC of the HyperShift
management cluster. Currently this is done by the HyperShift operator
using credentials passed by app-interface, which in turn obtains those
credentials using the OCM infrastructure access roles feature to obtain
the `network-mgmt` role. That role needs to have the permission to use
the `ModifyVpcEndpointServicePermissions` API in order to configure the
cross-account permissions that are needed.

Related: https://issues.redhat.com/browse/SDE-1586  
Related: https://issues.redhat.com/browse/SDA-5527  
Related: https://issues.redhat.com/browse/HOSTEDCP-408  