### PR TITLE
Add FLs and TLs as approvers

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -15,4 +15,6 @@ approvers:
 - iamkirkbater
 - jharrington22
 - NautiluX
+- srep-functional-leads
+- srep-team-leads
 maintainers:


### PR DESCRIPTION
Make FLs and TLs approvers for cases where standard approvers aren't suitable/are hard to come by.

Ref [OSD-25197](https://issues.redhat.com//browse/OSD-25197)
