### PR TITLE
Make sure to add federated role label to existing accounts if not present

### DIFF
--- a/controllers/awsfederatedaccountaccess/awsfederatedaccountaccess_controller.go
+++ b/controllers/awsfederatedaccountaccess/awsfederatedaccountaccess_controller.go
@@ -148,11 +148,7 @@ func (r *AWSFederatedAccountAccessReconciler) Reconcile(_ context.Context, reque
 			newLabel := map[string]string{awsv1alpha1.FederatedRoleNameLabel: requestedRole.Name}
 
 			// Join the new UID label with any current labels
-			if currentFAA.Labels != nil {
-				currentFAA.Labels = controllerutils.JoinLabelMaps(currentFAA.Labels, newLabel)
-			} else {
-				currentFAA.Labels = newLabel
-			}
+			currentFAA.Labels = controllerutils.JoinLabelMaps(currentFAA.Labels, newLabel)
 
 			err = r.Client.Update(context.TODO(), currentFAA)
 			if err != nil {
@@ -180,14 +176,10 @@ func (r *AWSFederatedAccountAccessReconciler) Reconcile(_ context.Context, reque
 		uid := controllerutils.GenerateShortUID()
 
 		reqLogger.Info(fmt.Sprintf("Adding UID %s to AccountAccess %s", uid, currentFAA.Name))
-		newLabel := map[string]string{"uid": uid}
+		newLabel := map[string]string{awsv1alpha1.UIDLabel: uid}
 
 		// Join the new UID label with any current labels
-		if currentFAA.Labels != nil {
-			currentFAA.Labels = controllerutils.JoinLabelMaps(currentFAA.Labels, newLabel)
-		} else {
-			currentFAA.Labels = newLabel
-		}
+		currentFAA.Labels = controllerutils.JoinLabelMaps(currentFAA.Labels, newLabel)
 
 		// Update the CR with new labels
 		err = r.Client.Update(context.TODO(), currentFAA)
@@ -222,14 +214,10 @@ func (r *AWSFederatedAccountAccessReconciler) Reconcile(_ context.Context, reque
 	if !hasLabel(currentFAA, awsv1alpha1.AccountIDLabel) {
 
 		reqLogger.Info(fmt.Sprintf("Adding awsAccountID %s to AccountAccess %s", accountID, currentFAA.Name))
-		newLabel := map[string]string{"awsAccountID": accountID}
+		newLabel := map[string]string{awsv1alpha1.AccountIDLabel: accountID}
 
 		// Join the new UID label with any current labels
-		if currentFAA.Labels != nil {
-			currentFAA.Labels = controllerutils.JoinLabelMaps(currentFAA.Labels, newLabel)
-		} else {
-			currentFAA.Labels = newLabel
-		}
+		currentFAA.Labels = controllerutils.JoinLabelMaps(currentFAA.Labels, newLabel)
 
 		// Update the CR with new labels
 		err = r.Client.Update(context.TODO(), currentFAA)

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -195,6 +195,9 @@ func GenerateLabel(key, value string) map[string]string {
 
 // JoinLabelMaps adds a label to CR
 func JoinLabelMaps(m1, m2 map[string]string) map[string]string {
+	if m1 == nil {
+		return m2
+	}
 
 	for key, value := range m2 {
 		m1[key] = value

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -195,14 +195,16 @@ func GenerateLabel(key, value string) map[string]string {
 
 // JoinLabelMaps adds a label to CR
 func JoinLabelMaps(m1, m2 map[string]string) map[string]string {
-	if m1 == nil {
-		return m2
+	merged := make(map[string]string)
+
+	for key, value := range m1 {
+		merged[key] = value
 	}
 
 	for key, value := range m2 {
-		m1[key] = value
+		merged[key] = value
 	}
-	return m1
+	return merged
 }
 
 // AccountCRHasIAMUserIDLabel check for label

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -310,7 +310,7 @@ func TestJoinLabelMaps(t *testing.T) {
 	}{
 		{
 			name: "both maps nil",
-			want: nil,
+			want: map[string]string{},
 		},
 		{
 			name: "m1 is nil",
@@ -331,7 +331,7 @@ func TestJoinLabelMaps(t *testing.T) {
 			want: map[string]string{"foo": "bar"},
 		},
 		{
-			name: "m1 and m2 populated with different entires",
+			name: "m1 and m2 populated with differententries ",
 			m1:   map[string]string{"foo": "bar"},
 			m2:   map[string]string{"boo": "far"},
 			want: map[string]string{"foo": "bar", "boo": "far"},

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -300,3 +300,48 @@ func TestGetControllerMaxReconcilesFromCM(t *testing.T) {
 		})
 	}
 }
+
+func TestJoinLabelMaps(t *testing.T) {
+	tests := []struct {
+		name string
+		m1   map[string]string
+		m2   map[string]string
+		want map[string]string
+	}{
+		{
+			name: "both maps nil",
+			want: nil,
+		},
+		{
+			name: "m1 is nil",
+			m1:   nil,
+			m2:   map[string]string{"foo": "bar"},
+			want: map[string]string{"foo": "bar"},
+		},
+		{
+			name: "m2 is nil",
+			m1:   map[string]string{"foo": "bar"},
+			m2:   nil,
+			want: map[string]string{"foo": "bar"},
+		},
+		{
+			name: "m1 and m2 populated with same entry",
+			m1:   map[string]string{"foo": "bar"},
+			m2:   map[string]string{"foo": "bar"},
+			want: map[string]string{"foo": "bar"},
+		},
+		{
+			name: "m1 and m2 populated with different entires",
+			m1:   map[string]string{"foo": "bar"},
+			m2:   map[string]string{"boo": "far"},
+			want: map[string]string{"foo": "bar", "boo": "far"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := JoinLabelMaps(tt.m1, tt.m2); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("JoinLabelMaps() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Small miss from https://github.com/openshift/aws-account-operator/pull/751.

Catches an edge case where the `awsFederatedRole` label would not be applied to existing `awsfederatedaccountaccess` CRs.