### PR TITLE
OSD-18390: Ensure Region Initialization Fails on Missing AMI

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -10,7 +10,7 @@ WORKDIR ${OPERATOR_PATH}
 
 RUN make go-build FIPS_ENABLED=${FIPS_ENABLED}
 
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.10-1154
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.10-1179
 ENV OPERATOR_BIN=aws-account-operator
 
 WORKDIR /root/

--- a/build/Dockerfile.olm-registry
+++ b/build/Dockerfile.olm-registry
@@ -4,7 +4,7 @@ COPY ${SAAS_OPERATOR_DIR} manifests
 RUN initializer --permissive
 
 # ubi-micro does not work for clusters with fips enabled unless we make OpenSSL available
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.10-1154
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.10-1179
 
 COPY --from=builder /bin/registry-server /bin/registry-server
 COPY --from=builder /bin/grpc_health_probe /bin/grpc_health_probe

--- a/controllers/account/ec2_test.go
+++ b/controllers/account/ec2_test.go
@@ -11,12 +11,12 @@ import (
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/aws/aws-sdk-go/service/sts"
 	"github.com/go-logr/logr"
-	"go.uber.org/mock/gomock"
 	awsv1alpha1 "github.com/openshift/aws-account-operator/api/v1alpha1"
 	"github.com/openshift/aws-account-operator/pkg/awsclient"
 	"github.com/openshift/aws-account-operator/pkg/awsclient/mock"
 	"github.com/openshift/aws-account-operator/pkg/testutils"
 	"github.com/stretchr/testify/assert"
+	"go.uber.org/mock/gomock"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/scheme"
@@ -134,7 +134,7 @@ func TestCreateSubnet(t *testing.T) {
 			ctrl := gomock.NewController(t)
 			defer ctrl.Finish()
 
-			expectedSubnetInputTags := []awsclient.AWSTag{}
+			var expectedSubnetInputTags []awsclient.AWSTag
 			expectedSubnetInputTags = append(expectedSubnetInputTags, awsclient.AWSTag{
 				Key:   "clusterAccountName",
 				Value: test.AwsAccount.Name,
@@ -311,7 +311,7 @@ func TestCreateEC2Instance(t *testing.T) {
 				RequesterId:   aws.String("aao"),
 				ReservationId: aws.String("1"),
 			},
-			instanceOutputError: awserr.New("Test", "Test", fmt.Errorf("Test")),
+			instanceOutputError: awserr.New("Test", "Test", fmt.Errorf("test")),
 		}, "", true},
 	}
 	for _, tt := range tests {
@@ -399,29 +399,29 @@ func TestReconcileAccount_InitializeSupportedRegions(t *testing.T) {
 				awsClientBuilder: mockAWSBuilder,
 				shardName:        "test",
 			}, args{
-				reqLogger: testutils.NewTestLogger(),
-				account: &awsv1alpha1.Account{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      TestAccountName,
-						Namespace: TestAccountNamespace,
-					},
+			reqLogger: testutils.NewTestLogger(),
+			account: &awsv1alpha1.Account{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      TestAccountName,
+					Namespace: TestAccountNamespace,
 				},
-				regions: []awsv1alpha1.AwsRegions{
-					{
-						Name: "us-east-1",
-					}},
-				creds: &sts.AssumeRoleOutput{
-					AssumedRoleUser: &sts.AssumedRoleUser{},
-					Credentials: &sts.Credentials{
-						AccessKeyId:     aws.String("123456"),
-						Expiration:      &time.Time{},
-						SecretAccessKey: aws.String("123456"),
-						SessionToken:    aws.String("123456"),
-					},
-					PackedPolicySize: new(int64),
+			},
+			regions: []awsv1alpha1.AwsRegions{
+				{
+					Name: "us-east-1",
+				}},
+			creds: &sts.AssumeRoleOutput{
+				AssumedRoleUser: &sts.AssumedRoleUser{},
+				Credentials: &sts.Credentials{
+					AccessKeyId:     aws.String("123456"),
+					Expiration:      &time.Time{},
+					SecretAccessKey: aws.String("123456"),
+					SessionToken:    aws.String("123456"),
 				},
-				amiOwner: "",
-			}},
+				PackedPolicySize: new(int64),
+			},
+			amiOwner: "",
+		}},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
Currently, when a region is being initialized, if we fail to lookup an AMI to use, or the instance type, the code would continue to execute and later fail on passing an empty string to AWS.

The function performing the initialization does return errors as well, but they are never read by the controller calling. Instead it spawns a goroutine for each region init, and uses channels to handle errors and info messages.

In the scenario where the AMI lookup fails, the error is sent back on the errors channel, and then that channel is closed, following by the goroutine continuing to run in the background until it eventually panics trying to send to the now closed error channel.

This causes the operator process to exit prematurely, leading to odd scenarios around cleaning up initialization VPCs that get leaked.

I also did a bit of code cleanup while I was in here.

## Checklist before requesting review

- [x] I have tested this locally
- [ ] I have included unit tests
- [ ] I have updated any corresponding documentation

## Steps To Manually Test
1. Start the operator with an invalid `ami-owner` and fedramp enabled
2. Create an `AccountClaim`, which will try to spawn a VPC and init
3. When the AMI is not found, it returns early, never creates the VPC, and marks the AccountClaim as failed

https://issues.redhat.com/browse/OSD-18390