### PR TITLE
Adds check if account is claimed before moving OU - Take Two

### DIFF
--- a/pkg/controller/validation/account_validation_controller.go
+++ b/pkg/controller/validation/account_validation_controller.go
@@ -87,6 +87,7 @@ func newReconciler(mgr manager.Manager) reconcile.Reconciler {
 		Client:           utils.NewClientWithMetricsOrDie(log, mgr, controllerName),
 		scheme:           mgr.GetScheme(),
 		awsClientBuilder: &awsclient.Builder{},
+		OUNameIDMap:      map[string]string{},
 	}
 
 	return utils.NewReconcilerWithMetrics(reconciler, controllerName)

--- a/pkg/controller/validation/account_validation_controller.go
+++ b/pkg/controller/validation/account_validation_controller.go
@@ -284,7 +284,10 @@ func (r *ValidateAccount) ValidateAccountOU(awsClient awsclient.Client, account 
 				ouNeedsCreating = true
 			} else {
 				log.Info("Unexpected error attempting to get OU ID for Legal Entity", "legal_entity", account.Spec.LegalEntity.ID)
-				return fmt.Errorf("Unexpected error attempting to get OU ID for %s", account.Spec.LegalEntity.ID)
+				return &AccountValidationError{
+					Type: OULookupFailed,
+					Err:  errors.New("unexpected error attempting to get OU ID for legal entity"),
+				}
 			}
 		}
 

--- a/pkg/controller/validation/account_validation_controller.go
+++ b/pkg/controller/validation/account_validation_controller.go
@@ -13,6 +13,7 @@ import (
 	"github.com/openshift/aws-account-operator/config"
 	awsv1alpha1 "github.com/openshift/aws-account-operator/pkg/apis/aws/v1alpha1"
 	"github.com/openshift/aws-account-operator/pkg/awsclient"
+	"github.com/openshift/aws-account-operator/pkg/controller/accountclaim"
 	"github.com/openshift/aws-account-operator/pkg/controller/utils"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -115,7 +116,7 @@ func ParentsTillPredicate(awsId string, client awsclient.Client, p func(s string
 
 // Verify if the account is already in the root OU
 // The predicate indicates if the parent considered the desired root was found.
-func IsAccountInPoolOU(account awsv1alpha1.Account, client awsclient.Client, isPoolOU func(s string) bool) bool {
+func IsAccountInCorrectOU(account awsv1alpha1.Account, client awsclient.Client, isPoolOU func(s string) bool) bool {
 	if account.Spec.AwsAccountID == "" {
 		return false
 	}
@@ -202,10 +203,8 @@ func ValidateAccountTags(client awsclient.Client, accountId *string, shardName s
 
 					return nil
 				} else {
-					return &AccountValidationError{
-						Type: IncorrectOwnerTag,
-						Err:  fmt.Errorf("Account is not tagged with the correct owner, has %s; want %s", *tag.Value, shardName),
-					}
+					log.Info(fmt.Sprintf("Account is not tagged with the correct owner, has %s; want %s", *tag.Value, shardName))
+					return nil
 				}
 			} else {
 				return nil
@@ -267,16 +266,27 @@ func ValidateAwsAccountId(account awsv1alpha1.Account) error {
 	return nil
 }
 
-func (r *ValidateAccount) ValidateAccountOU(awsClient awsclient.Client, account awsv1alpha1.Account, poolOU string) error {
-	// Perform all checks on the account we want.
-	inPool := IsAccountInPoolOU(account, awsClient, func(s string) bool {
-		return s == poolOU
+func ValidateAccountOU(awsClient awsclient.Client, account awsv1alpha1.Account, poolOU string, claimedAccountOU string) error {
+	// Default OU should be the aao-managed-accounts OU.
+	// If the account has been claimed ever, we want to use the legal entity ID OU
+	correctOU := poolOU
+	if account.HasBeenClaimedAtLeastOnce() {
+		claimedOU, err := accountclaim.CreateOrFindOU(log, awsClient, account.Spec.LegalEntity.ID, claimedAccountOU)
+		if err != nil {
+			return err
+		}
+
+		correctOU = claimedOU
+	}
+
+	inCorrectOU := IsAccountInCorrectOU(account, awsClient, func(s string) bool {
+		return s == correctOU
 	})
-	if inPool {
-		log.Info("Account is already in the root OU.")
+	if inCorrectOU {
+		log.Info("Account is already in the correct OU.")
 	} else {
-		log.Info("Account is not in the root OU - it will be moved.")
-		err := MoveAccount(account.Spec.AwsAccountID, awsClient, poolOU, accountMoveEnabled)
+		log.Info("Account is not in the correct OU - it will be moved.")
+		err := MoveAccount(account.Spec.AwsAccountID, awsClient, correctOU, accountMoveEnabled)
 		if err != nil {
 			log.Error(err, "Could not move account")
 			return &AccountValidationError{
@@ -351,7 +361,7 @@ func (r *ValidateAccount) Reconcile(request reconcile.Request) (reconcile.Result
 		return utils.RequeueWithError(err)
 	}
 
-	err = r.ValidateAccountOU(awsClient, account, cm.Data["root"])
+	err = ValidateAccountOU(awsClient, account, cm.Data["root"], cm.Data["base"])
 	if err != nil {
 		// Decide who we will requeue now
 		validationError, ok := err.(*AccountValidationError)

--- a/pkg/controller/validation/account_validation_controller_test.go
+++ b/pkg/controller/validation/account_validation_controller_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/organizations"
 	"github.com/golang/mock/gomock"
 	"github.com/google/go-cmp/cmp"
@@ -66,6 +67,20 @@ func multipleOrganisation(ctrl *gomock.Controller) *mock.MockClient {
 	return mockClient
 }
 
+func designatedOrganization(ctrl *gomock.Controller, ouID string) *mock.MockClient {
+	mockClient := mock.NewMockClient(ctrl)
+	mockClient.EXPECT().ListParents(&organizations.ListParentsInput{
+		ChildId: aws.String("111111"),
+	}).Return(&organizations.ListParentsOutput{
+		Parents: []*organizations.Parent{
+			{
+				Id:   aws.String(ouID),
+				Type: aws.String(""),
+			}},
+	}, nil)
+	return mockClient
+}
+
 func alwaysTrue(s string) bool {
 	return true
 }
@@ -118,7 +133,7 @@ func TestParentsTillPredicate(t *testing.T) {
 	}
 }
 
-func TestIsAccountInRootOU(t *testing.T) {
+func TestIsAccountInCorrectOU(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	// Simulate a root organization
 	type args struct {
@@ -157,9 +172,9 @@ func TestIsAccountInRootOU(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := IsAccountInPoolOU(tt.args.account, tt.args.client, tt.args.isRootOU)
+			got := IsAccountInCorrectOU(tt.args.account, tt.args.client, tt.args.isRootOU)
 			if got != tt.expected {
-				t.Errorf("IsAccountInRootOU() = %v, expected %v", got, tt.expected)
+				t.Errorf("IsAccountInCorrectOU() = %v, expected %v", got, tt.expected)
 			}
 		})
 	}
@@ -213,6 +228,89 @@ func TestMoveAccount(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if err := MoveAccount(tt.args.account, tt.args.client, tt.args.targetOU, tt.args.moveAccount); (err != nil) != tt.wantErr {
 				t.Errorf("MoveAccount() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestValidateAccountOU(t *testing.T) {
+	ctrl := gomock.NewController(t)
+
+	testPoolOUID := "ou-abcd-efghijk"
+	testBaseOUID := "ou-lmno-qrstuvwxyz"
+	testLegalEntityOUID := "ou-aabb-ccddeeff"
+
+	legalEntity := awsv1alpha1.LegalEntity{
+		ID:   "abcdefg",
+		Name: "Test Entity ID",
+	}
+
+	notHandledError := fmt.Errorf("Some random error")
+	tests := []struct {
+		name      string
+		awsClient awsclient.Client
+		account   awsv1alpha1.Account
+		wantErr   error
+	}{
+		{
+			name:      "Account that has never been claimed and is in pool OU should return no errors",
+			awsClient: designatedOrganization(ctrl, testPoolOUID),
+			account: awsv1alpha1.Account{
+				Spec: awsv1alpha1.AccountSpec{
+					AwsAccountID: "111111",
+				},
+			},
+			wantErr: nil,
+		}, {
+			name: "Account that has been claimed before and is in legalEntity OU should return no error",
+			awsClient: func(client *mock.MockClient) *mock.MockClient {
+				client.EXPECT().CreateOrganizationalUnit(&organizations.CreateOrganizationalUnitInput{
+					ParentId: aws.String(testBaseOUID),
+					Name:     aws.String(legalEntity.ID),
+				}).Return(nil, awserr.New("DuplicateOrganizationalUnitException", "", nil))
+				client.EXPECT().ListOrganizationalUnitsForParent(&organizations.ListOrganizationalUnitsForParentInput{
+					ParentId: aws.String(testBaseOUID),
+				}).Return(&organizations.ListOrganizationalUnitsForParentOutput{
+					OrganizationalUnits: []*organizations.OrganizationalUnit{
+						{
+							Name: aws.String(legalEntity.ID),
+							Id:   aws.String(testLegalEntityOUID),
+						},
+					},
+				}, nil)
+				return client
+			}(designatedOrganization(ctrl, testLegalEntityOUID)),
+			account: awsv1alpha1.Account{
+				Spec: awsv1alpha1.AccountSpec{
+					AwsAccountID: "111111",
+					LegalEntity:  legalEntity,
+				},
+			},
+			wantErr: nil,
+		}, {
+			name: "Account that has been claimed before and has unknown error happen when checking the OU should return the error",
+			awsClient: func(client *mock.MockClient) *mock.MockClient {
+				client.EXPECT().CreateOrganizationalUnit(&organizations.CreateOrganizationalUnitInput{
+					ParentId: aws.String(testBaseOUID),
+					Name:     aws.String(legalEntity.ID),
+				}).Return(nil, notHandledError)
+				return client
+			}(designatedOrganization(ctrl, testLegalEntityOUID)),
+			account: awsv1alpha1.Account{
+				Spec: awsv1alpha1.AccountSpec{
+					AwsAccountID: "111111",
+					LegalEntity:  legalEntity,
+				},
+			},
+			wantErr: notHandledError,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateAccountOU(tt.awsClient, tt.account, testPoolOUID, testBaseOUID)
+			if err != tt.wantErr {
+				t.Errorf("Error validating account OU. Got: %v, want %v", err, tt.wantErr)
 			}
 		})
 	}

--- a/pkg/controller/validation/account_validation_controller_test.go
+++ b/pkg/controller/validation/account_validation_controller_test.go
@@ -251,6 +251,7 @@ func TestValidateAccountOU(t *testing.T) {
 		awsClient awsclient.Client
 		account   awsv1alpha1.Account
 		wantErr   error
+		ouMap     map[string]string
 	}{
 		{
 			name:      "Account that has never been claimed and is in pool OU should return no errors",
@@ -261,6 +262,7 @@ func TestValidateAccountOU(t *testing.T) {
 				},
 			},
 			wantErr: nil,
+			ouMap:   map[string]string{},
 		}, {
 			name: "Account that has been claimed before and is in legalEntity OU should return no error",
 			awsClient: func(client *mock.MockClient) *mock.MockClient {
@@ -287,13 +289,10 @@ func TestValidateAccountOU(t *testing.T) {
 				},
 			},
 			wantErr: nil,
+			ouMap:   map[string]string{},
 		}, {
-			name: "Account that has been claimed before and has unknown error happen when checking the OU should return the error",
+			name: "Account has been claimed before and is in OU Map",
 			awsClient: func(client *mock.MockClient) *mock.MockClient {
-				client.EXPECT().CreateOrganizationalUnit(&organizations.CreateOrganizationalUnitInput{
-					ParentId: aws.String(testBaseOUID),
-					Name:     aws.String(legalEntity.ID),
-				}).Return(nil, notHandledError)
 				return client
 			}(designatedOrganization(ctrl, testLegalEntityOUID)),
 			account: awsv1alpha1.Account{
@@ -302,14 +301,40 @@ func TestValidateAccountOU(t *testing.T) {
 					LegalEntity:  legalEntity,
 				},
 			},
-			wantErr: notHandledError,
+			wantErr: nil,
+			ouMap:   map[string]string{legalEntity.ID: testLegalEntityOUID},
+		}, {
+			name: "When encountering an error listing parents when getting OU ID from name it should return the error",
+			awsClient: func() *mock.MockClient {
+				mockClient := mock.NewMockClient(ctrl)
+				mockClient.EXPECT().ListOrganizationalUnitsForParent(&organizations.ListOrganizationalUnitsForParentInput{
+					ParentId: aws.String(testBaseOUID),
+				}).Return(&organizations.ListOrganizationalUnitsForParentOutput{}, notHandledError)
+				return mockClient
+			}(),
+			account: awsv1alpha1.Account{
+				Spec: awsv1alpha1.AccountSpec{
+					AwsAccountID: "111111",
+					LegalEntity:  legalEntity,
+				},
+			},
+			wantErr: fmt.Errorf("unexpected error attempting to get OU ID for legal entity"),
+			ouMap:   map[string]string{},
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := ValidateAccountOU(tt.awsClient, tt.account, testPoolOUID, testBaseOUID)
+			r := &ValidateAccount{}
+			r.OUNameIDMap = tt.ouMap
+			err := r.ValidateAccountOU(tt.awsClient, tt.account, testPoolOUID, testBaseOUID)
 			if err != tt.wantErr {
+				var ave *AccountValidationError
+				if errors.As(err, &ave) {
+					if ave.Err.Error() == tt.wantErr.Error() {
+						return
+					}
+				}
 				t.Errorf("Error validating account OU. Got: %v, want %v", err, tt.wantErr)
 			}
 		})


### PR DESCRIPTION
Reverts openshift/aws-account-operator#726, which removed the functionality that another PR added.

This re-adds the original functionality of trying to allow correct movement of the OU, however instead of using the accountclaim controller's naive implementation we're utilizing an in-memory map of the OUs that we've seen before to sidestep AWS Rate limits.