### PR TITLE
Remove workaround for KMS tests.

### DIFF
--- a/test/integration/api/create_account.sh
+++ b/test/integration/api/create_account.sh
@@ -20,8 +20,6 @@ while true
 do STATUS=$(oc get account ${OSD_STAGING_1_ACCOUNT_CR_NAME_OSD} -n ${NAMESPACE} -o json | jq -r '.status.state');
     if [ "$STATUS" == "Ready" ]; then
         break
-    elif [ "$STATUS" == "InitializingRegions" ]; then
-        break
     elif [ "$STATUS" == "Failed" ]; then
         echo "Account ${OSD_STAGING_1_ACCOUNT_CR_NAME_OSD} failed to create"
         exit 1


### PR DESCRIPTION
The way tests work with the new changes, don't need to break during
account creation, because only a claim is created for the test.

With the workaround the other tests fail, because the credentials are
not yet valid, when the test_secrets.sh script tries to validate them.