### PR TITLE
[OSD-9910] Add account validation controller to AAO

### DIFF
--- a/hack/olm-registry/olm-artifacts-template.yaml
+++ b/hack/olm-registry/olm-artifacts-template.yaml
@@ -115,6 +115,7 @@ objects:
       me-south-1:ami-0b41a37a62a4296fc:t3.micro
       us-gov-west-1:ami-2c74214d:t2.micro
       us-gov-east-1:ami-9e10f0ef:t2.micro
+    feature.validation_move_account: "false"
 
 - apiVersion: aws.managed.openshift.io/v1alpha1
   kind: AccountPool

--- a/hack/templates/aws.managed.openshift.io_v1alpha1_configmap.tmpl
+++ b/hack/templates/aws.managed.openshift.io_v1alpha1_configmap.tmpl
@@ -22,6 +22,7 @@ objects:
     quota.vcpu: ${VCPU_QUOTA}
     account-limit: ${ACCOUNTLIMIT}
     MaxConcurrentReconciles.account: "2"
+    MaxConcurrentReconciles.accountvalidation: "2"
     MaxConcurrentReconciles.accountclaim: "1"
     MaxConcurrentReconciles.accountpool: "1"
     MaxConcurrentReconciles.awsfederatedaccountaccess: "1"
@@ -53,3 +54,4 @@ objects:
       us-gov-east-1:ami-9e10f0ef:t2.micro
     sts-jump-role: ${STS_JUMP_ARN}
     support-jump-role: ${SUPPORT_JUMP_ROLE}
+    feature.validation_move_account: "false"

--- a/pkg/awsclient/client.go
+++ b/pkg/awsclient/client.go
@@ -112,6 +112,7 @@ type Client interface {
 	ListOrganizationalUnitsForParent(*organizations.ListOrganizationalUnitsForParentInput) (*organizations.ListOrganizationalUnitsForParentOutput, error)
 	ListChildren(*organizations.ListChildrenInput) (*organizations.ListChildrenOutput, error)
 	TagResource(*organizations.TagResourceInput) (*organizations.TagResourceOutput, error)
+	ListParents(*organizations.ListParentsInput) (*organizations.ListParentsOutput, error)
 
 	//sts
 	AssumeRole(*sts.AssumeRoleInput) (*sts.AssumeRoleOutput, error)
@@ -359,6 +360,10 @@ func (c *awsClient) ListChildren(input *organizations.ListChildrenInput) (*organ
 
 func (c *awsClient) TagResource(input *organizations.TagResourceInput) (*organizations.TagResourceOutput, error) {
 	return c.orgClient.TagResource(input)
+}
+
+func (c *awsClient) ListParents(input *organizations.ListParentsInput) (*organizations.ListParentsOutput, error) {
+	return c.orgClient.ListParents(input)
 }
 
 func (c *awsClient) AssumeRole(input *sts.AssumeRoleInput) (*sts.AssumeRoleOutput, error) {

--- a/pkg/awsclient/mock/zz_generated.mock_client.go
+++ b/pkg/awsclient/mock/zz_generated.mock_client.go
@@ -791,6 +791,21 @@ func (mr *MockClientMockRecorder) TagResource(arg0 interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TagResource", reflect.TypeOf((*MockClient)(nil).TagResource), arg0)
 }
 
+// ListParents mocks base method
+func (m *MockClient) ListParents(arg0 *organizations.ListParentsInput) (*organizations.ListParentsOutput, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListParents", arg0)
+	ret0, _ := ret[0].(*organizations.ListParentsOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListParents indicates an expected call of ListParents
+func (mr *MockClientMockRecorder) ListParents(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListParents", reflect.TypeOf((*MockClient)(nil).ListParents), arg0)
+}
+
 // AssumeRole mocks base method
 func (m *MockClient) AssumeRole(arg0 *sts.AssumeRoleInput) (*sts.AssumeRoleOutput, error) {
 	m.ctrl.T.Helper()

--- a/pkg/controller/add_account_validation.go
+++ b/pkg/controller/add_account_validation.go
@@ -1,0 +1,10 @@
+package controller
+
+import (
+	"github.com/openshift/aws-account-operator/pkg/controller/validation"
+)
+
+func init() {
+	// AddToManagerFuncs is a list of functions to create controllers and add them to a manager.
+	AddToManagerFuncs = append(AddToManagerFuncs, validation.Add)
+}

--- a/pkg/controller/utils/clientwrapper.go
+++ b/pkg/controller/utils/clientwrapper.go
@@ -34,6 +34,7 @@ func InitControllerMaxReconciles(kubeClient client.Client) []error {
 		"account",
 		"accountclaim",
 		"accountpool",
+		"accountvalidation",
 		"awsfederatedaccountaccess",
 		"awsfederatedrole",
 	}

--- a/pkg/controller/utils/utils.go
+++ b/pkg/controller/utils/utils.go
@@ -6,10 +6,13 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"strconv"
 	"strings"
+	"time"
 
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	"github.com/go-logr/logr"
 	awsv1alpha1 "github.com/openshift/aws-account-operator/pkg/apis/aws/v1alpha1"
@@ -218,4 +221,25 @@ func GetOperatorConfigMap(kubeClient client.Client) (*corev1.ConfigMap, error) {
 		types.NamespacedName{Namespace: awsv1alpha1.AccountCrNamespace,
 			Name: awsv1alpha1.DefaultConfigMap}, configMap)
 	return configMap, err
+}
+
+func GetEnvironmentBool(key string, fallback bool) bool {
+	value := os.Getenv(key)
+	cast, err := strconv.ParseBool(value)
+	if err != nil {
+		return fallback
+	}
+	return cast
+}
+
+func DoNotRequeue() (reconcile.Result, error) {
+	return reconcile.Result{Requeue: false}, nil
+}
+
+func RequeueWithError(err error) (reconcile.Result, error) {
+	return reconcile.Result{}, err
+}
+
+func RequeueAfter(after time.Duration) (reconcile.Result, error) {
+	return reconcile.Result{Requeue: true, RequeueAfter: after}, nil
 }

--- a/pkg/controller/validation/account_validation_controller.go
+++ b/pkg/controller/validation/account_validation_controller.go
@@ -1,0 +1,242 @@
+package validation
+
+import (
+	"context"
+	"errors"
+	"strconv"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/organizations"
+	"github.com/openshift/aws-account-operator/config"
+	awsv1alpha1 "github.com/openshift/aws-account-operator/pkg/apis/aws/v1alpha1"
+	"github.com/openshift/aws-account-operator/pkg/awsclient"
+	"github.com/openshift/aws-account-operator/pkg/controller/utils"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/controller-runtime/pkg/source"
+)
+
+var log = logf.Log.WithName("controller_accountvalidation")
+
+var account_move_enabled = false
+
+const (
+	controllerName = "accountvalidation"
+	moveWaitTime   = 5 * time.Minute
+)
+
+type ValidateAccount struct {
+	Client           client.Client
+	scheme           *runtime.Scheme
+	awsClientBuilder awsclient.IBuilder
+}
+
+type ValidationError int64
+
+const (
+	InvalidAccount ValidationError = iota
+	AccountMoveFailed
+)
+
+type AccountValidationError struct {
+	Type ValidationError
+	Err  error
+}
+
+func (ave *AccountValidationError) Error() string {
+	return ave.Err.Error()
+}
+
+func Add(mgr manager.Manager) error {
+	return add(mgr, newReconciler(mgr))
+}
+
+func add(mgr manager.Manager, r reconcile.Reconciler) error {
+	c, err := utils.NewControllerWithMaxReconciles(log, controllerName, mgr, r)
+	if err != nil {
+		return err
+	}
+
+	err = c.Watch(&source.Kind{Type: &awsv1alpha1.Account{}}, &handler.EnqueueRequestForObject{})
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func newReconciler(mgr manager.Manager) reconcile.Reconciler {
+	reconciler := &ValidateAccount{
+		Client:           utils.NewClientWithMetricsOrDie(log, mgr, controllerName),
+		scheme:           mgr.GetScheme(),
+		awsClientBuilder: &awsclient.Builder{},
+	}
+
+	return utils.NewReconcilerWithMetrics(reconciler, controllerName)
+}
+
+// Retrieve all parents of the given awsId until the predicate returns true.
+func ParentsTillPredicate(awsId string, client awsclient.Client, p func(s string) bool, parents *[]string) error {
+	listParentsInput := organizations.ListParentsInput{
+		ChildId: aws.String(awsId),
+	}
+	listParentsOutput, err := client.ListParents(&listParentsInput)
+	if err != nil {
+		return err
+	}
+	if len(listParentsOutput.Parents) == 0 {
+		log.Info("Exhausted search looking for root OU - root OU and account OU likely in separate subtrees.", "path", parents)
+		return nil
+	} else {
+		id := *listParentsOutput.Parents[0].Id
+		parents = append(parents, id)
+		if p(id) {
+			return nil
+		}
+		return ParentsTillPredicate(id, client, p, parents)
+	}
+}
+
+// Verify if the account is already in the root OU
+// The predicate indicates if the parent considered the desired root was found.
+func IsAccountInPoolOU(account awsv1alpha1.Account, client awsclient.Client, isPoolOU func(s string) bool) bool {
+	if account.Spec.AwsAccountID == "" {
+		return false, errors.New("AwsAccountID is empty.")
+	}
+	parentList := []string{}
+	err := ParentsTillPredicate(account.Spec.AwsAccountID, client, isPoolOU, &parentList)
+	if err != nil {
+		return false, err
+	}
+	if len(parentList) == 1 {
+		return true
+	}
+	return false
+}
+
+func MoveAccount(account awsv1alpha1.Account, client awsclient.Client, targetOU string, dryRun bool) error {
+	awsAccountId := account.Spec.AwsAccountID
+
+	listParentsInput := organizations.ListParentsInput{
+		ChildId: aws.String(awsAccountId),
+	}
+	listParentsOutput, err := client.ListParents(&listParentsInput)
+	if err != nil {
+		log.Error(err, "Can not find parent for AWS account", "aws-account", awsAccountId)
+		return err
+	}
+	oldOu := listParentsOutput.Parents[0].Id
+	moveAccountInput := organizations.MoveAccountInput{
+		AccountId:           aws.String(awsAccountId),
+		DestinationParentId: aws.String(targetOU),
+		SourceParentId:      oldOu,
+	}
+	if !dryRun {
+		log.Info("Moving aws account from old ou to new ou", "aws-account", awsAccountId, "old-ou", *oldOu, "new-ou", targetOU)
+		_, err = client.MoveAccount(&moveAccountInput)
+		if err != nil {
+			log.Error(err, "Could not move aws account to new ou", "aws-account", awsAccountId, "ou", targetOU)
+			return err
+		}
+	} else {
+		log.Info("Not moving aws account from old ou to new ou (dry run)", "aws-account", awsAccountId, "old-ou", *oldOu, "new-ou", targetOU)
+	}
+	return nil
+}
+
+func (r *ValidateAccount) ValidateAccountOU(awsClient awsclient.Client, account awsv1alpha1.Account, configMap *v1.ConfigMap) error {
+	poolOU := configMap.Data["root"]
+	// Perform basic short-circuit checks
+	if account.IsBYOC() {
+		log.Info("Will not validate a CCS account", "account", account)
+		return &AccountValidationError{
+			Type: InvalidAccount,
+			Err:  errors.New("Account is a CCS account"),
+		}
+	}
+	if account.IsOwnedByAccountPool() {
+		log.Info("Will not validate account owned by account pool", account)
+		return &AccountValidationError{
+			Type: InvalidAccount,
+			Err:  errors.New("Account is in an account pool"),
+		}
+	}
+
+	// Perform all checks on the account we want.
+	inPool := IsAccountInPoolOU(account, awsClient, func(s string) bool {
+		return s == poolOU
+	})
+	if inPool {
+		log.Info("Account is already in the root OU.", "account", account)
+	} else {
+		log.Info("Account is not in the root OU - it will be moved.", "account", account)
+		err := MoveAccount(account, awsClient, poolOU, account_move_enabled)
+		if err != nil {
+			log.Error(err, "Could not move account", "account", account)
+			return &AccountValidationError{
+				Type: AccountMoveFailed,
+				Err:  err,
+			}
+		}
+	}
+	return nil
+}
+
+func (r *ValidateAccount) Reconcile(request reconcile.Request) (reconcile.Result, error) {
+	log.WithValues("Controller", controllerName, "Request.Namespace", request.Namespace, "Request.Name", request.Name)
+
+	// Setup: retrieve account and awsClient
+	var account awsv1alpha1.Account
+	err := r.Client.Get(context.TODO(), request.NamespacedName, &account)
+	if err != nil {
+		log.Error(err, "Could not retrieve account to validate", "account-request", request.NamespacedName)
+		return utils.DoNotRequeue()
+	}
+
+	cm, err := utils.GetOperatorConfigMap(r.Client)
+	if err != nil {
+		log.Error(err, "Could not retrieve the operator configmap")
+		return utils.RequeueAfter(5 * time.Minute)
+	}
+
+	enabled, err := strconv.ParseBool(cm.Data["feature.validation_move_account"])
+	if err != nil {
+		log.Info("Could not retrieve feature flag 'feature.validation_move_account' - account moving is disabled")
+	} else {
+		account_move_enabled = enabled
+	}
+	log.Info("Is moving accounts enabled?", "enabled", account_move_enabled)
+
+	awsClientInput := awsclient.NewAwsClientInput{
+		AwsRegion:  config.GetDefaultRegion(),
+		SecretName: utils.AwsSecretName,
+		NameSpace:  awsv1alpha1.AccountCrNamespace,
+	}
+	awsClient, err := r.awsClientBuilder.GetClient(controllerName, r.Client, awsClientInput)
+	if err != nil {
+		log.Error(err, "Could not retrieve AWS client.")
+	}
+
+	// Perform any checks we want
+	err = r.ValidateAccountOU(awsClient, account, cm)
+	if err != nil {
+		// Decide who we will requeue now
+		validationError, ok := err.(*AccountValidationError)
+		if ok {
+			if validationError.Type == InvalidAccount {
+				return utils.DoNotRequeue()
+			}
+			if validationError.Type == AccountMoveFailed {
+				return utils.RequeueAfter(moveWaitTime)
+			}
+		}
+	}
+
+	return utils.DoNotRequeue()
+}

--- a/pkg/controller/validation/account_validation_controller_test.go
+++ b/pkg/controller/validation/account_validation_controller_test.go
@@ -1,0 +1,328 @@
+package validation
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/organizations"
+	"github.com/golang/mock/gomock"
+	"github.com/google/go-cmp/cmp"
+	"github.com/openshift/aws-account-operator/pkg/apis"
+	awsv1alpha1 "github.com/openshift/aws-account-operator/pkg/apis/aws/v1alpha1"
+	"github.com/openshift/aws-account-operator/pkg/awsclient"
+	"github.com/openshift/aws-account-operator/pkg/awsclient/mock"
+	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+func emptyOrganisation(ctrl *gomock.Controller) *mock.MockClient {
+	mockClient := mock.NewMockClient(ctrl)
+	mockClient.EXPECT().ListParents(&organizations.ListParentsInput{
+		ChildId: aws.String("111111"),
+	}).Return(&organizations.ListParentsOutput{
+		Parents: []*organizations.Parent{},
+	}, nil)
+	return mockClient
+}
+
+func singleOrganisation(ctrl *gomock.Controller) *mock.MockClient {
+	mockClient := mock.NewMockClient(ctrl)
+	mockClient.EXPECT().ListParents(&organizations.ListParentsInput{
+		ChildId: aws.String("111111"),
+	}).Return(&organizations.ListParentsOutput{
+		Parents: []*organizations.Parent{
+			{
+				Id:   aws.String("1"),
+				Type: aws.String(""),
+			}},
+	}, nil)
+	return mockClient
+}
+
+func multipleOrganisation(ctrl *gomock.Controller) *mock.MockClient {
+	mockClient := mock.NewMockClient(ctrl)
+	mockClient.EXPECT().ListParents(&organizations.ListParentsInput{
+		ChildId: aws.String("111111"),
+	}).Return(&organizations.ListParentsOutput{
+		Parents: []*organizations.Parent{
+			{
+				Id:   aws.String("1"),
+				Type: aws.String(""),
+			},
+			{
+				Id:   aws.String("2"),
+				Type: aws.String(""),
+			},
+		},
+	}, nil)
+	return mockClient
+}
+
+func alwaysTrue(s string) bool {
+	return true
+}
+
+func alwaysFalse(s string) bool {
+	return false
+}
+
+func TestParentsTillPredicate(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	parents := []string{}
+	type args struct {
+		awsId   string
+		client  awsclient.Client
+		p       func(s string) bool
+		parents *[]string
+	}
+	tests := []struct {
+		name     string
+		args     args
+		expected *[]string
+		wantErr  bool
+	}{
+		{
+			name:     "No parents",
+			args:     args{awsId: "111111", client: emptyOrganisation(ctrl), p: alwaysTrue, parents: &parents},
+			expected: &[]string{},
+			wantErr:  false,
+		},
+		{
+			name:     "Single parent",
+			args:     args{awsId: "111111", client: singleOrganisation(ctrl), p: alwaysTrue, parents: &parents},
+			expected: &[]string{},
+			wantErr:  false,
+		},
+		{
+			name:     "Multiple parents are not expected",
+			args:     args{awsId: "111111", client: multipleOrganisation(ctrl), p: alwaysTrue, parents: &parents},
+			expected: &[]string{},
+			wantErr:  true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			parents = []string{}
+			if err := ParentsTillPredicate(tt.args.awsId, tt.args.client, tt.args.p, tt.args.parents); (err != nil) != tt.wantErr {
+				t.Errorf("ParentsTillP() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestIsAccountInRootOU(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	// Simulate a root organization
+	type args struct {
+		account  awsv1alpha1.Account
+		client   awsclient.Client
+		isRootOU func(s string) bool
+	}
+	tests := []struct {
+		name     string
+		args     args
+		expected bool
+	}{
+		{name: "Empty accountID", args: args{
+			account:  awsv1alpha1.Account{},
+			client:   mock.NewMockClient(ctrl),
+			isRootOU: alwaysFalse,
+		}, expected: false},
+		{name: "Account is not in root", args: args{
+			account: awsv1alpha1.Account{
+				Spec: awsv1alpha1.AccountSpec{
+					AwsAccountID: "111111",
+				},
+			},
+			client:   emptyOrganisation(ctrl),
+			isRootOU: alwaysFalse,
+		}, expected: false},
+		{name: "Account is in root", args: args{
+			account: awsv1alpha1.Account{
+				Spec: awsv1alpha1.AccountSpec{
+					AwsAccountID: "111111",
+				},
+			},
+			client:   singleOrganisation(ctrl),
+			isRootOU: alwaysTrue,
+		}, expected: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := IsAccountInPoolOU(tt.args.account, tt.args.client, tt.args.isRootOU)
+			if got != tt.expected {
+				t.Errorf("IsAccountInRootOU() = %v, expected %v", got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestMoveAccount(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	errorListParents := func(ctrl *gomock.Controller) *mock.MockClient {
+		client := mock.NewMockClient(ctrl)
+		client.EXPECT().ListParents(gomock.Any()).Return(nil, errors.New("something went wrong"))
+		return client
+	}
+	type args struct {
+		account     string
+		client      awsclient.Client
+		targetOU    string
+		moveAccount bool
+	}
+	tests := []struct {
+		name    string
+		args    args
+		wantErr bool
+	}{
+		{name: "No parent for account returns error", args: args{
+			account:     "111111",
+			client:      errorListParents(ctrl),
+			targetOU:    "any",
+			moveAccount: true,
+		}, wantErr: true},
+		{name: "Account not in target OU will trigger a move", args: args{
+			account: "111111",
+			client: func(client *mock.MockClient) *mock.MockClient {
+				client.EXPECT().MoveAccount(&organizations.MoveAccountInput{
+					AccountId:           aws.String("111111"),
+					DestinationParentId: aws.String("targetOU"),
+					SourceParentId:      aws.String("1"),
+				}).Return(nil, nil)
+				return client
+			}(singleOrganisation(ctrl)),
+			targetOU:    "targetOU",
+			moveAccount: true,
+		}, wantErr: false},
+		{name: "Setting moveAccount false will prevent MoveAccount from being called", args: args{
+			account:     "111111",
+			client:      singleOrganisation(ctrl),
+			targetOU:    "targetOU",
+			moveAccount: false,
+		}, wantErr: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := MoveAccount(tt.args.account, tt.args.client, tt.args.targetOU, tt.args.moveAccount); (err != nil) != tt.wantErr {
+				t.Errorf("MoveAccount() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestValidateAccount_Reconcile(t *testing.T) {
+	err := apis.AddToScheme(scheme.Scheme)
+	if err != nil {
+		fmt.Printf("failed adding to scheme in account_validation_controller_test.go")
+	}
+	ctrl := gomock.NewController(t)
+	newBuilder := func(ctrl *gomock.Controller) awsclient.IBuilder {
+		mockClient := mock.NewMockClient(ctrl)
+		mockBuilder := mock.NewMockIBuilder(ctrl)
+		mockBuilder.EXPECT().GetClient(gomock.Any(), gomock.Any(), gomock.Any()).Return(mockClient, nil)
+		return mockBuilder
+	}
+	type fields struct {
+		Client           client.Client
+		scheme           *runtime.Scheme
+		awsClientBuilder awsclient.IBuilder
+	}
+	type args struct {
+		request reconcile.Request
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		want    reconcile.Result
+		wantErr bool
+	}{
+		{name: "Will not attempt to reconcile a CCS account.", fields: fields{
+			Client: fake.NewFakeClient([]runtime.Object{
+				&awsv1alpha1.Account{
+					TypeMeta: v1.TypeMeta{
+						Kind:       "Account",
+						APIVersion: "v1alpha1",
+					},
+					ObjectMeta: v1.ObjectMeta{
+						Name:      "test",
+						Namespace: "default",
+					},
+					Spec: awsv1alpha1.AccountSpec{
+						BYOC: true,
+					},
+				}, &corev1.ConfigMap{
+					ObjectMeta: v1.ObjectMeta{
+						Name:      awsv1alpha1.DefaultConfigMap,
+						Namespace: awsv1alpha1.AccountCrNamespace,
+					}}}...),
+			scheme:           scheme.Scheme,
+			awsClientBuilder: newBuilder(ctrl),
+		}, args: args{
+			request: reconcile.Request{
+				NamespacedName: types.NamespacedName{
+					Namespace: "default",
+					Name:      "test",
+				},
+			},
+		}, want: reconcile.Result{Requeue: false}, wantErr: false},
+		{name: "Will not attempt to reconcile a account pool account.", fields: fields{
+			Client: fake.NewFakeClient([]runtime.Object{
+				&awsv1alpha1.Account{
+					TypeMeta: v1.TypeMeta{
+						Kind:       "Account",
+						APIVersion: "v1alpha1",
+					},
+					ObjectMeta: v1.ObjectMeta{
+						Name:      "test",
+						Namespace: "default",
+						OwnerReferences: []v1.OwnerReference{
+							{
+								Kind: "AccountPool",
+							},
+						},
+					},
+				},
+				&corev1.ConfigMap{
+					ObjectMeta: v1.ObjectMeta{
+						Name:      awsv1alpha1.DefaultConfigMap,
+						Namespace: awsv1alpha1.AccountCrNamespace,
+					},
+				}}...),
+			scheme:           scheme.Scheme,
+			awsClientBuilder: newBuilder(ctrl),
+		}, args: args{
+			request: reconcile.Request{
+				NamespacedName: types.NamespacedName{
+					Namespace: "default",
+					Name:      "test",
+				},
+			},
+		}, want: reconcile.Result{Requeue: false}, wantErr: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := &ValidateAccount{
+				Client:           tt.fields.Client,
+				scheme:           tt.fields.scheme,
+				awsClientBuilder: tt.fields.awsClientBuilder,
+			}
+			got, err := r.Reconcile(tt.args.request)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ValidateAccount.Reconcile() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !cmp.Equal(got, tt.want) {
+				t.Errorf("ValidateAccount.Reconcile() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Adds a new controller to validate accounts to the operator.

Currently the validation logic only includes verifying that an unclaimed, non-ccs account is under the expected root organisation.
If this is not the case the account will be moved.