### PR TITLE
[OSD-21097-handle-permissions-errors] Handle Misconfigured Role Permissions

### DIFF
--- a/api/v1alpha1/account_types.go
+++ b/api/v1alpha1/account_types.go
@@ -95,6 +95,7 @@ const (
 	OptInRequestTodo     OptInRequestStatus = "TODO"
 	OptInRequestEnabling OptInRequestStatus = "ENABLING"
 	OptInRequestEnabled  OptInRequestStatus = "ENABLED"
+	OptInRequestUnknown  OptInRequestStatus = "MANUAL_ACTION"
 )
 
 type SupportedOptInRegions string
@@ -242,7 +243,7 @@ func (a *Account) HasSupportCaseID() bool {
 // HasOpenOptInRegionRequests returns true if an account has any supported regions have not been enabled
 func (a *Account) HasOpenOptInRegionRequests() bool {
 	for _, region := range a.Status.OptInRegions {
-		if region.Status != OptInRequestEnabled {
+		if region.Status != OptInRequestEnabled && region.Status != OptInRequestUnknown {
 			return true
 		}
 	}

--- a/controllers/account/account_controller.go
+++ b/controllers/account/account_controller.go
@@ -435,7 +435,7 @@ func (r *AccountReconciler) Reconcile(ctx context.Context, request ctrl.Request)
 }
 
 func (r *AccountReconciler) handleOptInRegionEnablement(reqLogger logr.Logger, currentAcctInstance *awsv1alpha1.Account, awsSetupClient awsclient.Client, optInRegions string) (reconcile.Result, error) {
-	numberOfAccountsOptingIn, err := CalculateOptingInRegionAccounts(r.Client)
+	numberOfAccountsOptingIn, err := CalculateOptingInRegionAccounts(reqLogger, r.Client)
 	if err != nil {
 		return reconcile.Result{}, nil
 	}

--- a/controllers/account/region_enablement.go
+++ b/controllers/account/region_enablement.go
@@ -24,6 +24,10 @@ func HandleOptInRegionRequests(reqLogger logr.Logger, awsClient awsclient.Client
 	regionOptInRequired, err := RegionNeedsOptIn(reqLogger, awsClient, optInRegion)
 	if err != nil {
 		reqLogger.Error(err, "failed retrieving region Opt-In status from AWS")
+		if strings.Contains(err.Error(), "AccessDeniedException") {
+			optInRegionRequest.Status = awsv1alpha1.OptInRequestUnknown
+			return nil
+		}
 	}
 
 	// Region enablement is required
@@ -320,7 +324,7 @@ func SetOptRegionStatus(reqLogger logr.Logger, optInRegions []string, currentAcc
 	return nil
 }
 
-func CalculateOptingInRegionAccounts(c client.Client) (int, error) {
+func CalculateOptingInRegionAccounts(reqLogger logr.Logger, c client.Client) (int, error) {
 	// Retrieve a list of accounts with region enablement in progress for supported Opt-In regions
 	accountList := &awsv1alpha1.AccountList{}
 	listOpts := []client.ListOption{
@@ -348,5 +352,10 @@ func CalculateOptingInRegionAccounts(c client.Client) (int, error) {
 			numberOfAccountsOptingIn += 1
 		}
 	}
+	reqLogger.Info(
+		fmt.Sprintf("Current number of accounts opting into regions: [%i]",
+			numberOfAccountsOptingIn),
+	)
+
 	return numberOfAccountsOptingIn, nil
 }

--- a/controllers/account/region_enablement.go
+++ b/controllers/account/region_enablement.go
@@ -353,7 +353,7 @@ func CalculateOptingInRegionAccounts(reqLogger logr.Logger, c client.Client) (in
 		}
 	}
 	reqLogger.Info(
-		fmt.Sprintf("Current number of accounts opting into regions: [%i]",
+		fmt.Sprintf("Current number of accounts opting into regions: [%d]",
 			numberOfAccountsOptingIn),
 	)
 

--- a/controllers/account/region_enablement.go
+++ b/controllers/account/region_enablement.go
@@ -26,7 +26,6 @@ func HandleOptInRegionRequests(reqLogger logr.Logger, awsClient awsclient.Client
 		reqLogger.Error(err, "failed retrieving region Opt-In status from AWS")
 		if strings.Contains(err.Error(), "AccessDeniedException") {
 			optInRegionRequest.Status = awsv1alpha1.OptInRequestUnknown
-			return nil
 		}
 	}
 

--- a/controllers/validation/account_validation_controller.go
+++ b/controllers/validation/account_validation_controller.go
@@ -539,7 +539,7 @@ func (r *AccountValidationReconciler) ValidateOptInRegions(reqLogger logr.Logger
 		regionList = append(regionList, strings.TrimSpace(region))
 	}
 
-	numberOfAccountsOptingIn, err := accountcontroller.CalculateOptingInRegionAccounts(r.Client)
+	numberOfAccountsOptingIn, err := accountcontroller.CalculateOptingInRegionAccounts(reqLogger, r.Client)
 	if err != nil {
 		return &AccountValidationError{
 			Type: NotAllOptInRegionsEnabled,


### PR DESCRIPTION
# What is being added?
A fix to handle accounts that don't have the correct permissions to enable opt in regions. The change will update the state from TODO to MANUL_ACTION and prevent accounts from continuously trying to enable accounts with the wrong permissions 

## Checklist before requesting review

- [x] I have tested this locally
- [ ] I have included unit tests
- [ ] I have updated any corresponding documentation

## Steps To Manually Test

1. Start the operator
2. Modify OrganizationAccountAccessRole permissions
3. Run "make predeploy"
4. Set "feature.opt_in_regions" to true in hack/templates/aws.managed.openshift.io_v1alpha1_configmap.tmpl
5. Add "opt-in-regions" entry to hack/templates/aws.managed.openshift.io_v1alpha1_configmap.tmpl
6. Run "make create-account"
7. Set account.Spec.accountPool to "hs-zero-size-accountpool"
8. Verify account CR state changes to READY
9. Verify in the AWS console that the opt-in regions specified in the configMap are enabled

Ref [OSD-21097](https://issues.redhat.com//browse/OSD-21097)