### PR TITLE
[OSD-19300-update-IAMUser-recreation] Add function to handle IAM user and secret recreation for accounts that are reused, non-BYOC, and in a ready state

### DIFF
--- a/api/v1alpha1/account_types.go
+++ b/api/v1alpha1/account_types.go
@@ -257,11 +257,6 @@ func (a *Account) IsReusedAccountMissingIAMUser() bool {
 	return a.IsReady() && a.Status.Reused && a.Spec.IAMUserSecret == "" && !a.IsBYOC() && !a.HasClaimLink() && !a.IsSTS()
 }
 
-// IsReusedAccountWithIAMUserSecret returns true if the account is in a ready state and a reused non-byoc account with IAMUser secret and no claimlink
-func (a *Account) IsReusedAccountWithIAMUserSecret() bool {
-	return a.IsReady() && a.Status.Reused && a.Spec.IAMUserSecret != "" && !a.IsBYOC() && !a.HasClaimLink() && !a.IsSTS()
-}
-
 // IsPendingVerification returns true if the account is in a PendingVerification state
 func (a *Account) IsPendingVerification() bool {
 	return a.Status.State == string(AccountPendingVerification)


### PR DESCRIPTION

# What is being added?
This PR addresses an issue where, upon deleting a Fleet Manager account claim, the associated AWS account loses long-lived IAM credentials. Subsequently, the re-initialization process fails with the error: "Initializing regions for longer than 3060 seconds." Investigation revealed that the problem stems from accounts that have previously undergone the initialization process not updating the "lastTransitionTime" in the Status.Conditions field. Consequently, during the timeout check, the "lastTransitionTime" from the account's initial creation is used, causing failures for accounts older than 51 minutes.

To resolve this, a separate function has been introduced to handle the recreation of IAM users and secrets exclusively for  accounts in a ready state. This is specifically designed for reused, non-BYOC accounts without IAM user and secret and no claim link, eliminating the need for re-initialization. 


## Checklist before requesting review

- [X] I have tested this locally
- [X] I have included unit tests
- [X] I have updated any corresponding documentation

## Steps To Manually Test

1. Start the operator
2. Run "make predeploy"
3. Run "make create-account"
4. Set account.Spec.accountPool to "hs-zero-size-accountpool"
5. Run "make create-accountclaim-namespace"
6. Run "make create-fleet-accountclaim"
7. Observe that the IAMuser and secret is deleted
8. Run "make delete-fleet-accountclaim"
9. Observe that the IAMuser and secret is created
10. Run "create-accountclaim"
11. Observe that the account created in step 3 is claimed

Ref OSD-19300
