### PR TITLE
[OSD-19874] Add a new validation check to delete accounts.

### DIFF
--- a/hack/olm-registry/olm-artifacts-template.yaml
+++ b/hack/olm-registry/olm-artifacts-template.yaml
@@ -53,6 +53,9 @@ parameters:
 - name: FEATURE_VALIDATE_TAG_ACCOUNT
   required: false
   value: "false"
+- name: FEATURE_VALIDATE_DELETE_ACCOUNT
+  required: false
+  value: "false"
 - name: FEATURE_ACCOUNTPOOL_VALIDATION
   required: false
   value: "false"
@@ -119,6 +122,7 @@ objects:
     fedramp: "${FEDRAMP}"
     feature.validation_move_account: ${FEATURE_VALIDATE_MOVE_ACCOUNT}
     feature.validation_tag_account: ${FEATURE_VALIDATE_TAG_ACCOUNT}
+    feature.validation_delete_account: ${FEATURE_VALIDATE_DELETE_ACCOUNT}
     feature.accountpool_validation: ${FEATURE_ACCOUNTPOOL_VALIDATION}
     feature.accountclaim_fleet_manager_trusted_arn: ${FEATURE_ACCOUNTCLAIM_FLEET_MANAGER_TRUSTED_ARN}
 

--- a/hack/templates/aws.managed.openshift.io_v1alpha1_configmap.tmpl
+++ b/hack/templates/aws.managed.openshift.io_v1alpha1_configmap.tmpl
@@ -34,6 +34,7 @@ objects:
     support-jump-role: ${SUPPORT_JUMP_ROLE}
     feature.validation_move_account: "false"
     feature.validation_tag_account: "false"
+    feature.validation_delete_account: "false"
     feature.accountpool_validation: "false"
     feature.accountclaim_fleet_manager_trusted_arn: "false"
     shard-name: local


### PR DESCRIPTION
This check - in contrast to all other checks - will only run for Failed accounts that have no AWSAccountId. If this is the case and the feature is enabled the account CR will be deleted.

# What is being added?

This is a partial fix, as we are seeing a lot of Failed account without AWS account associated.
This makes it look like a lot of accounts are not being reused, while those are just not usable at all.

## Checklist before requesting review

- [X] I have tested this locally
- [X] I have included unit tests
- [ ] I have updated any corresponding documentation

## Steps To Manually Test
_Please provide us steps to reproduce the scenarios needed to test this.  If an integration test is provided, let us know how to run it. If not, enumerate the steps to validate this does what it's supposed to._
1. Start the operator
1. Run the thing
1. Observe X in the spec for the thing
1. Clean up the thing

Ref [OSD-19874](https://issues.redhat.com//browse/OSD-19874)

I tested this locally by forcing an account into a Failed state without AWS account:

```
1.7043782369086888e+09  INFO    controller_accountvalidation    Not cleaning up account that is failed & has no AWS account (dry run)   {"account": "osd-creds-mgmt-7ck79t"}
```

So we could deploy this to see what it would clean up in staging and then decide if we toggle the feature flag on.
