### PR TITLE
OSD-28574 enforce cpu and memory limits for aws account operator

### DIFF
--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -21,6 +21,10 @@ spec:
           command:
           - aws-account-operator
           imagePullPolicy: Always
+          resources:
+            limits:
+              cpu: "200m"
+              memory: "2Gi"
           env:
             - name: WATCH_NAMESPACE
               value: ""


### PR DESCRIPTION
# What is being added?
Added CPU and Memory limits for the aws-account-operator.

In order to choose the values I went into a hive cluster and check the CPU and memory metrics of the operator over a period of time of weeks. The values chosen are larger than the ones showed in the metrics just in case.

## Steps To Manually Test
Once the PR is merge into staging environment. we can deploy A cluster in stage environment and watch how to aws-account-operator handles the creation of a new cluster and seeing any spikes or metrics that appear in order to know for sure the values chosen are good.

Ref [OSD-28574](https://issues.redhat.com//browse/OSD-28574)
