### PR TITLE
[OSD-20500] Dont fail when pool is missing in configmap

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -10,7 +10,7 @@ WORKDIR ${OPERATOR_PATH}
 
 RUN make go-build FIPS_ENABLED=${FIPS_ENABLED}
 
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.9-1108.1705420507
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.9-1108.1706691034
 ENV OPERATOR_BIN=aws-account-operator
 
 WORKDIR /root/

--- a/build/Dockerfile.olm-registry
+++ b/build/Dockerfile.olm-registry
@@ -4,7 +4,7 @@ COPY ${SAAS_OPERATOR_DIR} manifests
 RUN initializer --permissive
 
 # ubi-micro does not work for clusters with fips enabled unless we make OpenSSL available
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.9-1108.1705420507
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.9-1108.1706691034
 
 COPY --from=builder /bin/registry-server /bin/registry-server
 COPY --from=builder /bin/grpc_health_probe /bin/grpc_health_probe

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -145,8 +145,8 @@ func GetServiceQuotasFromAccountPool(reqLogger logr.Logger, accountPoolName stri
 	var parsedRegionalServiceQuotas = make(awsv1alpha1.RegionalServiceQuotas)
 
 	if poolData, ok := data[accountPoolName]; !ok {
-		reqLogger.Error(fixtures.NotFound, "Accountpool not found")
-		return nil, fixtures.NotFound
+    reqLogger.Info("Accountpool not found in configmap. Not setting servicequotas.")
+		return parsedRegionalServiceQuotas, nil
 	} else {
 		// for each service quota in a given region, we'll need to parse and save to use in the account spec.
 		for regionName, serviceQuotas := range poolData.RegionedServicequotas {

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -145,7 +145,7 @@ func GetServiceQuotasFromAccountPool(reqLogger logr.Logger, accountPoolName stri
 	var parsedRegionalServiceQuotas = make(awsv1alpha1.RegionalServiceQuotas)
 
 	if poolData, ok := data[accountPoolName]; !ok {
-    reqLogger.Info("Accountpool not found in configmap. Not setting servicequotas.")
+		reqLogger.Info("Accountpool not found in configmap. Not setting servicequotas.")
 		return parsedRegionalServiceQuotas, nil
 	} else {
 		// for each service quota in a given region, we'll need to parse and save to use in the account spec.

--- a/pkg/utils/utils_suite_test.go
+++ b/pkg/utils/utils_suite_test.go
@@ -1,0 +1,13 @@
+package utils
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestAccount(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Utils Suite")
+}

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -450,9 +450,10 @@ fm-accountpool:
       L-69A177A2: '255'
 `
 			client := fake.NewClientBuilder().WithScheme(scheme.Scheme).WithRuntimeObjects([]runtime.Object{configMap}...).Build()
-			quotas, err := GetServiceQuotasFromAccountPool(nullLogger, "nonexisting", client)
-			Expect(err).ToNot(BeNil())
-			Expect(quotas).To(BeEmpty())
+			quotas, err := GetServiceQuotasFromAccountPool(nullLogger, "fm-accountpool", client)
+			Expect(err).To(BeNil())
+			Expect(quotas).ToNot(BeEmpty())
+      Expect(quotas).To(HaveKey("default"))
 		})
 	})
 

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -453,7 +453,7 @@ fm-accountpool:
 			quotas, err := GetServiceQuotasFromAccountPool(nullLogger, "fm-accountpool", client)
 			Expect(err).To(BeNil())
 			Expect(quotas).ToNot(BeEmpty())
-      Expect(quotas).To(HaveKey("default"))
+			Expect(quotas).To(HaveKey("default"))
 		})
 	})
 


### PR DESCRIPTION
# What is being added?
- Change the way missing accountpool keys in the configmap are treated
- Now, missing accountpools will be treated like their config section was emtpy
- This ensures that we don't unneccessarily run into an error condition

## Checklist before requesting review

- [x] I have tested this locally
- [x] I have included unit tests
- [x] I have updated any corresponding documentation

Ref [OSD-20500](https://issues.redhat.com//browse/OSD-20500)
