### PR TITLE
OSD-14200 Add Max Concurrent Reconcile limit

### DIFF
--- a/controllers/validation/accountpool_validation_controller.go
+++ b/controllers/validation/accountpool_validation_controller.go
@@ -26,6 +26,10 @@ var (
 	logs              = logf.Log.WithName("controller_accountpoolvalidation")
 )
 
+const (
+	validationControllerName = "accountpoolvalidation"
+)
+
 type AccountPoolValidationReconciler struct {
 	Client           client.Client
 	Scheme           *runtime.Scheme
@@ -33,7 +37,7 @@ type AccountPoolValidationReconciler struct {
 }
 
 func (r *AccountPoolValidationReconciler) Reconcile(ctx context.Context, request ctrl.Request) (ctrl.Result, error) {
-	reqLogger := logs.WithValues("Controller", "accountpoolvalidation", "Request.Namespace", request.Namespace, "Request.Name", request.Name)
+	reqLogger := logs.WithValues("Controller", validationControllerName, "Request.Namespace", request.Namespace, "Request.Name", request.Name)
 
 	// Fetch the AccountPool instance
 	reqLogger.Info("Fetching accountpool")
@@ -179,12 +183,12 @@ func (r *AccountPoolValidationReconciler) checkAccountServiceQuota(reqLogger log
 
 func (r *AccountPoolValidationReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	r.awsClientBuilder = &awsclient.Builder{}
-	maxReconciles, err := utils.GetControllerMaxReconciles("accountpoolvalidation")
+	maxReconciles, err := utils.GetControllerMaxReconciles(validationControllerName)
 	if err != nil {
-		logs.Error(err, "missing max reconciles for controller", "controller", "accountpoolvalidation")
+		logs.Error(err, "missing max reconciles for controller", "controller", validationControllerName)
 	}
 
-	rwm := utils.NewReconcilerWithMetrics(r, "accountpoolvalidation")
+	rwm := utils.NewReconcilerWithMetrics(r, validationControllerName)
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&awsv1alpha1.AccountPool{}).
 		WithOptions(controller.Options{

--- a/controllers/validation/accountpool_validation_controller.go
+++ b/controllers/validation/accountpool_validation_controller.go
@@ -26,10 +26,6 @@ var (
 	logs              = logf.Log.WithName("controller_accountpoolvalidation")
 )
 
-const (
-	ControllerName = "accountpoolvalidation"
-)
-
 type AccountPoolValidationReconciler struct {
 	Client           client.Client
 	Scheme           *runtime.Scheme
@@ -37,7 +33,7 @@ type AccountPoolValidationReconciler struct {
 }
 
 func (r *AccountPoolValidationReconciler) Reconcile(ctx context.Context, request ctrl.Request) (ctrl.Result, error) {
-	reqLogger := logs.WithValues("Controller", ControllerName, "Request.Namespace", request.Namespace, "Request.Name", request.Name)
+	reqLogger := logs.WithValues("Controller", "accountpoolvalidation", "Request.Namespace", request.Namespace, "Request.Name", request.Name)
 
 	// Fetch the AccountPool instance
 	reqLogger.Info("Fetching accountpool")
@@ -183,9 +179,9 @@ func (r *AccountPoolValidationReconciler) checkAccountServiceQuota(reqLogger log
 
 func (r *AccountPoolValidationReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	r.awsClientBuilder = &awsclient.Builder{}
-	maxReconciles, err := utils.GetControllerMaxReconciles(controllerName)
+	maxReconciles, err := utils.GetControllerMaxReconciles("accountpoolvalidation")
 	if err != nil {
-		logs.Error(err, "missing max reconciles for controller", "controller", controllerName)
+		logs.Error(err, "missing max reconciles for controller", "controller", "accountpoolvalidation")
 	}
 
 	rwm := utils.NewReconcilerWithMetrics(r, "accountpoolvalidation")

--- a/hack/olm-registry/olm-artifacts-template.yaml
+++ b/hack/olm-registry/olm-artifacts-template.yaml
@@ -32,6 +32,10 @@ parameters:
   required: false
 - name: MAXCONCURRENTRECONCILES_ACCOUNT
   value: "1"
+- name: MAXCONCURRENTRECONCILES_ACCOUNTVALIDATION
+  value: "1"
+- name: MAXCONCURRENTRECONCILES_ACCOUNTPOOLVALIDATION
+  value: "1"
 - name: MAXCONCURRENTRECONCILES_ACCOUNTCLAIM
   value: "1"
 - name: MAXCONCURRENTRECONCILES_ACCOUNTPOOL
@@ -102,6 +106,8 @@ objects:
     aws-managed-tags: "${AWS_MANAGED_TAGS}"
     accountpool: "${ACCOUNT_POOL_CONFIG}"
     MaxConcurrentReconciles.account: "${MAXCONCURRENTRECONCILES_ACCOUNT}"
+    MaxConcurrentReconciles.accountvalidation: "${MAXCONCURRENTRECONCILES_ACCOUNTVALIDATION}"
+    MaxConcurrentReconciles.accountpoolvalidation: "${MAXCONCURRENTRECONCILES_ACCOUNTPOOLVALIDATION}"
     MaxConcurrentReconciles.accountclaim: "${MAXCONCURRENTRECONCILES_ACCOUNTCLAIM}"
     MaxConcurrentReconciles.accountpool: "${MAXCONCURRENTRECONCILES_ACCOUNTPOOL}"
     MaxConcurrentReconciles.awsfederatedaccountaccess: "${MAXCONCURRENTRECONCILES_AWSFEDERATEDACCOUNTACCESS}"

--- a/hack/templates/aws.managed.openshift.io_v1alpha1_configmap.tmpl
+++ b/hack/templates/aws.managed.openshift.io_v1alpha1_configmap.tmpl
@@ -24,6 +24,7 @@ objects:
     account-limit: ${ACCOUNT_LIMIT}
     MaxConcurrentReconciles.account: "2"
     MaxConcurrentReconciles.accountvalidation: "2"
+    MaxConcurrentReconciles.accountpoolvalidation: "1"
     MaxConcurrentReconciles.accountclaim: "1"
     MaxConcurrentReconciles.accountpool: "1"
     MaxConcurrentReconciles.awsfederatedaccountaccess: "1"

--- a/pkg/utils/clientwrapper.go
+++ b/pkg/utils/clientwrapper.go
@@ -23,6 +23,7 @@ func InitControllerMaxReconciles(kubeClient client.Client) []error {
 		"account",
 		"accountclaim",
 		"accountpool",
+		"accountpoolvalidation",
 		"accountvalidation",
 		"awsfederatedaccountaccess",
 		"awsfederatedrole",


### PR DESCRIPTION
# What is being added?
Adds Max Concurrent Reconcile limit field in the configmap for the accountpool validation controller

## Checklist before requesting review
- [x] I have tested this locally
- [ ] I have included unit tests
- [ ] I have updated any corresponding documentation

Ref [OSD-14200](https://issues.redhat.com//browse/OSD-14200)
