### PR TITLE
[OSD-19300-update-IAMUser-recreation] update account init statement for reused accounts

### DIFF
--- a/api/v1alpha1/account_types.go
+++ b/api/v1alpha1/account_types.go
@@ -254,18 +254,12 @@ func (a *Account) GetQuotaRequestsByStatus(stati ...ServiceRequestStatus) (int, 
 
 // IsReusedAccountMissingIAMUser returns true if the account is in a ready state and a reused non-byoc account without a IAMUser secret and claimlink
 func (a *Account) IsReusedAccountMissingIAMUser() bool {
-	if a.IsReady() && a.Status.Reused == true && a.Spec.IAMUserSecret == "" && !a.IsBYOC() && !a.HasClaimLink() && !a.IsSTS() {
-		return true
-	}
-	return false
+	return a.IsReady() && a.Status.Reused && a.Spec.IAMUserSecret == "" && !a.IsBYOC() && !a.HasClaimLink() && !a.IsSTS()
 }
 
 // IsReusedAccountWithIAMUserSecret returns true if the account is in a ready state and a reused non-byoc account with IAMUser secret and no claimlink
 func (a *Account) IsReusedAccountWithIAMUserSecret() bool {
-	if a.IsReady() && a.Status.Reused == true && a.Spec.IAMUserSecret != "" && !a.IsBYOC() && !a.HasClaimLink() && !a.IsSTS() {
-		return true
-	}
-	return false
+	return a.IsReady() && a.Status.Reused && a.Spec.IAMUserSecret != "" && !a.IsBYOC() && !a.HasClaimLink() && !a.IsSTS()
 }
 
 // IsPendingVerification returns true if the account is in a PendingVerification state

--- a/api/v1alpha1/account_types.go
+++ b/api/v1alpha1/account_types.go
@@ -260,6 +260,14 @@ func (a *Account) IsReusedAccountMissingIAMUser() bool {
 	return false
 }
 
+// IsReusedAccountWithIAMUserSecret returns true if the account is in a ready state and a reused non-byoc account with IAMUser secret and no claimlink
+func (a *Account) IsReusedAccountWithIAMUserSecret() bool {
+	if a.IsReady() && a.Status.Reused == true && a.Spec.IAMUserSecret != "" && !a.IsBYOC() && !a.HasClaimLink() && !a.IsSTS() {
+		return true
+	}
+	return false
+}
+
 // IsPendingVerification returns true if the account is in a PendingVerification state
 func (a *Account) IsPendingVerification() bool {
 	return a.Status.State == string(AccountPendingVerification)

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -10,7 +10,7 @@ WORKDIR ${OPERATOR_PATH}
 
 RUN make go-build FIPS_ENABLED=${FIPS_ENABLED}
 
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.9-1108
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.9-1108.1705420507
 ENV OPERATOR_BIN=aws-account-operator
 
 WORKDIR /root/

--- a/build/Dockerfile.olm-registry
+++ b/build/Dockerfile.olm-registry
@@ -4,7 +4,7 @@ COPY ${SAAS_OPERATOR_DIR} manifests
 RUN initializer --permissive
 
 # ubi-micro does not work for clusters with fips enabled unless we make OpenSSL available
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.9-1108
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.9-1108.1705420507
 
 COPY --from=builder /bin/registry-server /bin/registry-server
 COPY --from=builder /bin/grpc_health_probe /bin/grpc_health_probe

--- a/controllers/account/account_controller.go
+++ b/controllers/account/account_controller.go
@@ -381,6 +381,11 @@ func (r *AccountReconciler) Reconcile(ctx context.Context, request ctrl.Request)
 			}
 
 			reqLogger.Info("IAM User created and saved", "user", iamUserUHC)
+
+			// Exit account init when the reused account has IAMUserSecret recreated and is in ready state
+			if currentAcctInstance.IsReusedAccountWithIAMUserSecret() {
+				return reconcile.Result{}, err
+			}
 		}
 
 		err = r.initializeRegions(reqLogger, currentAcctInstance, creds, amiOwner)


### PR DESCRIPTION
# What is being added?
An if statement is being added to the account controller to prevent reused accounts that only need their IAM user and secret recreated from going through the entire account initialization process.

## Checklist before requesting review

- [x] I have tested this locally
- [ ] I have included unit tests
- [ ] I have updated any corresponding documentation

## Steps To Manually Test
Start the operator
Run "make predeploy"
Run "make create-account"
Set account.Spec.accountPool to "hs-zero-size-accountpool"
Run "make create-accountclaim-namespace"
Run "make create-fleet-accountclaim"
Observe that the IAMuser and secret is deleted
Run "make delete-fleet-accountclaim"
Observe that the IAMuser and secret is created
Run "create-accountclaim"
Observe that the account created in step 3 is claimed

Ref [OSD-19300](https://issues.redhat.com//browse/OSD-19300)