### PR TITLE
[SDE-2273] Enable eu-central-2

### DIFF
--- a/hack/olm-registry/olm-artifacts-template.yaml
+++ b/hack/olm-registry/olm-artifacts-template.yaml
@@ -109,6 +109,7 @@ objects:
       ca-central-1:ami-06ca3c0058d0275b3:t2.micro
       eu-north-1:ami-08bc26bf92a90ba04:t3.micro
       eu-central-1:ami-09de4a4c670389e4b:t2.micro
+      eu-central-2:ami-0ad6de85a8b717c26:t3.micro
       eu-west-1:ami-0202869bdd0fc8c75:t2.micro
       eu-west-2:ami-0188c0c5eddd2d032:t2.micro
       eu-west-3:ami-0c4224e392ec4e440:t2.micro

--- a/hack/templates/aws.managed.openshift.io_v1alpha1_configmap.tmpl
+++ b/hack/templates/aws.managed.openshift.io_v1alpha1_configmap.tmpl
@@ -36,6 +36,7 @@ objects:
       ca-central-1:ami-06ca3c0058d0275b3:t2.micro
       eu-north-1:ami-08bc26bf92a90ba04:t3.micro
       eu-central-1:ami-09de4a4c670389e4b:t2.micro
+      eu-central-2:ami-0ad6de85a8b717c26:t3.micro
       eu-west-1:ami-0202869bdd0fc8c75:t2.micro
       eu-west-2:ami-0188c0c5eddd2d032:t2.micro
       eu-west-3:ami-0c4224e392ec4e440:t2.micro


### PR DESCRIPTION
# What is being added?
This adds the eu-central-2 AMI and instance type configuration.

Ref [SDE-2273](https://issues.redhat.com//browse/SDE-2273) and [OSD-14721](https://issues.redhat.com/browse/OSD-14721)
