### PR TITLE
[OSD-19300] update account cleanup

### DIFF
--- a/controllers/accountclaim/accountclaim_controller.go
+++ b/controllers/accountclaim/accountclaim_controller.go
@@ -44,7 +44,7 @@ const (
 	waitPeriod              = 30
 	controllerName          = "accountclaim"
 	fakeAnnotation          = "managed.openshift.com/fake"
-	awsSTSSecret            = "aws-sts"
+	awsSTSSecret            = "sts-secret"
 	stsRoleName             = "managed-sts-role"
 	stsPolicyName           = "AAO-CustomPolicy"
 )
@@ -476,8 +476,15 @@ func newStsSecretforCR(secretName string, secretNameSpace string, arn []byte) *c
 // CreateOrUpdateSecret creates a secret in AWS Secrets Manager or updates it if it already exists.
 func (r *AccountClaimReconciler) createIAMRoleSecret(reqLogger logr.Logger, accountClaim *awsv1alpha1.AccountClaim, roleARN string) error {
 	var OCMSecretNamespace string
+	var OCMSecretName string
 
-	OCMSecretName := awsSTSSecret
+	if accountClaim.Spec.AwsCredentialSecret.Name == "" {
+		OCMSecretName = accountClaim.ObjectMeta.Name + "-" + awsSTSSecret
+
+	} else {
+		OCMSecretName = accountClaim.Spec.AwsCredentialSecret.Name
+	}
+
 	if accountClaim.Spec.AwsCredentialSecret.Namespace == "" {
 		OCMSecretNamespace = accountClaim.ObjectMeta.Namespace
 

--- a/controllers/accountclaim/accountclaim_controller_test.go
+++ b/controllers/accountclaim/accountclaim_controller_test.go
@@ -109,10 +109,16 @@ var _ = Describe("AccountClaim", func() {
 		Context("AccountClaim is marked for Deletion", func() {
 
 			var (
-				objs []runtime.Object
+				objs              []runtime.Object
+				orgAccessRoleName string
+				roleSessionName   string
+				orgAccessArn      string
 			)
 
 			BeforeEach(func() {
+				orgAccessRoleName = "OrganizationAccountAccessRole"
+				roleSessionName = "awsAccountOperator"
+				orgAccessArn = "arn:aws:iam:::role/OrganizationAccountAccessRole"
 				accountClaim.DeletionTimestamp = &metav1.Time{Time: time.Now()}
 				accountClaim.SetFinalizers(append(accountClaim.GetFinalizers(), accountClaimFinalizer))
 
@@ -154,6 +160,22 @@ var _ = Describe("AccountClaim", func() {
 					Volumes: []*ec2.Volume{},
 				}
 
+				mockAWSClient.EXPECT().AssumeRole(&sts.AssumeRoleInput{
+					DurationSeconds: aws.Int64(3600),
+					RoleArn:         &orgAccessArn,
+					RoleSessionName: &roleSessionName,
+				}).Return(&sts.AssumeRoleOutput{
+					AssumedRoleUser: &sts.AssumedRoleUser{
+						Arn:           aws.String(fmt.Sprintf("aws:::%s/%s", orgAccessRoleName, roleSessionName)),
+						AssumedRoleId: aws.String(fmt.Sprintf("%s/%s", orgAccessRoleName, roleSessionName)),
+					},
+					Credentials: &sts.Credentials{
+						AccessKeyId:     aws.String("ACCESS_KEY"),
+						SecretAccessKey: aws.String("SECRET_KEY"),
+						SessionToken:    aws.String("SESSION_TOKEN"),
+					},
+					PackedPolicySize: aws.Int64(40),
+				}, nil)
 				mockAWSClient.EXPECT().ListHostedZones(gomock.Any()).Return(lhzo, nil)
 				mockAWSClient.EXPECT().ListBuckets(gomock.Any()).Return(lbo, nil)
 				mockAWSClient.EXPECT().DescribeVpcEndpointServiceConfigurations(gomock.Any()).Return(dvpcesco, nil)
@@ -207,6 +229,22 @@ var _ = Describe("AccountClaim", func() {
 					Volumes: []*ec2.Volume{},
 				}
 
+				mockAWSClient.EXPECT().AssumeRole(&sts.AssumeRoleInput{
+					DurationSeconds: aws.Int64(3600),
+					RoleArn:         &orgAccessArn,
+					RoleSessionName: &roleSessionName,
+				}).Return(&sts.AssumeRoleOutput{
+					AssumedRoleUser: &sts.AssumedRoleUser{
+						Arn:           aws.String(fmt.Sprintf("aws:::%s/%s", orgAccessRoleName, roleSessionName)),
+						AssumedRoleId: aws.String(fmt.Sprintf("%s/%s", orgAccessRoleName, roleSessionName)),
+					},
+					Credentials: &sts.Credentials{
+						AccessKeyId:     aws.String("ACCESS_KEY"),
+						SecretAccessKey: aws.String("SECRET_KEY"),
+						SessionToken:    aws.String("SESSION_TOKEN"),
+					},
+					PackedPolicySize: aws.Int64(40),
+				}, nil)
 				mockAWSClient.EXPECT().ListHostedZones(gomock.Any()).Return(lhzo, nil)
 				mockAWSClient.EXPECT().ListBuckets(gomock.Any()).Return(lbo, nil)
 				mockAWSClient.EXPECT().DescribeVpcEndpointServiceConfigurations(gomock.Any()).Return(dvpcesco, nil)
@@ -231,6 +269,22 @@ var _ = Describe("AccountClaim", func() {
 				mockAWSClient := mock.GetMockClient(r.awsClientBuilder)
 				// Use a bogus error, just so we can fail AWS calls.
 				theErr := awserr.NewBatchError("foo", "bar", []error{})
+				mockAWSClient.EXPECT().AssumeRole(&sts.AssumeRoleInput{
+					DurationSeconds: aws.Int64(3600),
+					RoleArn:         &orgAccessArn,
+					RoleSessionName: &roleSessionName,
+				}).Return(&sts.AssumeRoleOutput{
+					AssumedRoleUser: &sts.AssumedRoleUser{
+						Arn:           aws.String(fmt.Sprintf("aws:::%s/%s", orgAccessRoleName, roleSessionName)),
+						AssumedRoleId: aws.String(fmt.Sprintf("%s/%s", orgAccessRoleName, roleSessionName)),
+					},
+					Credentials: &sts.Credentials{
+						AccessKeyId:     aws.String("ACCESS_KEY"),
+						SecretAccessKey: aws.String("SECRET_KEY"),
+						SessionToken:    aws.String("SESSION_TOKEN"),
+					},
+					PackedPolicySize: aws.Int64(40),
+				}, nil)
 				mockAWSClient.EXPECT().ListHostedZones(gomock.Any()).Return(nil, theErr)
 				mockAWSClient.EXPECT().ListBuckets(gomock.Any()).Return(nil, theErr)
 				mockAWSClient.EXPECT().DescribeVpcEndpointServiceConfigurations(gomock.Any()).Return(nil, theErr)

--- a/controllers/accountclaim/reuse.go
+++ b/controllers/accountclaim/reuse.go
@@ -62,24 +62,44 @@ func (r *AccountClaimReconciler) finalizeAccountClaim(reqLogger logr.Logger, acc
 	}
 
 	var awsClient awsclient.Client
-	awsRegion := config.GetDefaultRegion()
-	// We expect this secret to exist in the same namespace Account CR's are created
-	awsSetupClient, err := r.awsClientBuilder.GetClient(controllerName, r.Client, awsclient.NewAwsClientInput{
-		SecretName: utils.AwsSecretName,
-		NameSpace:  awsv1alpha1.AccountCrNamespace,
-		AwsRegion:  awsRegion,
-	})
+	var awsClientInput awsclient.NewAwsClientInput
 
-	if err != nil {
-		reqLogger.Error(err, "failed building operator AWS client")
-		return err
-	}
+	clusterAwsRegion := accountClaim.Spec.Aws.Regions[0].Name
+	if reusedAccount.IsBYOC() {
+		// AWS credential comes from accountclaim object osdCcsAdmin user
+		// We must use this user as we would other delete the osdManagedAdmin
+		// user that we're going to delete
+		// TODO: We should use the role here
+		awsClientInput = awsclient.NewAwsClientInput{
+			SecretName: accountClaim.Spec.BYOCSecretRef.Name,
+			NameSpace:  accountClaim.Namespace,
+			AwsRegion:  clusterAwsRegion,
+		}
+		awsClient, err = r.awsClientBuilder.GetClient(controllerName, r.Client, awsClientInput)
+		if err != nil {
+			connErr := fmt.Sprintf("Unable to create aws client for region %s", clusterAwsRegion)
+			reqLogger.Error(err, connErr)
+			return err
+		}
+	} else {
+		awsRegion := config.GetDefaultRegion()
+		// We expect this secret to exist in the same namespace Account CR's are created
+		awsSetupClient, err := r.awsClientBuilder.GetClient(controllerName, r.Client, awsclient.NewAwsClientInput{
+			SecretName: utils.AwsSecretName,
+			NameSpace:  awsv1alpha1.AccountCrNamespace,
+			AwsRegion:  awsRegion,
+		})
+		if err != nil {
+			reqLogger.Error(err, "failed building operator AWS client")
+			return err
+		}
 
-	awsClient, _, err = stsclient.HandleRoleAssumption(reqLogger, r.awsClientBuilder, reusedAccount, r.Client, awsSetupClient, "", awsv1alpha1.AccountOperatorIAMRole, "")
-	if err != nil {
-		connErr := fmt.Sprintf("Unable to create aws client for region %s", awsRegion)
-		reqLogger.Error(err, connErr)
-		return err
+		awsClient, _, err = stsclient.HandleRoleAssumption(reqLogger, r.awsClientBuilder, reusedAccount, r.Client, awsSetupClient, "", awsv1alpha1.AccountOperatorIAMRole, "")
+		if err != nil {
+			connErr := fmt.Sprintf("Unable to create aws client for region %s", awsRegion)
+			reqLogger.Error(err, connErr)
+			return err
+		}
 	}
 
 	if reusedAccount.IsBYOC() {


### PR DESCRIPTION
# What is being added?
_Is this a fix for a bug?  What's the bug?  Is this a new feature? Please describe it. Is this just a small typo fix?  That's fine too!_
Update the account cleanup process to use OrgAccessRole instead of static creds. 


## Checklist before requesting review

- [x] I have tested this locally
- [x] I have included unit tests
- [ ] I have updated any corresponding documentation


Ref [OSD-19300](https://issues.redhat.com//browse/OSD-19300)
