### PR TITLE
Removes accountpool validation check

### DIFF
--- a/controllers/validation/account_validation_controller.go
+++ b/controllers/validation/account_validation_controller.go
@@ -222,13 +222,6 @@ func ValidateAccountOrigin(account awsv1alpha1.Account) error {
 			Err:  errors.New("Account is a CCS account"),
 		}
 	}
-	if !account.IsOwnedByAccountPool() {
-		log.Info("Will not validate account not owned by account pool")
-		return &AccountValidationError{
-			Type: InvalidAccount,
-			Err:  errors.New("Account is not in an account pool"),
-		}
-	}
 	if !account.IsReady() {
 		log.Info("Will not validate account not in a ready state")
 		return &AccountValidationError{

--- a/controllers/validation/account_validation_controller_test.go
+++ b/controllers/validation/account_validation_controller_test.go
@@ -353,11 +353,6 @@ func TestValidateAccountOrigin(t *testing.T) {
 			args: args{
 				account: awsv1alpha1.Account{
 					ObjectMeta: v1.ObjectMeta{
-						OwnerReferences: []v1.OwnerReference{
-							{
-								Kind: "AccountPool",
-							},
-						},
 						Name:      "testaccount",
 						Namespace: "testnamespace",
 					},
@@ -373,35 +368,10 @@ func TestValidateAccountOrigin(t *testing.T) {
 			expectedErr: "Account is a CCS account",
 		},
 		{
-			name: "Account not owned by account pool",
-			args: args{
-				account: awsv1alpha1.Account{
-					ObjectMeta: v1.ObjectMeta{
-						OwnerReferences: nil,
-						Name:            "testaccount",
-						Namespace:       "testnamespace",
-					},
-					Spec: awsv1alpha1.AccountSpec{
-						BYOC: false,
-					},
-					Status: awsv1alpha1.AccountStatus{
-						State: string(awsv1alpha1.AccountReady),
-					},
-				},
-			},
-			wantErr:     true,
-			expectedErr: "Account is not in an account pool",
-		},
-		{
 			name: "Account is not in ready state",
 			args: args{
 				account: awsv1alpha1.Account{
 					ObjectMeta: v1.ObjectMeta{
-						OwnerReferences: []v1.OwnerReference{
-							{
-								Kind: "AccountPool",
-							},
-						},
 						Name:      "testaccount",
 						Namespace: "testnamespace",
 					},
@@ -421,11 +391,6 @@ func TestValidateAccountOrigin(t *testing.T) {
 			args: args{
 				account: awsv1alpha1.Account{
 					ObjectMeta: v1.ObjectMeta{
-						OwnerReferences: []v1.OwnerReference{
-							{
-								Kind: "AccountPool",
-							},
-						},
 						Name:      "testaccount",
 						Namespace: "testnamespace",
 					},


### PR DESCRIPTION
Removes the extra check in the validation controller making sure that the account is owned by the accountpool.  This gives us the ability to validate migrated accounts (migrated from v3 - v4 shards)