### PR TITLE
OSD-14723 enable ap-southeast-4

### DIFF
--- a/hack/olm-registry/olm-artifacts-template.yaml
+++ b/hack/olm-registry/olm-artifacts-template.yaml
@@ -119,6 +119,7 @@ objects:
       ap-southeast-1:ami-055c55112e25b1f1f:t2.micro
       ap-southeast-2:ami-036b423b657376f5b:t2.micro
       ap-southeast-3:ami-095c30251fd6a1c5e:t3.micro
+      ap-southeast-4:ami-0fe006c8d5a67ab1b:t3.micro
       sa-east-1:ami-05c1c16cac05a7c0b:t2.micro
       af-south-1:ami-0f4b49fefef9be45a:t3.micro
       me-south-1:ami-0b41a37a62a4296fc:t3.micro


### PR DESCRIPTION
# What is being added?
Adding a new region in the config file.
This is mostly following https://github.com/openshift/aws-account-operator/blob/master/docs/6.0-Maintenance.md#61---adding-a-new-region-to-support 
The AMI is not the same as us-east-1 because the current us-east-1 image is too old to find in ap-southeast-4. The image used here is 
ami-0fe006c8d5a67ab1b  RHEL-9.1.0_HVM-20221101-x86_64-2-Hourly2-GP2
Owner account ID  309956199498 (same as other regions)

## Checklist before requesting review

- [N/A] I have tested this locally
   The change is more on configuration file.
   Ran `make lint` `make test` `make test-apis`
- [N/A] I have included unit tests
   No code change
- [N/A] I have updated any corresponding documentation

## Steps To Manually Test
_Please provide us steps to reproduce the scenarios needed to test this.  If an integration test is provided, let us know how to run it. If not, enumerate the steps to validate this does what it's supposed to._
1. Start the operator
1. Run the thing
1. Observe X in the spec for the thing
1. Clean up the thing

Ref [OSD-14723](https://issues.redhat.com//browse/OSD-14723)
