### PR TITLE
Add route53:ListHostedZonesByVPC to network-mgmt role

### DIFF
--- a/hack/olm-registry/olm-artifacts-template.yaml
+++ b/hack/olm-registry/olm-artifacts-template.yaml
@@ -217,6 +217,7 @@ objects:
             - "ram:ListPrincipals"
             - "ram:ListResources"
             - "ram:RejectResourceShareInvitation"
+            - "route53:ListHostedZonesByVPC"
             - "route53resolver:AssociateResolverRule"
             - "route53resolver:DeleteResolverRule"
             - "route53resolver:DisassociateResolverRule"


### PR DESCRIPTION
Adding `route53:ListHostedZonesByVPC` statement to `network-mgmt` role's policy.

[OSD-15530](https://issues.redhat.com/browse/OSD-15530)
