### PR TITLE
[OSD-17066] Update Total Account Watcher to count both active and creating accounts

### DIFF
--- a/pkg/awsclient/client.go
+++ b/pkg/awsclient/client.go
@@ -16,10 +16,11 @@ package awsclient
 import (
 	"context"
 	"fmt"
-	"github.com/aws/aws-sdk-go/service/account"
-	"github.com/aws/aws-sdk-go/service/account/accountiface"
 	"net/http"
 	"time"
+
+	"github.com/aws/aws-sdk-go/service/account"
+	"github.com/aws/aws-sdk-go/service/account/accountiface"
 
 	"github.com/aws/aws-sdk-go/aws/endpoints"
 	"github.com/aws/aws-sdk-go/service/route53/route53iface"
@@ -123,6 +124,7 @@ type Client interface {
 	ListAccounts(*organizations.ListAccountsInput) (*organizations.ListAccountsOutput, error)
 	CreateAccount(*organizations.CreateAccountInput) (*organizations.CreateAccountOutput, error)
 	DescribeCreateAccountStatus(*organizations.DescribeCreateAccountStatusInput) (*organizations.DescribeCreateAccountStatusOutput, error)
+	ListCreateAccountStatus(*organizations.ListCreateAccountStatusInput) (*organizations.ListCreateAccountStatusOutput, error)
 	MoveAccount(*organizations.MoveAccountInput) (*organizations.MoveAccountOutput, error)
 	CreateOrganizationalUnit(*organizations.CreateOrganizationalUnitInput) (*organizations.CreateOrganizationalUnitOutput, error)
 	ListOrganizationalUnitsForParent(*organizations.ListOrganizationalUnitsForParentInput) (*organizations.ListOrganizationalUnitsForParentOutput, error)
@@ -395,6 +397,10 @@ func (c *awsClient) ListRoles(input *iam.ListRolesInput) (*iam.ListRolesOutput, 
 
 func (c *awsClient) ListAccounts(input *organizations.ListAccountsInput) (*organizations.ListAccountsOutput, error) {
 	return c.orgClient.ListAccounts(input)
+}
+
+func (c *awsClient) ListCreateAccountStatus(input *organizations.ListCreateAccountStatusInput) (*organizations.ListCreateAccountStatusOutput, error) {
+	return c.orgClient.ListCreateAccountStatus(input)
 }
 
 func (c *awsClient) CreateAccount(input *organizations.CreateAccountInput) (*organizations.CreateAccountOutput, error) {

--- a/pkg/awsclient/mock/zz_generated.mock_client.go
+++ b/pkg/awsclient/mock/zz_generated.mock_client.go
@@ -903,6 +903,21 @@ func (mr *MockClientMockRecorder) ListChildren(arg0 any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListChildren", reflect.TypeOf((*MockClient)(nil).ListChildren), arg0)
 }
 
+// ListCreateAccountStatus mocks base method.
+func (m *MockClient) ListCreateAccountStatus(arg0 *organizations.ListCreateAccountStatusInput) (*organizations.ListCreateAccountStatusOutput, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListCreateAccountStatus", arg0)
+	ret0, _ := ret[0].(*organizations.ListCreateAccountStatusOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListCreateAccountStatus indicates an expected call of ListCreateAccountStatus.
+func (mr *MockClientMockRecorder) ListCreateAccountStatus(arg0 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListCreateAccountStatus", reflect.TypeOf((*MockClient)(nil).ListCreateAccountStatus), arg0)
+}
+
 // ListHostedZones mocks base method.
 func (m *MockClient) ListHostedZones(arg0 *route53.ListHostedZonesInput) (*route53.ListHostedZonesOutput, error) {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
# What is being added?
This PR addresses [OSD-17066](https://issues.redhat.com/browse/OSD-17066), which calls for AAO's Total Account Watcher to keep track of both active AWS accounts _and_ AWS accounts that are still being created. Currently, the Watcher only counts active AWS accounts, which has led to race conditions where too many accounts were allowed to be created.

The approach this PR takes is quite simple: in addition to counting the number of active accounts returned by `ListAccounts()`, AccountWatcher's `getTotalAwsAccounts()` now also counts the number of accounts returned by `ListCreateAccountStatus(States: ["IN_PROGRESS"])`. Both counts are added together and returned as one integer. We rely on AWS to only return "IN_PROGRESS" account creations by specifying such criteria in our ListCreateAccountStatus call. As for the other two possible [account creation states](https://github.com/aws/aws-sdk-go-v2/blob/service/organizations/v1.31.1/service/organizations/types/enums.go#L236): we assume that accounts marked "SUCCEEDED" are already returned by `ListAccounts()`, and that accounts marked "FAILED" are irrelevant.

This PR modifies almost all of AccountWatcher's unit tests such that goMock now expects a call to ListCreateAccountStatus. This PR also adds a few new unit test cases designed to simulate the race condition scenario mentioned in the ticket.

## Checklist before requesting review
- [ ] I have tested this locally
- [x] I have included unit tests
- [ ] I have updated any corresponding documentation

## Steps To Manually Test
_Please provide us steps to reproduce the scenarios needed to test this.  If an integration test is provided, let us know how to run it. If not, enumerate the steps to validate this does what it's supposed to._
1. Start the operator
1. Run the thing
1. Observe X in the spec for the thing
1. Clean up the thing

Ref OSD-17066