### PR TITLE
Adds additional log and updates olm template

### DIFF
--- a/hack/olm-registry/olm-artifacts-template.yaml
+++ b/hack/olm-registry/olm-artifacts-template.yaml
@@ -41,6 +41,12 @@ parameters:
 - name: FEDRAMP
   required: false
   value: "false"
+- name: FEATURE_VALIDATE_MOVE_ACCOUNT
+  required: false
+  value: "false"
+- name: FEATURE_VALIDATE_TAG_ACCOUNT
+  required: false
+  value: "false"
 
 objects:
 - apiVersion: operators.coreos.com/v1alpha1
@@ -115,7 +121,8 @@ objects:
       me-south-1:ami-0b41a37a62a4296fc:t3.micro
       us-gov-west-1:ami-2c74214d:t2.micro
       us-gov-east-1:ami-9e10f0ef:t2.micro
-    feature.validation_move_account: "false"
+    feature.validation_move_account: ${FEATURE_VALIDATE_MOVE_ACCOUNT}
+    feature.validation_tag_account: ${FEATURE_VALIDATE_TAG_ACCOUNT}
 
 - apiVersion: aws.managed.openshift.io/v1alpha1
   kind: AccountPool

--- a/pkg/controller/validation/account_validation_controller.go
+++ b/pkg/controller/validation/account_validation_controller.go
@@ -3,6 +3,7 @@ package validation
 import (
 	"context"
 	"errors"
+	"fmt"
 	"github.com/openshift/aws-account-operator/pkg/controller/account"
 	"strconv"
 	"time"
@@ -202,7 +203,7 @@ func ValidateAccountTags(client awsclient.Client, accountId *string, shardName s
 				} else {
 					return &AccountValidationError{
 						Type: IncorrectOwnerTag,
-						Err:  errors.New("Account is not tagged with the correct owner"),
+						Err:  fmt.Errorf("Account is not tagged with the correct owner, has %s; want %s", *tag.Value, shardName),
 					}
 				}
 			} else {


### PR DESCRIPTION
Adds an additional log statement to validate desired functionality
before enabling, as well as explicitly defines the feature flags as
configurable in the configmap in order to be able to run this
shard-by-shard when we're ready to turn on the flags.

Adds on to [OSD-10116](https://issues.redhat.com//browse/OSD-10116)