### PR TITLE
Updates the validation controller OU logic

### DIFF
--- a/controllers/validation/account_validation_controller.go
+++ b/controllers/validation/account_validation_controller.go
@@ -250,11 +250,12 @@ func ValidateAwsAccountId(account awsv1alpha1.Account) error {
 
 func (r *AccountValidationReconciler) ValidateAccountOU(awsClient awsclient.Client, account awsv1alpha1.Account, poolOU string, baseOU string) error {
 	// Default OU should be the aao-managed-accounts OU.
-	// If the account has been claimed ever, we want to use the legal entity ID OU
 	correctOU := poolOU
 
 	ouNeedsCreating := false
-	if account.HasBeenClaimedAtLeastOnce() {
+
+	// If the legal entity is not empty, it should go into the legalEntity's OU
+	if account.Spec.LegalEntity.ID != "" {
 		claimedOU, err := r.GetOUIDFromName(awsClient, baseOU, account.Spec.LegalEntity.ID)
 		if err != nil {
 			if errors.Is(err, awsv1alpha1.ErrNonexistentOU) {


### PR DESCRIPTION
Changes the validation controller to not care if the account has been reused before, but only care if the legal entity id is currently set. This allows us to take into consideration accounts that have had the legal entity reset and have not been claimed again, because the `reused` status is still set to true on those accounts.

Resolves [OSD-13089](https://issues.redhat.com//browse/OSD-13089)