### PR TITLE
Enabling ap-south-2 region for cloud provider operators

### DIFF
--- a/build/Dockerfile.olm-registry
+++ b/build/Dockerfile.olm-registry
@@ -3,7 +3,7 @@ ARG SAAS_OPERATOR_DIR
 COPY ${SAAS_OPERATOR_DIR} manifests
 RUN initializer --permissive
 
-FROM registry.access.redhat.com/ubi8/ubi-micro:8.7-8
+FROM registry.access.redhat.com/ubi8/ubi-micro:8.8-1
 
 COPY --from=builder /bin/registry-server /bin/registry-server
 COPY --from=builder /bin/grpc_health_probe /bin/grpc_health_probe

--- a/hack/olm-registry/olm-artifacts-template.yaml
+++ b/hack/olm-registry/olm-artifacts-template.yaml
@@ -116,6 +116,7 @@ objects:
       ap-northeast-3:ami-070dd2ec8c4a6df38:t2.micro
       ap-east-1:ami-f4fab885:t3.micro
       ap-south-1:ami-0963937a03c01ecd4:t2.micro
+      ap-south-2:ami-07fc4af782348e97c:t3.micro
       ap-southeast-1:ami-055c55112e25b1f1f:t2.micro
       ap-southeast-2:ami-036b423b657376f5b:t2.micro
       ap-southeast-3:ami-095c30251fd6a1c5e:t3.micro

--- a/hack/templates/aws.managed.openshift.io_v1alpha1_configmap.tmpl
+++ b/hack/templates/aws.managed.openshift.io_v1alpha1_configmap.tmpl
@@ -45,6 +45,7 @@ objects:
       ap-northeast-3:ami-070dd2ec8c4a6df38:t2.micro
       ap-east-1:ami-f4fab885:t3.micro
       ap-south-1:ami-0963937a03c01ecd4:t2.micro
+      ap-south-2:ami-07fc4af782348e97c:t3.micro
       ap-southeast-1:ami-055c55112e25b1f1f:t2.micro
       ap-southeast-2:ami-036b423b657376f5b:t2.micro
       ap-southeast-3:ami-095c30251fd6a1c5e:t3.micro


### PR DESCRIPTION
# What is being added?
Feature : Enabling ap-south-2region for cloud provider operators

## Checklist before requesting review

- [x] I have tested this locally
- [ ] I have included unit tests
- [ ] I have updated any corresponding documentation

## Steps To Manually Test
_Please provide us steps to reproduce the scenarios needed to test this.  If an integration test is provided, let us know how to run it. If not, enumerate the steps to validate this does what it's supposed to._
1. Start the operator
1. Run the thing
1. Observe X in the spec for the thing
1. Clean up the thing

Ref [OSD-14722](https://issues.redhat.com/browse/OSD-14722)
