### PR TITLE
[OSD-13554-revert] Revert 05b09adce99468717714eeed1a8ebe650b4a74d3

### DIFF
--- a/api/v1alpha1/account_types.go
+++ b/api/v1alpha1/account_types.go
@@ -84,7 +84,6 @@ type AccountStatus struct {
 	Claimed       bool   `json:"claimed,omitempty"`
 	SupportCaseID string `json:"supportCaseID,omitempty"`
 	// +optional
-        // +listType=map
 	Conditions               []AccountCondition    `json:"conditions,omitempty"`
 	State                    string                `json:"state,omitempty"`
 	RotateCredentials        bool                  `json:"rotateCredentials,omitempty"`

--- a/api/v1alpha1/zz_generated.openapi.go
+++ b/api/v1alpha1/zz_generated.openapi.go
@@ -857,11 +857,6 @@ func schema_openshift_aws_account_operator_api_v1alpha1_AccountStatus(ref common
 						},
 					},
 					"conditions": {
-						VendorExtensible: spec.VendorExtensible{
-							Extensions: spec.Extensions{
-								"x-kubernetes-list-type": "map",
-							},
-						},
 						SchemaProps: spec.SchemaProps{
 							Type: []string{"array"},
 							Items: &spec.SchemaOrArray{

--- a/controllers/account/account_controller.go
+++ b/controllers/account/account_controller.go
@@ -1042,7 +1042,6 @@ func CreateAccount(reqLogger logr.Logger, client awsclient.Client, accountName, 
 
 	createOutput, err := client.CreateAccount(&createInput)
 	if err != nil {
-		errMsg := "Error creating account"
 		var returnErr error
 		if aerr, ok := err.(awserr.Error); ok {
 			switch aerr.Code() {
@@ -1054,10 +1053,10 @@ func CreateAccount(reqLogger logr.Logger, client awsclient.Client, accountName, 
 				returnErr = awsv1alpha1.ErrAwsTooManyRequests
 			default:
 				returnErr = awsv1alpha1.ErrAwsFailedCreateAccount
+				utils.LogAwsError(reqLogger, "New AWS Error during account creation", returnErr, err)
 			}
 
 		}
-		utils.LogAwsError(reqLogger, errMsg, returnErr, err)
 		return &organizations.DescribeCreateAccountStatusOutput{}, returnErr
 	}
 

--- a/controllers/account/account_controller_test.go
+++ b/controllers/account/account_controller_test.go
@@ -1269,16 +1269,15 @@ func TestFinalizeAccount_LabelledBYOCAccount(t *testing.T) {
 
 var _ = Describe("Account Controller", func() {
 	var (
-		nullTestLogger testutils.TestLogger
-		nullLogger     logr.Logger
-		mockAWSClient  *mock.MockClient
-		accountName    string
-		accountEmail   string
-		ctrl           *gomock.Controller
-		account        *awsv1alpha1.Account
-		configMap      *v1.ConfigMap
-		r              *AccountReconciler
-		req            reconcile.Request
+		nullLogger    logr.Logger
+		mockAWSClient *mock.MockClient
+		accountName   string
+		accountEmail  string
+		ctrl          *gomock.Controller
+		account       *awsv1alpha1.Account
+		configMap     *v1.ConfigMap
+		r             *AccountReconciler
+		req           reconcile.Request
 	)
 
 	err := apis.AddToScheme(scheme.Scheme)
@@ -1290,8 +1289,7 @@ var _ = Describe("Account Controller", func() {
 		ctrl = gomock.NewController(GinkgoT())
 		accountName = TestAccountName
 		accountEmail = TestAccountEmail
-		nullTestLogger = testutils.NewTestLogger()
-		nullLogger = nullTestLogger.Logger()
+		nullLogger = testutils.NewTestLogger().Logger()
 		mockAWSClient = mock.NewMockClient(ctrl)
 		configMap = &v1.ConfigMap{
 			TypeMeta: metav1.TypeMeta{},
@@ -1327,7 +1325,6 @@ var _ = Describe("Account Controller", func() {
 			Expect(err).To(HaveOccurred())
 			Expect(createAccountOutput).To(Equal(&organizations.DescribeCreateAccountStatusOutput{}))
 			Expect(awsv1alpha1.ErrAwsAccountLimitExceeded).To(Equal(err))
-			Expect(nullTestLogger.Messages()).Should(ContainElement(ContainSubstring(organizations.ErrCodeConstraintViolationException)))
 		})
 
 		It("AWS returns ErrCodeServiceException from CreateAccount", func() {
@@ -1337,7 +1334,6 @@ var _ = Describe("Account Controller", func() {
 			Expect(err).To(HaveOccurred())
 			Expect(createAccountOutput).To(Equal(&organizations.DescribeCreateAccountStatusOutput{}))
 			Expect(awsv1alpha1.ErrAwsInternalFailure).To(Equal(err))
-			Expect(nullTestLogger.Messages()).Should(ContainElement(ContainSubstring(organizations.ErrCodeServiceException)))
 		})
 
 		It("AWS returns ErrCodeTooManyRequestsException from CreateAccount", func() {
@@ -1347,7 +1343,6 @@ var _ = Describe("Account Controller", func() {
 			Expect(err).To(HaveOccurred())
 			Expect(createAccountOutput).To(Equal(&organizations.DescribeCreateAccountStatusOutput{}))
 			Expect(awsv1alpha1.ErrAwsTooManyRequests).To(Equal(err))
-			Expect(nullTestLogger.Messages()).Should(ContainElement(ContainSubstring(organizations.ErrCodeTooManyRequestsException)))
 		})
 
 		It("AWS returns error from CreateAccount", func() {
@@ -1357,7 +1352,6 @@ var _ = Describe("Account Controller", func() {
 			Expect(err).To(HaveOccurred())
 			Expect(createAccountOutput).To(Equal(&organizations.DescribeCreateAccountStatusOutput{}))
 			Expect(awsv1alpha1.ErrAwsFailedCreateAccount).To(Equal(err))
-			Expect(nullTestLogger.Messages()).Should(ContainElement(ContainSubstring(organizations.ErrCodeDuplicateAccountException)))
 		})
 
 		It("AWS returns an error from DescribeCreateAccountStatus", func() {

--- a/deploy/crds/aws.managed.openshift.io_accounts.yaml
+++ b/deploy/crds/aws.managed.openshift.io_accounts.yaml
@@ -131,7 +131,6 @@ spec:
                       type: string
                   type: object
                 type: array
-                x-kubernetes-list-type: map
               regionalServiceQuotas:
                 additionalProperties:
                   additionalProperties:


### PR DESCRIPTION
reverts
"[OSD-17712] Add more logging for Account Creation Failure (#775)"

This reverts commit 05b09adce99468717714eeed1a8ebe650b4a74d3.

# What is being added?

deployment started to fail due to
```
spec.validation.openAPIV3Schema.properties[status].properties[conditions].x-kubernetes-list-map-keys:                                                                                                                                                                                                                                                    
      Required value: must not be empty if x-kubernetes-list-type is map' 
```
