### PR TITLE
OSD-14723: Adding AMI for enabling ap-southeast-4

### DIFF
--- a/fips.go
+++ b/fips.go
@@ -1,3 +1,4 @@
+//go:build fips_enabled
 // +build fips_enabled
 
 // BOILERPLATE GENERATED -- DO NOT EDIT

--- a/hack/olm-registry/olm-artifacts-template.yaml
+++ b/hack/olm-registry/olm-artifacts-template.yaml
@@ -119,6 +119,7 @@ objects:
       ap-southeast-1:ami-055c55112e25b1f1f:t2.micro
       ap-southeast-2:ami-036b423b657376f5b:t2.micro
       ap-southeast-3:ami-095c30251fd6a1c5e:t3.micro
+      ap-southeast-4:ami-0fe006c8d5a67ab1b:t3.micro
       sa-east-1:ami-05c1c16cac05a7c0b:t2.micro
       af-south-1:ami-0f4b49fefef9be45a:t3.micro
       me-south-1:ami-0b41a37a62a4296fc:t3.micro


### PR DESCRIPTION
# What is being added?
_Is this a fix for a bug?  What's the bug?  Is this a new feature? Please describe it. Is this just a small typo fix?  That's fine too!_
Feature : Adding AMI for enabling ap-southeast-4 , Melbourne
## Checklist before requesting review

- [ ] I have tested this locally
- [ ] I have included unit tests
- [ ] I have updated any corresponding documentation

## Steps To Manually Test
_Please provide us steps to reproduce the scenarios needed to test this.  If an integration test is provided, let us know how to run it. If not, enumerate the steps to validate this does what it's supposed to._
1. Start the operator
1. Run the thing
1. Observe X in the spec for the thing
1. Clean up the thing

Ref OSD-0000
