### PR TITLE
When an AWSFederatedRole CR is updated, automatically update all associated AWSFederatedAccountAccess CRs

### DIFF
--- a/api/v1alpha1/shared_types.go
+++ b/api/v1alpha1/shared_types.go
@@ -91,6 +91,10 @@ var ErrFailedToDeleteSubnet = errors.New("FailedToDeleteSubnet")
 // UIDLabel is the string for the uid label on AWS Federated Account Access CRs
 var UIDLabel = "uid"
 
+var FederatedRoleNameLabel = "awsFederatedRoleName"
+
+var LastRoleUpdateAnnotation = "lastRoleUpdate"
+
 // AccountIDLabel is the string for the AWS Account ID label on AWS Federated Account Access CRs
 var AccountIDLabel = "awsAccountID"
 

--- a/controllers/awsfederatedaccountaccess/awsfederatedaccountaccess_controller.go
+++ b/controllers/awsfederatedaccountaccess/awsfederatedaccountaccess_controller.go
@@ -5,12 +5,12 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"strings"
-
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/iam"
 	"github.com/aws/aws-sdk-go/service/sts"
+	"net/url"
+	"strings"
 
 	controllerutils "github.com/openshift/aws-account-operator/pkg/utils"
 	corev1 "k8s.io/api/core/v1"
@@ -64,7 +64,7 @@ type AWSFederatedAccountAccessReconciler struct {
 //
 // For more details, check Reconcile and its Result here:
 // - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.11.2/pkg/reconcile
-func (r *AWSFederatedAccountAccessReconciler) Reconcile(ctx context.Context, request ctrl.Request) (ctrl.Result, error) {
+func (r *AWSFederatedAccountAccessReconciler) Reconcile(_ context.Context, request ctrl.Request) (ctrl.Result, error) {
 	reqLogger := log.WithValues("Controller", controllerName, "Request.Namespace", request.Namespace, "Request.Name", request.Name)
 
 	// Fetch the AWSFederatedAccountAccess instance
@@ -129,6 +129,26 @@ func (r *AWSFederatedAccountAccessReconciler) Reconcile(ctx context.Context, req
 		}
 	}
 
+	// Get aws client
+	awsClient, err := r.awsClientBuilder.GetClient(controllerName, r.Client, awsclient.NewAwsClientInput{
+		SecretName: currentFAA.Spec.AWSCustomerCredentialSecret.Name,
+		NameSpace:  currentFAA.Spec.AWSCustomerCredentialSecret.Namespace,
+		AwsRegion:  config.GetDefaultRegion(),
+	})
+	if err != nil {
+		reqLogger.Error(err, "Unable to create aws client for region")
+		return reconcile.Result{}, err
+	}
+
+	if currentFAA.Status.State != "" {
+		if err = r.syncIAMPolicy(currentFAA, requestedRole, awsClient, reqLogger); err != nil {
+			reqLogger.Error(err, fmt.Sprintf("Failed to validate IAM policy for account access %s/%s", currentFAA.Namespace, currentFAA.Name))
+			currentFAA.Status.State = awsv1alpha1.AWSFederatedAccountStateFailed
+			SetStatuswithCondition(currentFAA, "Failed to update policy", awsv1alpha1.AWSFederatedAccountFailed, awsv1alpha1.AWSFederatedAccountStateFailed)
+			return reconcile.Result{}, err
+		}
+	}
+
 	// If the state is ready or failed don't do anything
 	if currentFAA.Status.State == awsv1alpha1.AWSFederatedAccountStateReady || currentFAA.Status.State == awsv1alpha1.AWSFederatedAccountStateFailed {
 		return reconcile.Result{}, nil
@@ -152,7 +172,7 @@ func (r *AWSFederatedAccountAccessReconciler) Reconcile(ctx context.Context, req
 		// Update the CR with new labels
 		err = r.Client.Update(context.TODO(), currentFAA)
 		if err != nil {
-			reqLogger.Error(err, fmt.Sprintf("Lable update for %s failed", currentFAA.Name))
+			reqLogger.Error(err, fmt.Sprintf("Failed to update label %s for %s/%s", awsv1alpha1.UIDLabel, currentFAA.Namespace, currentFAA.Name))
 			return reconcile.Result{}, err
 		}
 
@@ -163,16 +183,14 @@ func (r *AWSFederatedAccountAccessReconciler) Reconcile(ctx context.Context, req
 		return reconcile.Result{}, err
 	}
 
-	// Get aws client
-	awsRegion := config.GetDefaultRegion()
-	awsClient, err := r.awsClientBuilder.GetClient(controllerName, r.Client, awsclient.NewAwsClientInput{
-		SecretName: currentFAA.Spec.AWSCustomerCredentialSecret.Name,
-		NameSpace:  currentFAA.Spec.AWSCustomerCredentialSecret.Namespace,
-		AwsRegion:  awsRegion,
-	})
-	if err != nil {
-		reqLogger.Error(err, "Unable to create aws client for region ")
-		return reconcile.Result{}, err
+	if !hasLabel(currentFAA, awsv1alpha1.FederatedRoleNameLabel) {
+		currentFAA.Labels[awsv1alpha1.FederatedRoleNameLabel] = requestedRole.Name
+
+		err = r.Client.Update(context.TODO(), currentFAA)
+		if err != nil {
+			reqLogger.Error(err, fmt.Sprintf("Failed to update label %s for %s/%s", awsv1alpha1.FederatedRoleNameLabel, currentFAA.Namespace, currentFAA.Name))
+			return reconcile.Result{}, err
+		}
 	}
 
 	// Get account number of cluster account
@@ -246,7 +264,7 @@ func (r *AWSFederatedAccountAccessReconciler) Reconcile(ctx context.Context, req
 	currentFAA.Status.ConsoleURL = fmt.Sprintf("https://signin.aws.amazon.com/switchrole?account=%s&roleName=%s", accountID, *role.RoleName)
 
 	awsManagedPolicyNames := []string{}
-	// Add all aws managed policy names to a array
+	// Add all aws managed policy names to an array
 	awsManagedPolicyNames = append(awsManagedPolicyNames, requestedRole.Spec.AWSManagedPolicies...)
 	// Get policy arns for managed policies
 	policyArns := createPolicyArns(accountID, awsManagedPolicyNames, true)
@@ -282,29 +300,107 @@ func (r *AWSFederatedAccountAccessReconciler) Reconcile(ctx context.Context, req
 	return reconcile.Result{}, nil
 }
 
-// createIAMPolicy creates the IAM policys in AWSFederatedRole inside of our cluster account
-func (r *AWSFederatedAccountAccessReconciler) createIAMPolicy(awsClient awsclient.Client, afr awsv1alpha1.AWSFederatedRole, afaa awsv1alpha1.AWSFederatedAccountAccess) (*iam.Policy, error) {
-	// Same struct from the afr.Spec.AWSCustomPolicy.Statements , but with json tags as capitals due to requirements for the policydoc
-	type awsStatement struct {
-		Effect    string                 `json:"Effect"`
-		Action    []string               `json:"Action"`
-		Resource  []string               `json:"Resource,omitempty"`
-		Condition *awsv1alpha1.Condition `json:"Condition,omitempty"`
-		Principal *awsv1alpha1.Principal `json:"Principal,omitempty"`
+func detachRolePolicy(awsClient awsclient.Client, federatedRole *awsv1alpha1.AWSFederatedRole, awsAccountID string, uid string) error {
+	roleName := federatedRole.Name + "-" + uid
+	policyName := federatedRole.Spec.AWSCustomPolicy.Name + "-" + uid
+	policyArn := fmt.Sprintf("arn:aws:iam::%s:policy/%s", awsAccountID, policyName)
+
+	if _, err := awsClient.DetachRolePolicy(&iam.DetachRolePolicyInput{
+		PolicyArn: &policyArn,
+		RoleName:  &roleName,
+	}); err != nil {
+		if aerr, ok := err.(awserr.Error); ok {
+			if aerr.Code() != iam.ErrCodeNoSuchEntityException {
+				return err
+			}
+		} else {
+			return err
+		}
+	}
+	return nil
+}
+
+func (r *AWSFederatedAccountAccessReconciler) syncIAMPolicy(currentFAA *awsv1alpha1.AWSFederatedAccountAccess, requestedRole *awsv1alpha1.AWSFederatedRole, awsClient awsclient.Client, reqLogger logr.Logger) error {
+	// validate that the policy in AWS matches the CR
+	uid, ok := currentFAA.Labels[awsv1alpha1.UIDLabel]
+	if !ok {
+		err := errors.New("FederatedAccountAccess has no uid label")
+		reqLogger.Error(err, fmt.Sprintf("Federated account access %s/%s has no uid label.", currentFAA.Namespace, currentFAA.Name))
+		return err
+	}
+	roleName := fmt.Sprintf("%s-%s", requestedRole.Name, uid)
+	policyName := fmt.Sprintf("%s-%s", requestedRole.Spec.AWSCustomPolicy.Name, uid)
+	awsRolePolicies, err := awsClient.ListAttachedRolePolicies(&iam.ListAttachedRolePoliciesInput{RoleName: &roleName})
+	if err != nil {
+		reqLogger.Error(err, fmt.Sprintf("Failed to list policies for role %s from AWS", roleName))
+		return err
 	}
 
-	statements := []awsStatement{}
+	for _, awsAttachedPolicy := range awsRolePolicies.AttachedPolicies {
+		if *awsAttachedPolicy.PolicyName == policyName {
+			awsPolicy, err := awsClient.GetPolicy(&iam.GetPolicyInput{PolicyArn: awsAttachedPolicy.PolicyArn})
+			if err != nil {
+				reqLogger.Error(err, fmt.Sprintf("Failed to get policy %s for role %s from AWS", *awsAttachedPolicy.PolicyName, roleName))
+				return err
+			}
+
+			awsPolicyVersion, err := awsClient.GetPolicyVersion(&iam.GetPolicyVersionInput{
+				PolicyArn: awsAttachedPolicy.PolicyArn,
+				VersionId: awsPolicy.Policy.DefaultVersionId,
+			})
+			if err != nil {
+				reqLogger.Error(err, fmt.Sprintf("Failed to get version %s for policy %s for role %s from AWS", *awsPolicy.Policy.DefaultVersionId, *awsAttachedPolicy.PolicyName, roleName))
+				return err
+			}
+
+			awsDocument, err := url.QueryUnescape(*awsPolicyVersion.PolicyVersion.Document)
+			if err != nil {
+				reqLogger.Error(err, fmt.Sprintf("Failed to parse policy document from AWS for %v", awsAttachedPolicy.PolicyName))
+			}
+
+			jsonRequestedRole, err := controllerutils.MarshalIAMPolicy(*requestedRole)
+			if err != nil {
+				reqLogger.Error(err, fmt.Sprintf("Failed to marshal policy %s for role %s from AWS", *awsAttachedPolicy.PolicyName, roleName))
+				return err
+			}
+
+			if jsonRequestedRole == awsDocument {
+				return nil
+			}
+
+			err = detachRolePolicy(awsClient, requestedRole, currentFAA.Labels[awsv1alpha1.AccountIDLabel], uid)
+			if err != nil {
+				reqLogger.Error(err, fmt.Sprintf("Failed to detach policy %s from role %s", requestedRole.Spec.AWSCustomPolicy.Name, requestedRole.Name))
+				return err
+			}
+			err = r.createOrUpdateIAMPolicy(awsClient, *requestedRole, *currentFAA)
+			if err != nil {
+				reqLogger.Error(err, fmt.Sprintf("Failed to apply IAM policy for AWS federated account access CR %s/%s", requestedRole.Namespace, roleName))
+				return err
+			}
+			err = r.attachIAMPolices(awsClient, roleName, createPolicyArns(currentFAA.Labels[awsv1alpha1.AccountIDLabel], []string{requestedRole.Spec.AWSCustomPolicy.Name + "-" + uid}, false))
+			if err != nil {
+				reqLogger.Error(err, fmt.Sprintf("Failed to attach IAM policy for AWS federated account access CR %s/%s", requestedRole.Namespace, roleName))
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+// createIAMPolicy creates the IAM policies in AWSFederatedRole inside our cluster account
+func (r *AWSFederatedAccountAccessReconciler) createIAMPolicy(awsClient awsclient.Client, afr awsv1alpha1.AWSFederatedRole, afaa awsv1alpha1.AWSFederatedAccountAccess) (*iam.Policy, error) {
+	// Same struct from the afr.Spec.AWSCustomPolicy.Statements , but with json tags as capitals due to requirements for the policydoc
+
+	statements := []controllerutils.AwsStatement{}
 
 	for _, sm := range afr.Spec.AWSCustomPolicy.Statements {
-		var a awsStatement = awsStatement(sm)
+		var a = controllerutils.AwsStatement(sm)
 		statements = append(statements, a)
 	}
 
 	// Create an aws policydoc formated struct
-	policyDoc := struct {
-		Version   string
-		Statement []awsStatement
-	}{
+	policyDoc := controllerutils.AwsPolicy{
 		Version:   "2012-10-17",
 		Statement: statements,
 	}
@@ -403,7 +499,8 @@ func (r *AWSFederatedAccountAccessReconciler) createOrUpdateIAMPolicy(awsClient 
 	if err != nil {
 		if aerr, ok := err.(awserr.Error); ok {
 			if aerr.Code() == "EntityAlreadyExists" {
-				_, err = awsClient.DeletePolicy(&iam.DeletePolicyInput{PolicyArn: aws.String(customPolArns[0])})
+				policyName := afr.Spec.AWSCustomPolicy.Name + "-" + uidLabel
+				err = checkAndDeletePolicy(awsClient, uidLabel, afr.Spec.AWSCustomPolicy.Name, &policyName, &customPolArns[0])
 				if err != nil {
 					return err
 				}
@@ -643,7 +740,7 @@ func (r *AWSFederatedAccountAccessReconciler) cleanFederatedRoles(reqLogger logr
 				}
 			}
 
-			err = checkAndDeletePolicy(reqLogger, awsClient, uidLabel, federatedRoleCR.Spec.AWSCustomPolicy.Name, attachedPolicy.PolicyName, attachedPolicy.PolicyArn)
+			err = checkAndDeletePolicy(awsClient, uidLabel, federatedRoleCR.Spec.AWSCustomPolicy.Name, attachedPolicy.PolicyName, attachedPolicy.PolicyArn)
 			if err != nil {
 				return err
 			}
@@ -699,7 +796,7 @@ func (r *AWSFederatedAccountAccessReconciler) deleteNonAttachedCustomPolicy(reqL
 		}
 
 		for _, policy := range policyListOutput.Policies {
-			err = checkAndDeletePolicy(reqLogger, awsClient, uidLabel, federatedRoleCR.Spec.AWSCustomPolicy.Name, policy.PolicyName, policy.Arn)
+			err = checkAndDeletePolicy(awsClient, uidLabel, federatedRoleCR.Spec.AWSCustomPolicy.Name, policy.PolicyName, policy.Arn)
 			if err != nil {
 				return err
 			}
@@ -724,26 +821,31 @@ func hasLabel(awsFederatedAccountAccess *awsv1alpha1.AWSFederatedAccountAccess, 
 	return false
 }
 
-func checkAndDeletePolicy(reqLogger logr.Logger, awsClient awsclient.Client, uidLabel string, crPolicyName string, policyName *string, policyArn *string) error {
-
-	var awsCustomPolicyname string
-	awsCustomPolicyname = getPolicyNameWithUID(awsCustomPolicyname, crPolicyName, uidLabel)
+func checkAndDeletePolicy(awsClient awsclient.Client, uidLabel string, crPolicyName string, policyName *string, policyArn *string) error {
+	awsCustomPolicyname := getPolicyNameWithUID(crPolicyName, uidLabel)
 
 	if *policyName == awsCustomPolicyname {
-		_, err := awsClient.DeletePolicy(&iam.DeletePolicyInput{PolicyArn: policyArn})
+		policyVersions, err := awsClient.ListPolicyVersions(&iam.ListPolicyVersionsInput{PolicyArn: policyArn})
+		if err != nil {
+			return err
+		}
+
+		for _, policyVersion := range policyVersions.Versions {
+			if !*policyVersion.IsDefaultVersion {
+				if _, err = awsClient.DeletePolicyVersion(&iam.DeletePolicyVersionInput{VersionId: policyVersion.VersionId, PolicyArn: policyArn}); err != nil {
+					return err
+				}
+			}
+		}
+
+		_, err = awsClient.DeletePolicy(&iam.DeletePolicyInput{PolicyArn: policyArn})
 		if err != nil {
 			if aerr, ok := err.(awserr.Error); ok {
 				switch aerr.Code() {
 				default:
-					reqLogger.Error(
-						aerr,
-						fmt.Sprint(aerr.Error()),
-					)
-					reqLogger.Error(err, fmt.Sprintf("%v", err))
 					return err
 				}
 			} else {
-				reqLogger.Error(err, "Other error while trying to detach policies")
 				return err
 			}
 		}
@@ -751,7 +853,7 @@ func checkAndDeletePolicy(reqLogger logr.Logger, awsClient awsclient.Client, uid
 	return nil
 }
 
-func getPolicyNameWithUID(awsCustomPolicyname string, crPolicyName string, uidLabel string) string {
+func getPolicyNameWithUID(crPolicyName string, uidLabel string) string {
 	if !strings.HasSuffix(crPolicyName, "-"+uidLabel) {
 		crPolicyName = crPolicyName + "-" + uidLabel
 	}

--- a/controllers/awsfederatedrole/awsfederatedrole_controller_test.go
+++ b/controllers/awsfederatedrole/awsfederatedrole_controller_test.go
@@ -1,0 +1,75 @@
+package awsfederatedrole
+
+import (
+	"context"
+	"fmt"
+	apis "github.com/openshift/aws-account-operator/api"
+	"github.com/openshift/aws-account-operator/api/v1alpha1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"testing"
+)
+
+const testRoleName = "test-role"
+
+func setupKubeClientMock(localObjects []runtime.Object) client.WithWatch {
+	return fake.NewClientBuilder().WithScheme(scheme.Scheme).WithRuntimeObjects(localObjects...).Build()
+}
+
+func generateAccountAccesses(num int) []runtime.Object {
+	var objects []runtime.Object
+	for i := 0; i < num; i++ {
+		objects = append(objects, &v1alpha1.AWSFederatedAccountAccess{
+			ObjectMeta: v1.ObjectMeta{
+				Labels:    map[string]string{v1alpha1.FederatedRoleNameLabel: testRoleName},
+				Name:      fmt.Sprintf("testAccount%v", i),
+				Namespace: "testNamespace",
+			},
+		})
+	}
+	return objects
+}
+
+func TestAWSFederatedRoleReconciler_annotateAccountAccesses(t *testing.T) {
+	err := apis.AddToScheme(scheme.Scheme)
+	if err != nil {
+		fmt.Printf("failed adding to scheme in awsfederatedrole_controller_test.go")
+	}
+
+	tests := []struct {
+		name         string
+		localObjects []runtime.Object
+	}{
+		{
+			name:         "no account accesses",
+			localObjects: []runtime.Object{},
+		},
+		{
+			name:         "single account access",
+			localObjects: generateAccountAccesses(1),
+		},
+		{
+			name:         "multiple account accesses",
+			localObjects: generateAccountAccesses(10),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fakeKubeClient := setupKubeClientMock(tt.localObjects)
+			if err := annotateAccountAccesses(fakeKubeClient, testRoleName); err != nil {
+				t.Errorf("annotateAccountAccesses() error = %v, wantErr %v", err, false)
+			}
+
+			accountAccesses := &v1alpha1.AWSFederatedAccountAccessList{}
+			_ = fakeKubeClient.List(context.TODO(), accountAccesses, client.MatchingLabels{v1alpha1.FederatedRoleNameLabel: testRoleName})
+			for _, account := range accountAccesses.Items {
+				if _, ok := account.Annotations[v1alpha1.LastRoleUpdateAnnotation]; !ok {
+					t.Errorf("annotateAccountAccesses() failed to add annotation to account %s", account.Name)
+				}
+			}
+		})
+	}
+}

--- a/pkg/awsclient/client.go
+++ b/pkg/awsclient/client.go
@@ -95,6 +95,10 @@ type Client interface {
 	ListAttachedUserPolicies(*iam.ListAttachedUserPoliciesInput) (*iam.ListAttachedUserPoliciesOutput, error)
 	CreatePolicy(*iam.CreatePolicyInput) (*iam.CreatePolicyOutput, error)
 	DeletePolicy(input *iam.DeletePolicyInput) (*iam.DeletePolicyOutput, error)
+	DeletePolicyVersion(input *iam.DeletePolicyVersionInput) (*iam.DeletePolicyVersionOutput, error)
+	GetPolicy(input *iam.GetPolicyInput) (*iam.GetPolicyOutput, error)
+	GetPolicyVersion(input *iam.GetPolicyVersionInput) (*iam.GetPolicyVersionOutput, error)
+	ListPolicyVersions(input *iam.ListPolicyVersionsInput) (*iam.ListPolicyVersionsOutput, error)
 	AttachRolePolicy(*iam.AttachRolePolicyInput) (*iam.AttachRolePolicyOutput, error)
 	DetachRolePolicy(*iam.DetachRolePolicyInput) (*iam.DetachRolePolicyOutput, error)
 	ListAttachedRolePolicies(*iam.ListAttachedRolePoliciesInput) (*iam.ListAttachedRolePoliciesOutput, error)
@@ -302,6 +306,22 @@ func (c *awsClient) CreatePolicy(input *iam.CreatePolicyInput) (*iam.CreatePolic
 
 func (c *awsClient) DeletePolicy(input *iam.DeletePolicyInput) (*iam.DeletePolicyOutput, error) {
 	return c.iamClient.DeletePolicy(input)
+}
+
+func (c *awsClient) DeletePolicyVersion(input *iam.DeletePolicyVersionInput) (*iam.DeletePolicyVersionOutput, error) {
+	return c.iamClient.DeletePolicyVersion(input)
+}
+
+func (c *awsClient) GetPolicy(input *iam.GetPolicyInput) (*iam.GetPolicyOutput, error) {
+	return c.iamClient.GetPolicy(input)
+}
+
+func (c *awsClient) GetPolicyVersion(input *iam.GetPolicyVersionInput) (*iam.GetPolicyVersionOutput, error) {
+	return c.iamClient.GetPolicyVersion(input)
+}
+
+func (c *awsClient) ListPolicyVersions(input *iam.ListPolicyVersionsInput) (*iam.ListPolicyVersionsOutput, error) {
+	return c.iamClient.ListPolicyVersions(input)
 }
 
 func (c *awsClient) AttachRolePolicy(input *iam.AttachRolePolicyInput) (*iam.AttachRolePolicyOutput, error) {

--- a/pkg/awsclient/mock/zz_generated.mock_client.go
+++ b/pkg/awsclient/mock/zz_generated.mock_client.go
@@ -312,6 +312,21 @@ func (mr *MockClientMockRecorder) DeletePolicy(input interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeletePolicy", reflect.TypeOf((*MockClient)(nil).DeletePolicy), input)
 }
 
+// DeletePolicyVersion mocks base method.
+func (m *MockClient) DeletePolicyVersion(input *iam.DeletePolicyVersionInput) (*iam.DeletePolicyVersionOutput, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeletePolicyVersion", input)
+	ret0, _ := ret[0].(*iam.DeletePolicyVersionOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DeletePolicyVersion indicates an expected call of DeletePolicyVersion.
+func (mr *MockClientMockRecorder) DeletePolicyVersion(input interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeletePolicyVersion", reflect.TypeOf((*MockClient)(nil).DeletePolicyVersion), input)
+}
+
 // DeleteRole mocks base method.
 func (m *MockClient) DeleteRole(arg0 *iam.DeleteRoleInput) (*iam.DeleteRoleOutput, error) {
 	m.ctrl.T.Helper()
@@ -642,6 +657,36 @@ func (mr *MockClientMockRecorder) GetFederationToken(arg0 interface{}) *gomock.C
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetFederationToken", reflect.TypeOf((*MockClient)(nil).GetFederationToken), arg0)
 }
 
+// GetPolicy mocks base method.
+func (m *MockClient) GetPolicy(input *iam.GetPolicyInput) (*iam.GetPolicyOutput, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetPolicy", input)
+	ret0, _ := ret[0].(*iam.GetPolicyOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetPolicy indicates an expected call of GetPolicy.
+func (mr *MockClientMockRecorder) GetPolicy(input interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPolicy", reflect.TypeOf((*MockClient)(nil).GetPolicy), input)
+}
+
+// GetPolicyVersion mocks base method.
+func (m *MockClient) GetPolicyVersion(input *iam.GetPolicyVersionInput) (*iam.GetPolicyVersionOutput, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetPolicyVersion", input)
+	ret0, _ := ret[0].(*iam.GetPolicyVersionOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetPolicyVersion indicates an expected call of GetPolicyVersion.
+func (mr *MockClientMockRecorder) GetPolicyVersion(input interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPolicyVersion", reflect.TypeOf((*MockClient)(nil).GetPolicyVersion), input)
+}
+
 // GetRole mocks base method.
 func (m *MockClient) GetRole(arg0 *iam.GetRoleInput) (*iam.GetRoleOutput, error) {
 	m.ctrl.T.Helper()
@@ -850,6 +895,21 @@ func (m *MockClient) ListPolicies(arg0 *iam.ListPoliciesInput) (*iam.ListPolicie
 func (mr *MockClientMockRecorder) ListPolicies(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListPolicies", reflect.TypeOf((*MockClient)(nil).ListPolicies), arg0)
+}
+
+// ListPolicyVersions mocks base method.
+func (m *MockClient) ListPolicyVersions(input *iam.ListPolicyVersionsInput) (*iam.ListPolicyVersionsOutput, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListPolicyVersions", input)
+	ret0, _ := ret[0].(*iam.ListPolicyVersionsOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListPolicyVersions indicates an expected call of ListPolicyVersions.
+func (mr *MockClientMockRecorder) ListPolicyVersions(input interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListPolicyVersions", reflect.TypeOf((*MockClient)(nil).ListPolicyVersions), input)
 }
 
 // ListRequestedServiceQuotaChangeHistory mocks base method.

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -75,7 +75,7 @@ func GetOperatorStartTime() *metav1.Time {
 }
 
 // The JSON tags as capitals due to requirements for the policydoc
-type awsStatement struct {
+type AwsStatement struct {
 	Effect    string                 `json:"Effect"`
 	Action    []string               `json:"Action"`
 	Resource  []string               `json:"Resource,omitempty"`
@@ -105,21 +105,21 @@ const (
 // in production or a development environment.
 var DetectDevMode devMode = devMode(strings.ToLower(os.Getenv(envDevMode)))
 
-type awsPolicy struct {
+type AwsPolicy struct {
 	Version   string
-	Statement []awsStatement
+	Statement []AwsStatement
 }
 
 // MarshalIAMPolicy converts a role CR into a JSON policy that is acceptable to AWS
 func MarshalIAMPolicy(role awsv1alpha1.AWSFederatedRole) (string, error) {
-	statements := []awsStatement{}
+	statements := []AwsStatement{}
 
 	for _, statement := range role.Spec.AWSCustomPolicy.Statements {
-		statements = append(statements, awsStatement(statement))
+		statements = append(statements, AwsStatement(statement))
 	}
 
 	// Create a aws policydoc formated struct
-	policyDoc := awsPolicy{
+	policyDoc := AwsPolicy{
 		Version:   "2012-10-17",
 		Statement: statements,
 	}

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -25,7 +25,7 @@ func createRoleMock(statements []awsv1alpha1.StatementEntry) awsv1alpha1.AWSFede
 }
 
 func TestMarshallingIAMPolicy(t *testing.T) {
-	expected := awsStatement{
+	expected := AwsStatement{
 		Effect:   "Allow",
 		Action:   []string{"ec2:DescribeInstances"},
 		Resource: []string{"*"},
@@ -53,7 +53,7 @@ func TestMarshallingIAMPolicy(t *testing.T) {
 
 	// Convert the policy back to an object so we can run comparisons easier than
 	// trying to do the same with a string.
-	var policy awsPolicy
+	var policy AwsPolicy
 	err = json.Unmarshal([]byte(policyJSON), &policy)
 	if err != nil {
 		t.Errorf("There was an error unmarshalling the IAM Policy. %s", err)
@@ -85,7 +85,7 @@ func TestMarshallingIAMPolicy(t *testing.T) {
 }
 
 func TestMarshalingMultipleStatements(t *testing.T) {
-	expectedList := []awsStatement{
+	expectedList := []AwsStatement{
 		{
 			Effect:   "Allow",
 			Action:   []string{"ec2:DescribeInstances"},
@@ -120,7 +120,7 @@ func TestMarshalingMultipleStatements(t *testing.T) {
 
 	// Convert the policy back to an object so we can run comparisons easier than
 	// trying to do the same with a string.
-	var policy awsPolicy
+	var policy AwsPolicy
 	err = json.Unmarshal([]byte(policyJSON), &policy)
 	if err != nil {
 		t.Errorf("There was an error unmarshalling the IAM Policy. %s", err)
@@ -135,7 +135,7 @@ func TestAddingConditionsToStatements(t *testing.T) {
 	condition := &awsv1alpha1.Condition{
 		StringEquals: map[string]string{"ram:RequestedResourceType": "route53resolver:ResolverRule"},
 	}
-	expected := awsStatement{
+	expected := AwsStatement{
 		Effect:    "Allow",
 		Action:    []string{"ec2:DescribeInstances"},
 		Resource:  []string{"*"},
@@ -165,7 +165,7 @@ func TestAddingConditionsToStatements(t *testing.T) {
 
 	// Convert the policy back to an object so we can run comparisons easier than
 	// trying to do the same with a string.
-	var policy awsPolicy
+	var policy AwsPolicy
 	err = json.Unmarshal([]byte(policyJSON), &policy)
 	if err != nil {
 		t.Errorf("There was an error unmarshalling the IAM Policy. %s", err)


### PR DESCRIPTION
# What is being added?
When an `awsfederatedaccountrole` CR is updated, this change will pick up that change and sync it to all `awsfederatedaccountaccess` IAM policies for that role.

## Checklist before requesting review

- [x] I have tested this locally
- [x] I have included unit tests
- [ ] I have updated any corresponding documentation

## Steps To Manually Test
1. Start the operator
1. Create a new `awsfederatedrole` CR and `awsfederatedaccountaccess` CR for that role.
1. Check the AWS console for the account you're working with - validate that IAM policy created matches the federated role CR.
1. `oc edit` the `awsfederatedrole` you created to change the permissions in `.spec.awsCustomPolicy.awsStatements.action`.
1. Refresh your AWS console. Observe that the change made to the CR in the previous step is reflected in the IAM policy.

Ref [OSD-15564](https://issues.redhat.com//browse/OSD-15564)
