### PR TITLE
[OSD-19873] Don't fail an account for a ConcurrentModificationException

### DIFF
--- a/api/v1alpha1/shared_types.go
+++ b/api/v1alpha1/shared_types.go
@@ -23,6 +23,9 @@ var ErrAwsInternalFailure = errors.New("InternalFailure")
 // ErrAwsFailedCreateAccount indicates that an account creation failed
 var ErrAwsFailedCreateAccount = errors.New("FailedCreateAccount")
 
+// ErrAwsConcurrentModification indicates that a resource is currently being modified and the request should be retried
+var ErrAwsConcurrentModification = errors.New("ConcurrentModificationOfOU")
+
 // ErrAwsTooManyRequests indicates that to many requests were sent in a short period
 var ErrAwsTooManyRequests = errors.New("TooManyRequestsException")
 

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -10,7 +10,7 @@ WORKDIR ${OPERATOR_PATH}
 
 RUN make go-build FIPS_ENABLED=${FIPS_ENABLED}
 
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.9-1029
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.9-1108
 ENV OPERATOR_BIN=aws-account-operator
 
 WORKDIR /root/

--- a/build/Dockerfile.olm-registry
+++ b/build/Dockerfile.olm-registry
@@ -4,7 +4,7 @@ COPY ${SAAS_OPERATOR_DIR} manifests
 RUN initializer --permissive
 
 # ubi-micro does not work for clusters with fips enabled unless we make OpenSSL available
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.9-1029
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.9-1108
 
 COPY --from=builder /bin/registry-server /bin/registry-server
 COPY --from=builder /bin/grpc_health_probe /bin/grpc_health_probe

--- a/controllers/account/account_controller.go
+++ b/controllers/account/account_controller.go
@@ -905,7 +905,6 @@ func (r *AccountReconciler) BuildAccount(reqLogger logr.Logger, awsClient awscli
 			log.Error(orgErr, "Failed to create AWS Account nonfatal error")
 			return "", orgErr
 		}
-
 	}
 
 	accountObjectKey := client.ObjectKeyFromObject(account)
@@ -933,8 +932,8 @@ func CreateAccount(reqLogger logr.Logger, client awsclient.Client, accountName, 
 		var returnErr error
 		if aerr, ok := err.(awserr.Error); ok {
 			switch aerr.Code() {
-      case organizations.ErrCodeConcurrentModificationException:
-        returnErr = awsv1alpha1.ErrAwsConcurrentModification 
+			case organizations.ErrCodeConcurrentModificationException:
+				returnErr = awsv1alpha1.ErrAwsConcurrentModification
 			case organizations.ErrCodeConstraintViolationException:
 				returnErr = awsv1alpha1.ErrAwsAccountLimitExceeded
 			case organizations.ErrCodeServiceException:

--- a/controllers/account/account_controller.go
+++ b/controllers/account/account_controller.go
@@ -933,6 +933,8 @@ func CreateAccount(reqLogger logr.Logger, client awsclient.Client, accountName, 
 		var returnErr error
 		if aerr, ok := err.(awserr.Error); ok {
 			switch aerr.Code() {
+      case organizations.ErrCodeConcurrentModificationException:
+        returnErr = awsv1alpha1.ErrAwsConcurrentModification 
 			case organizations.ErrCodeConstraintViolationException:
 				returnErr = awsv1alpha1.ErrAwsAccountLimitExceeded
 			case organizations.ErrCodeServiceException:


### PR DESCRIPTION


# What is being added?
Quite often when an AWS account is created, we get the error message `AWS Organizations can't complete your request because it conflicts with another attempt to modify the same entity. Try again later.` from AWS. When that happens, the account CR status is set to `Failed` and it will never be retried again. This causes a new account CR to be created instead, needlessly bloating our accounts.

This PR makes sure, that this error is actually retryable.

First attempt at figuring out our runaway account creation. I don't think this is the root cause for linked issue, but it still causes our failed account count to inflate needlessly.

## Checklist before requesting review

- [x] I have tested this locally
- [x] I have included unit tests
- [x] I have updated any corresponding documentation

Ref [OSD-19873](https://issues.redhat.com//browse/OSD-19873)
