### PR TITLE
Add a consumer ServiceAccount, ClusterRole, and ClusterRoleBinding

### DIFF
--- a/deploy/consumer_cluster_role.yaml
+++ b/deploy/consumer_cluster_role.yaml
@@ -1,0 +1,23 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: aws-account-operator-consumer
+rules:
+- apiGroups:
+  - "aws.managed.openshift.io"
+  resources:
+  - accountclaims
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch

--- a/deploy/consumer_cluster_role_binding.yaml
+++ b/deploy/consumer_cluster_role_binding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: aws-account-operator-consumer
+subjects:
+- kind: ServiceAccount
+  namespace: aws-account-operator
+  name: aws-account-operator-consumer
+roleRef:
+  kind: ClusterRole
+  name: aws-account-operator-consumer
+  apiGroup: rbac.authorization.k8s.io

--- a/deploy/consumer_service_account.yaml
+++ b/deploy/consumer_service_account.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: aws-account-operator-consumer
+  namespace: aws-account-operator # This namespace needs to be created in advance.


### PR DESCRIPTION
# What is being added?
The existing `aws-account-operator-client` service account contains most of the permissions required for the uhc specific use case. For a more generic use case where the AWS account credentials are simply consumed from the created secret, access to those secrets and the credentials within is missing.

This change adds a new `aws-account-operator-consumer` ServiceAccount, ClusterRole, and ClusterRoleBinding that grants just the necessary permissions for this basic use-case
