### PR TITLE
Add ServiceQuotasReadOnlyAccess managed policy to Read only users

### DIFF
--- a/hack/olm-registry/olm-artifacts-template.yaml
+++ b/hack/olm-registry/olm-artifacts-template.yaml
@@ -336,3 +336,4 @@ objects:
     - "AmazonS3ReadOnlyAccess"
     - "IAMReadOnlyAccess"
     - "CloudWatchReadOnlyAccess"
+    - "ServiceQuotasReadOnlyAccess"

--- a/test/deploy/aws.managed.openshift.io_v1alpha1_awsfederatedrole_readonly_cr.yaml
+++ b/test/deploy/aws.managed.openshift.io_v1alpha1_awsfederatedrole_readonly_cr.yaml
@@ -25,3 +25,4 @@ spec:
    - "AmazonS3ReadOnlyAccess"
    - "IAMReadOnlyAccess"
    - "CloudWatchReadOnlyAccess"
+   - "ServiceQuotasReadOnlyAccess"


### PR DESCRIPTION
related to https://issues.redhat.com/browse/OSD-17109

OCM users use the AWS Infrastructure Access feature to gain access to the cluster's AWS account. They can either choose read-only or network-mgmt roles.

To enable OSD users to get proper usage/quota metrics for AWS accounts, it is expected that users can get service quota from there. When trying to do that currently, a user gets a permission error (not authorized to perform: servicequotas:GetServiceQuota).

This PR adds the ServiceQuotasReadOnlyAccess managed policy to the Read only access policy.