### PR TITLE
Update required operator-sdk version.

### DIFF
--- a/docs/1.1-InstallationPrerequisites.md
+++ b/docs/1.1-InstallationPrerequisites.md
@@ -6,7 +6,7 @@ Please ensure you have the following installed, or configured, on your machine b
 * [Golang](https://golang.org/doc/install)
 * [aws-cli](https://aws.amazon.com/cli/)
 * Typically you'll want to use [CRC](https://github.com/code-ready/crc/) for local development, though it's fine if you're running OpenShift another way.
-* You need to have [the operator-sdk binary](https://github.com/operator-framework/operator-sdk/releases) in your `$PATH` < v0.18.
+* You need to have [the operator-sdk binary](https://github.com/operator-framework/operator-sdk/releases) in your `$PATH` > v1.0.
 
 ### 1.1.1 - IAM User and Secret
 

--- a/docs/2.0-Development.md
+++ b/docs/2.0-Development.md
@@ -45,8 +45,6 @@ make deploy-local
 
 will invoke the `operator-sdk` executable in `local` mode with the `FORCE_DEV_MODE=local` environment variable.
 
-**Note:** The operator relies on `operator-sdk` v0.16.0. The syntax of the executable has changed over time, so this `make` target may not work with other versions.
-
 ### 2.2.2 Cluster Mode
 
 In "cluster" development mode, as in local mode, AWS support case management is skipped.


### PR DESCRIPTION
The old documentation still specified v0.16.0 or < 0.18.0, however AAO can now run with operator-sdk v1.

# What is being added?
Just fixes the documentation.

## Checklist before requesting review

- [ ] I have tested this locally
- [ ] I have included unit tests
- [ ] I have updated any corresponding documentation
