### PR TITLE
[OSD-13614] Add multiple accountpools to AAO

### DIFF
--- a/api/v1alpha1/account_types.go
+++ b/api/v1alpha1/account_types.go
@@ -38,6 +38,7 @@ type AccountSpec struct {
 	ClaimLinkNamespace string      `json:"claimLinkNamespace,omitempty"`
 	LegalEntity        LegalEntity `json:"legalEntity,omitempty"`
 	ManualSTSMode      bool        `json:"manualSTSMode,omitempty"`
+	AccountPool        string      `json:"accountPool,omitempty"`
 }
 
 // AccountStatus defines the observed state of Account
@@ -147,7 +148,7 @@ func init() {
 
 // Helper Functions
 
-//IsFailed returns true if an account is in a failed state
+// IsFailed returns true if an account is in a failed state
 func (a *Account) IsFailed() bool {
 	failedStates := [7]string{
 		string(AccountFailed),
@@ -166,64 +167,64 @@ func (a *Account) IsFailed() bool {
 	return false
 }
 
-//HasState returns true if an account has a state set at all
+// HasState returns true if an account has a state set at all
 func (a *Account) HasState() bool {
 	return a.Status.State != ""
 }
 
-//HasSupportCaseID returns true if an account has a SupportCaseID Set
+// HasSupportCaseID returns true if an account has a SupportCaseID Set
 func (a *Account) HasSupportCaseID() bool {
 	return a.Status.SupportCaseID != ""
 }
 
-//IsPendingVerification returns true if the account is in a PendingVerification state
+// IsPendingVerification returns true if the account is in a PendingVerification state
 func (a *Account) IsPendingVerification() bool {
 	return a.Status.State == string(AccountPendingVerification)
 }
 
-//IsReady returns true if an account is ready
+// IsReady returns true if an account is ready
 func (a *Account) IsReady() bool {
 	return a.Status.State == string(AccountReady)
 }
 
-//IsCreating returns true if an account is creating
+// IsCreating returns true if an account is creating
 func (a *Account) IsCreating() bool {
 	return a.Status.State == string(AccountCreating)
 }
 
-//HasClaimLink returns true if an accounts claim link is not empty
+// HasClaimLink returns true if an accounts claim link is not empty
 func (a *Account) HasClaimLink() bool {
 	return a.Spec.ClaimLink != ""
 }
 
-//IsClaimed returns true if account Status.Claimed is false
+// IsClaimed returns true if account Status.Claimed is false
 func (a *Account) IsClaimed() bool {
 	return a.Status.Claimed
 }
 
-//IsPendingDeletion returns true if a DeletionTimestamp has been set
+// IsPendingDeletion returns true if a DeletionTimestamp has been set
 func (a *Account) IsPendingDeletion() bool {
 	return a.DeletionTimestamp != nil
 }
 
-//IsBYOC returns true if account is a BYOC account
+// IsBYOC returns true if account is a BYOC account
 func (a *Account) IsBYOC() bool {
 	return a.Spec.BYOC
 }
 
-//HasAwsAccountID returns true if awsAccountID is set
+// HasAwsAccountID returns true if awsAccountID is set
 func (a *Account) HasAwsAccountID() bool {
 	return a.Spec.AwsAccountID != ""
 }
 
-//IsReadyUnclaimedAndHasClaimLink returns true if an account is ready, unclaimed, and has a claim link
+// IsReadyUnclaimedAndHasClaimLink returns true if an account is ready, unclaimed, and has a claim link
 func (a *Account) IsReadyUnclaimedAndHasClaimLink() bool {
 	return a.IsReady() &&
 		a.HasClaimLink() &&
 		!a.IsClaimed()
 }
 
-//HasAwsv1alpha1Finalizer returns true if the awsv1alpha1 finalizer is set on the account
+// HasAwsv1alpha1Finalizer returns true if the awsv1alpha1 finalizer is set on the account
 func (a *Account) HasAwsv1alpha1Finalizer() bool {
 	for _, v := range a.GetFinalizers() {
 		if v == AccountFinalizer {
@@ -243,7 +244,7 @@ func (a *Account) IsNonSTSPendingDeletionWithFinalizer() bool {
 		a.HasAwsv1alpha1Finalizer()
 }
 
-//IsBYOCPendingDeletionWithFinalizer returns true if account is a BYOC Account,
+// IsBYOCPendingDeletionWithFinalizer returns true if account is a BYOC Account,
 // has been marked for deletion (deletion timestamp set), and has a finalizer set.
 func (a *Account) IsBYOCPendingDeletionWithFinalizer() bool {
 	return a.IsPendingDeletion() &&
@@ -251,36 +252,36 @@ func (a *Account) IsBYOCPendingDeletionWithFinalizer() bool {
 		a.HasAwsv1alpha1Finalizer()
 }
 
-//IsBYOCAndNotReady returns true if account is BYOC and the state is not AccountReady
+// IsBYOCAndNotReady returns true if account is BYOC and the state is not AccountReady
 func (a *Account) IsBYOCAndNotReady() bool {
 	return a.IsBYOC() && !a.IsReady()
 }
 
-//ReadyForInitialization returns true if account is a BYOC Account and the state is not ready OR
+// ReadyForInitialization returns true if account is a BYOC Account and the state is not ready OR
 // accout state is creating, and has not been claimed
 func (a *Account) ReadyForInitialization() bool {
 	return a.IsBYOCAndNotReady() ||
 		a.IsUnclaimedAndIsCreating()
 }
 
-//IsUnclaimedAndHasNoState returns true if account has not set state and has not been claimed
+// IsUnclaimedAndHasNoState returns true if account has not set state and has not been claimed
 func (a *Account) IsUnclaimedAndHasNoState() bool {
 	return !a.HasState() &&
 		!a.IsClaimed()
 }
 
-//IsUnclaimedAndIsCreating returns true if account state is AccountCreating and has not been claimed
+// IsUnclaimedAndIsCreating returns true if account state is AccountCreating and has not been claimed
 func (a *Account) IsUnclaimedAndIsCreating() bool {
 	return a.IsCreating() &&
 		!a.IsClaimed()
 }
 
-//IsInitializingRegions returns true if the account state is InitalizingRegions
+// IsInitializingRegions returns true if the account state is InitalizingRegions
 func (a *Account) IsInitializingRegions() bool {
 	return a.Status.State == AccountInitializingRegions
 }
 
-//IsProgressing returns true if the account state is Creating, Pending Verification, or InitializingRegions
+// IsProgressing returns true if the account state is Creating, Pending Verification, or InitializingRegions
 func (a *Account) IsProgressing() bool {
 	if a.Status.State == string(AccountCreating) ||
 		a.Status.State == string(AccountPendingVerification) ||
@@ -295,12 +296,12 @@ func (a *Account) HasBeenClaimedAtLeastOnce() bool {
 	return a.Spec.LegalEntity.ID != "" || a.Status.Reused
 }
 
-//HasNeverBeenClaimed returns true if the account is not claimed AND has no legalEntity set, meaning it hasn't been claimed before and is not available for reuse
+// HasNeverBeenClaimed returns true if the account is not claimed AND has no legalEntity set, meaning it hasn't been claimed before and is not available for reuse
 func (a *Account) HasNeverBeenClaimed() bool {
 	return !a.Status.Claimed && a.Spec.LegalEntity.ID == ""
 }
 
-//IsOwnedByAccountPool returns true if the account has an ownerreference type that is the accountpool
+// IsOwnedByAccountPool returns true if the account has an ownerreference type that is the accountpool
 func (a *Account) IsOwnedByAccountPool() bool {
 	if a.ObjectMeta.OwnerReferences == nil {
 		return false

--- a/api/v1alpha1/accountclaim_types.go
+++ b/api/v1alpha1/accountclaim_types.go
@@ -27,6 +27,7 @@ type AccountClaimSpec struct {
 	SupportRoleARN      string      `json:"supportRoleARN,omitempty"`
 	CustomTags          string      `json:"customTags,omitempty"`
 	KmsKeyId            string      `json:"kmsKeyId,omitempty"`
+	AccountPool         string      `json:"accountPool,omitempty"`
 }
 
 // AccountClaimStatus defines the observed state of AccountClaim

--- a/api/v1alpha1/zz_generated.openapi.go
+++ b/api/v1alpha1/zz_generated.openapi.go
@@ -504,6 +504,12 @@ func schema_openshift_aws_account_operator_api_v1alpha1_AccountClaimSpec(ref com
 							Format: "",
 						},
 					},
+					"accountPool": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"string"},
+							Format: "",
+						},
+					},
 				},
 				Required: []string{"legalEntity", "awsCredentialSecret", "aws", "accountLink"},
 			},
@@ -792,6 +798,12 @@ func schema_openshift_aws_account_operator_api_v1alpha1_AccountSpec(ref common.R
 					"manualSTSMode": {
 						SchemaProps: spec.SchemaProps{
 							Type:   []string{"boolean"},
+							Format: "",
+						},
+					},
+					"accountPool": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"string"},
 							Format: "",
 						},
 					},

--- a/config/config.go
+++ b/config/config.go
@@ -97,14 +97,14 @@ func GetDefaultAccountPoolName(reqLogger logr.Logger, kubeClient client.Client) 
 	accountpoolString := cm.Data["accountpool"]
 
 	type AccountPool struct {
-		IsDefault     bool              `yaml:"default,omitempty"`
-		Servicequotas map[string]string `yaml:"servicequotas,omitempty"`
+		IsDefault bool `yaml:"default,omitempty"`
 	}
 
 	data := make(map[string]AccountPool)
 	err = yaml.Unmarshal([]byte(accountpoolString), &data)
 
 	if err != nil {
+		reqLogger.Error(err, "failed unmarshalling the accountpool data")
 		return "", err
 	}
 

--- a/controllers/accountclaim/accountclaim_controller.go
+++ b/controllers/accountclaim/accountclaim_controller.go
@@ -3,6 +3,8 @@ package accountclaim
 import (
 	"context"
 	"fmt"
+	"time"
+
 	"github.com/go-logr/logr"
 	"github.com/openshift/aws-account-operator/config"
 	"github.com/openshift/aws-account-operator/controllers/account"
@@ -15,7 +17,6 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
-	"time"
 
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -53,8 +54,9 @@ type AccountClaimReconciler struct {
 //+kubebuilder:rbac:groups=aws.managed.openshift.io,resources=accountclaims/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=aws.managed.openshift.io,resources=accountclaims/finalizers,verbs=update
 
-//go:generate mockgen -destination ./mock/cr-client.go -package mock sigs.k8s.io/controller-runtime/pkg/client Client
 // NewReconcileAccountClaim initializes ReconcileAccountClaim
+//
+//go:generate mockgen -destination ./mock/cr-client.go -package mock sigs.k8s.io/controller-runtime/pkg/client Client
 func NewAccountClaimReconciler(client client.Client, scheme *runtime.Scheme, awsClientBuilder awsclient.IBuilder) *AccountClaimReconciler {
 	return &AccountClaimReconciler{
 		Client:           client,
@@ -146,21 +148,11 @@ func (r *AccountClaimReconciler) Reconcile(ctx context.Context, request ctrl.Req
 		return reconcile.Result{}, r.statusUpdate(reqLogger, accountClaim)
 	}
 
-	accountList := &awsv1alpha1.AccountList{}
-
-	listOpts := []client.ListOption{
-		client.InNamespace(awsv1alpha1.AccountCrNamespace),
-	}
-	if err = r.Client.List(context.TODO(), accountList, listOpts...); err != nil {
-		reqLogger.Error(err, "Unable to get accountList")
-		return reconcile.Result{}, err
-	}
-
 	var unclaimedAccount *awsv1alpha1.Account
 
 	// Get an unclaimed account from the pool
 	if accountClaim.Spec.AccountLink == "" {
-		unclaimedAccount, err = getUnclaimedAccount(reqLogger, accountList, accountClaim)
+		unclaimedAccount, err = r.getUnclaimedAccount(reqLogger, accountClaim)
 		if err != nil {
 			reqLogger.Error(err, "Unable to select an unclaimed account from the pool")
 			return reconcile.Result{}, err
@@ -427,45 +419,74 @@ func (r *AccountClaimReconciler) getClaimedAccount(accountLink string, namespace
 	return account, nil
 }
 
-func getUnclaimedAccount(reqLogger logr.Logger, accountList *awsv1alpha1.AccountList, accountClaim *awsv1alpha1.AccountClaim) (*awsv1alpha1.Account, error) {
-	var unclaimedAccount awsv1alpha1.Account
-	var reusedAccount awsv1alpha1.Account
-	var unclaimedAccountFound = false
-	var reusedAccountFound = false
-	time.Sleep(1000 * time.Millisecond)
+func (r *AccountClaimReconciler) getUnclaimedAccount(reqLogger logr.Logger, accountClaim *awsv1alpha1.AccountClaim) (*awsv1alpha1.Account, error) {
 
-	// Range through accounts and select the first one that doesn't have a claim link
-	for i, account := range accountList.Items {
-		if !account.Status.Claimed && account.Spec.ClaimLink == "" && account.Status.State == "Ready" {
-			// Check for a reused account with matching legalEntity
-			if account.Status.Reused {
-				if matchAccountForReuse(&accountList.Items[i], accountClaim) {
-					reusedAccountFound = true
-					reusedAccount = account
-					// if available we break the loop, reused account takes priority
-					break
-				}
-			} else {
-				// If account is not reused, and we didn't claim one yet, do it
-				if !unclaimedAccountFound {
-					unclaimedAccount = account
-					unclaimedAccountFound = true
-				}
+	accountList := &awsv1alpha1.AccountList{}
+
+	listOpts := []client.ListOption{
+		client.InNamespace(awsv1alpha1.AccountCrNamespace),
+	}
+
+	if err := r.Client.List(context.TODO(), accountList, listOpts...); err != nil {
+		reqLogger.Error(err, "Unable to get accountList")
+		return nil, err
+	}
+
+	defaultAccountPoolName, err := config.GetDefaultAccountPoolName(reqLogger, r.Client)
+
+	if err != nil {
+		return nil, err
+	}
+
+	if defaultAccountPoolName == "" {
+		// We shouldn't really ever hit this, as GetDefaultAccountPoolName will return NotFound err if
+		// defaultAccountPoolName is empty, more of a just in case something changes.
+		return nil, fmt.Errorf("Cannot find default accountpool")
+	}
+
+	if accountClaim.Spec.AccountPool == defaultAccountPoolName || accountClaim.Spec.AccountPool == "" {
+		for _, account := range accountList.Items {
+			// Ensure we're pulling accounts from the default accountPool
+			if account.Spec.AccountPool == defaultAccountPoolName || (account.IsOwnedByAccountPool() && account.Spec.AccountPool == "") {
+				return checkClaimAccountValidity(reqLogger, account, accountClaim)
+			}
+		}
+	} else {
+		for _, account := range accountList.Items {
+			if account.Spec.AccountPool == accountClaim.Spec.AccountPool {
+				return checkClaimAccountValidity(reqLogger, account, accountClaim)
 			}
 		}
 	}
 
-	// Give priority to reusing accounts instead of claiming
-	if reusedAccountFound {
-		reqLogger.Info(fmt.Sprintf("Reusing account: %s", reusedAccount.ObjectMeta.Name))
-		return &reusedAccount, nil
+	return nil, fmt.Errorf("can't find a suitable account to claim")
+}
+
+func checkClaimAccountValidity(reqLogger logr.Logger, account awsv1alpha1.Account, accountClaim *awsv1alpha1.AccountClaim) (*awsv1alpha1.Account, error) {
+
+	var unclaimedAccount awsv1alpha1.Account
+	var unclaimedAccountFound = false
+
+	if !account.Status.Claimed && account.Spec.ClaimLink == "" && account.Status.State == "Ready" {
+		// Check for a reused account with matching legalEntity
+		if account.Status.Reused {
+			if matchAccountForReuse(&account, accountClaim) {
+				reqLogger.Info(fmt.Sprintf("Reusing account: %s", account.ObjectMeta.Name))
+				return &account, nil
+			}
+		} else {
+			// If account is not reused, and we didn't claim one yet, do it
+			if !unclaimedAccountFound {
+				unclaimedAccount = account
+				unclaimedAccountFound = true
+			}
+		}
 	}
 	// Go for unclaimed accounts
 	if unclaimedAccountFound {
 		reqLogger.Info(fmt.Sprintf("Claiming account: %s", unclaimedAccount.ObjectMeta.Name))
 		return &unclaimedAccount, nil
 	}
-
 	// Neither unclaimed nor reused accounts found
 	return nil, fmt.Errorf("can't find a ready account to claim")
 }
@@ -508,10 +529,7 @@ func (r *AccountClaimReconciler) checkIAMSecretExists(name string, namespace str
 	secretObjectKey := client.ObjectKey{Name: name, Namespace: namespace}
 	err := r.Client.Get(context.TODO(), secretObjectKey, &secret)
 	//nolint:gosimple // Ignores false-positive S1008 gosimple notice
-	if err != nil {
-		return false
-	}
-	return true
+	return err == nil
 }
 
 func (r *AccountClaimReconciler) statusUpdate(reqLogger logr.Logger, accountClaim *awsv1alpha1.AccountClaim) error {

--- a/controllers/accountpool/accountpool_controller.go
+++ b/controllers/accountpool/accountpool_controller.go
@@ -135,6 +135,7 @@ func (r *AccountPoolReconciler) calculateAccountPoolStatus(reqLogger logr.Logger
 			defaultPoolName, err := config.GetDefaultAccountPoolName(reqLogger, r.Client)
 
 			if err != nil {
+				reqLogger.Error(err, "error getting default accountpool name")
 				return awsv1alpha1.AccountPoolStatus{}, err
 			}
 

--- a/controllers/accountpool/accountpool_controller.go
+++ b/controllers/accountpool/accountpool_controller.go
@@ -14,7 +14,9 @@ import (
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
+	"github.com/go-logr/logr"
 	awsv1alpha1 "github.com/openshift/aws-account-operator/api/v1alpha1"
+	"github.com/openshift/aws-account-operator/config"
 	"github.com/openshift/aws-account-operator/controllers/account"
 	"github.com/openshift/aws-account-operator/pkg/totalaccountwatcher"
 	"github.com/openshift/aws-account-operator/pkg/utils"
@@ -59,7 +61,7 @@ func (r *AccountPoolReconciler) Reconcile(ctx context.Context, request ctrl.Requ
 	}
 
 	// Calculate unclaimed accounts vs claimed accounts
-	calculatedStatus, err := r.calculateAccountPoolStatus()
+	calculatedStatus, err := r.calculateAccountPoolStatus(reqLogger, currentAccountPool.Name)
 	if err != nil {
 		return reconcile.Result{}, err
 	}
@@ -87,6 +89,7 @@ func (r *AccountPoolReconciler) Reconcile(ctx context.Context, request ctrl.Requ
 
 	// Create Account CR
 	newAccount := account.GenerateAccountCR(awsv1alpha1.AccountCrNamespace)
+	newAccount.Spec.AccountPool = currentAccountPool.Name
 	utils.AddFinalizer(newAccount, awsv1alpha1.AccountFinalizer)
 
 	// Set AccountPool instance as the owner and controller
@@ -104,7 +107,7 @@ func (r *AccountPoolReconciler) Reconcile(ctx context.Context, request ctrl.Requ
 }
 
 // Calculates the unclaimedAccountCount and Claimed Account Counts
-func (r *AccountPoolReconciler) calculateAccountPoolStatus() (awsv1alpha1.AccountPoolStatus, error) {
+func (r *AccountPoolReconciler) calculateAccountPoolStatus(reqLogger logr.Logger, poolName string) (awsv1alpha1.AccountPoolStatus, error) {
 	unclaimedAccountCount := 0
 	claimedAccountCount := 0
 	availableAccounts := 0
@@ -124,6 +127,25 @@ func (r *AccountPoolReconciler) calculateAccountPoolStatus() (awsv1alpha1.Accoun
 		// if the account is not owned by the accountpool, skip it
 		if !account.IsOwnedByAccountPool() {
 			continue
+		}
+
+		// Special intermediary case until all account crs have had their account.Spec.AccountPool set appropriately.
+		// If account.Spec.AccountPool is empty, we count it as if it's from the default accountpool.
+		if account.Spec.AccountPool == "" {
+			defaultPoolName, err := config.GetDefaultAccountPoolName(reqLogger, r.Client)
+
+			if err != nil {
+				return awsv1alpha1.AccountPoolStatus{}, err
+			}
+
+			if poolName != defaultPoolName {
+				continue
+			}
+		} else {
+			// If an accountpool name is specified, we want to count ONLY that pool
+			if account.Spec.AccountPool != poolName {
+				continue
+			}
 		}
 
 		// count unclaimed accounts

--- a/controllers/accountpool/accountpool_controller_test.go
+++ b/controllers/accountpool/accountpool_controller_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
-
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -94,6 +94,17 @@ func TestReconcileAccountPool(t *testing.T) {
 	}
 
 	localmetrics.Collector = localmetrics.NewMetricsCollector(nil)
+
+	configmap := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      awsv1alpha1.DefaultConfigMap,
+			Namespace: awsv1alpha1.AccountCrNamespace,
+		},
+		Data: map[string]string{
+			"accountpool": "test: {\"default\": true}",
+		},
+	}
+
 	tests := []struct {
 		name                  string
 		localObjects          []runtime.Object
@@ -118,6 +129,7 @@ func TestReconcileAccountPool(t *testing.T) {
 						UnclaimedAccounts: 2,
 					},
 				},
+				configmap,
 				createAccountMock("account1", "Ready", unclaimed),
 				createAccountMock("account2", "Ready", unclaimed),
 			},
@@ -155,6 +167,7 @@ func TestReconcileAccountPool(t *testing.T) {
 						UnclaimedAccounts: 0,
 					},
 				},
+				configmap,
 			},
 			expectedAccountPool: awsv1alpha1.AccountPool{
 				ObjectMeta: metav1.ObjectMeta{
@@ -190,6 +203,7 @@ func TestReconcileAccountPool(t *testing.T) {
 				createAccountMock("account3", "PendingVerification", unclaimed),
 				createAccountMock("account4", "Failed", unclaimed),
 				createAccountMock("account5", "Ready", claimed),
+				configmap,
 			},
 			expectedAccountPool: awsv1alpha1.AccountPool{
 				ObjectMeta: metav1.ObjectMeta{

--- a/deploy/crds/aws.managed.openshift.io_accountclaims.yaml
+++ b/deploy/crds/aws.managed.openshift.io_accountclaims.yaml
@@ -52,6 +52,8 @@ spec:
                 type: string
               accountOU:
                 type: string
+              accountPool:
+                type: string
               aws:
                 description: Aws struct contains specific AWS account configuration
                   options

--- a/deploy/crds/aws.managed.openshift.io_accounts.yaml
+++ b/deploy/crds/aws.managed.openshift.io_accounts.yaml
@@ -52,6 +52,8 @@ spec:
           spec:
             description: AccountSpec defines the desired state of Account
             properties:
+              accountPool:
+                type: string
               awsAccountID:
                 type: string
               byoc:

--- a/hack/scripts/set_operator_configmap.sh
+++ b/hack/scripts/set_operator_configmap.sh
@@ -89,5 +89,9 @@ if [ -z "${SUPPORT_JUMP_ROLE+x}" ]; then
     exit 1
 fi
 
+ACCOUNTPOOL_CONFIG="
+zero-size-accountpool:
+  default: true"
+
 echo "Deploying AWS Account Operator Configmap"
-oc process -p ROOT="${AWS_ROOT_OU}" -p BASE="${AWS_BASE_OU}" -p ACCOUNTLIMIT="${AWS_ACCOUNT_LIMIT}" -p VCPU_QUOTA="${AWS_VCPU_QUOTA}" -p OPERATOR_NAMESPACE=aws-account-operator -p STS_JUMP_ARN="${STS_JUMP_ARN}" -p SUPPORT_JUMP_ROLE="${SUPPORT_JUMP_ROLE}" -f hack/templates/aws.managed.openshift.io_v1alpha1_configmap.tmpl | oc apply -f -
+oc process -p ROOT="${AWS_ROOT_OU}" -p BASE="${AWS_BASE_OU}" -p ACCOUNTLIMIT="${AWS_ACCOUNT_LIMIT}" -p VCPU_QUOTA="${AWS_VCPU_QUOTA}" -p OPERATOR_NAMESPACE=aws-account-operator -p STS_JUMP_ARN="${STS_JUMP_ARN}" -p SUPPORT_JUMP_ROLE="${SUPPORT_JUMP_ROLE}" -p ACCOUNTPOOL_CONFIG="${ACCOUNTPOOL_CONFIG}" -f hack/templates/aws.managed.openshift.io_v1alpha1_configmap.tmpl | oc apply -f -

--- a/hack/templates/aws.managed.openshift.io_v1alpha1_configmap.tmpl
+++ b/hack/templates/aws.managed.openshift.io_v1alpha1_configmap.tmpl
@@ -8,6 +8,7 @@ parameters:
 - name: OPERATOR_NAMESPACE
 - name: STS_JUMP_ARN
 - name: SUPPORT_JUMP_ROLE
+- name: ACCOUNTPOOL_CONFIG
 metadata:
   name: test-aws-ou-mapping-configmap-template
 objects:
@@ -57,6 +58,4 @@ objects:
     feature.validation_move_account: "false"
     feature.validation_tag_account: "false"
     shard-name: local
-    accountpool: | 
-      zero-size-accountpool: 
-        default: true
+    accountpool: ${ACCOUNTPOOL_CONFIG}

--- a/hack/templates/aws.managed.openshift.io_v1alpha1_configmap.tmpl
+++ b/hack/templates/aws.managed.openshift.io_v1alpha1_configmap.tmpl
@@ -57,3 +57,6 @@ objects:
     feature.validation_move_account: "false"
     feature.validation_tag_account: "false"
     shard-name: local
+    accountpool: | 
+      zero-size-accountpool: 
+        default: true


### PR DESCRIPTION
- Add handling to AAO for multiple account pools.
- Account claims can now specify which account pool they would like to claim from, if none specified, will claim from default account pool.

 
Ticket ref: [OSD-13614](https://issues.redhat.com//browse/OSD-13614)