### PR TITLE
[OSD-19093] Don't run account claim cleanup when there are additional finalizers

### DIFF
--- a/controllers/accountclaim/accountclaim_controller.go
+++ b/controllers/accountclaim/accountclaim_controller.go
@@ -246,6 +246,13 @@ func (r *AccountClaimReconciler) handleAccountClaimDeletion(reqLogger logr.Logge
 		return nil
 	}
 
+  // Workaround for FleetManagers special account handling, see
+  // https://issues.redhat.com/browse/OSD-19093
+  if len(accountClaim.GetFinalizers()) > 1 {
+    reqLogger.Info("Found additional finalizers on AccountClaim. Not attempting cleanup.")
+    return nil
+  }
+
 	// Only do AWS cleanup and account reset if accountLink is not empty
 	// We will not attempt AWS cleanup if the account is BYOC since we're not going to reuse these accounts
 	if accountClaim.Spec.AccountLink != "" {

--- a/controllers/accountclaim/accountclaim_controller_test.go
+++ b/controllers/accountclaim/accountclaim_controller_test.go
@@ -245,6 +245,21 @@ var _ = Describe("AccountClaim", func() {
 				Expect(err).NotTo(HaveOccurred())
 				Expect(ac.Finalizers).To(Equal(accountClaim.GetFinalizers()))
 			})
+
+      It("should do nothing when there are additional finalizers present", func() {
+				accountClaim.SetFinalizers(append(accountClaim.GetFinalizers(), "another.blocking.finalizer"))
+				r.Client = fake.NewClientBuilder().WithScheme(scheme.Scheme).WithRuntimeObjects(objs...).Build()
+				_, err := r.Reconcile(context.TODO(), req)
+
+				Expect(err).NotTo(HaveOccurred())
+
+        // validate that all finalizers are still there
+				ac := awsv1alpha1.AccountClaim{}
+				err = r.Client.Get(context.TODO(), types.NamespacedName{Name: name, Namespace: namespace}, &ac)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(ac.Finalizers).To(Equal(accountClaim.GetFinalizers()))
+         
+      })
 		})
 
 		When("Accountclaim is BYOC", func() {


### PR DESCRIPTION
# What is being added?
Add a check to the account cr deletion step to ensure that we only run the account cleanup when there are no additional finalizers present on the accountclaim.

## Checklist before requesting review

- [X] I have tested this locally
- [X] I have included unit tests
- [X] I have updated any corresponding documentation

Ref [OSD-19093](https://issues.redhat.com//browse/OSD-19093)
