### PR TITLE
Manual pick of TESTTARGETS fix for boilerplate

### DIFF
--- a/boilerplate/openshift/golang-osd-operator/standard.mk
+++ b/boilerplate/openshift/golang-osd-operator/standard.mk
@@ -127,11 +127,6 @@ ifeq ($(origin TESTTARGETS), undefined)
 TESTTARGETS := $(shell ${GOENV} go list -e ./... | grep -E -v "/(vendor)/" | grep -E -v "/(test/e2e)/")
 endif
 
-# If for any reason we've made it this far and TESTTARGETS is still empty, fail early.
-ifeq ($(TESTTARGETS),)
-$(error TESTTARGETS is empty)
-endif
-
 # ex, -v
 TESTOPTS :=
 
@@ -195,6 +190,12 @@ go-check: ## Golang linting and other static analysis
 
 .PHONY: go-generate
 go-generate:
+	# If for any reason we've made it this far and TESTTARGETS is still empty, fail early.
+	@if [ -z "$(TESTTARGETS)" ]; then \
+		echo "ERROR: TESTTARGETS is empty"; \
+		exit 1; \
+	fi
+
 	${GOENV} go generate $(TESTTARGETS)
 	# Don't forget to commit generated files
 
@@ -273,6 +274,12 @@ SHELL = /usr/bin/env bash -o pipefail
 
 .PHONY: go-test
 go-test: setup-envtest
+	# If for any reason we've made it this far and TESTTARGETS is still empty, fail early.
+	@if [ -z "$(TESTTARGETS)" ]; then \
+		echo "ERROR: TESTTARGETS is empty"; \
+		exit 1; \
+	fi
+
 	KUBEBUILDER_ASSETS=$(KUBEBUILDER_ASSETS) go test $(TESTOPTS) $(TESTTARGETS)
 
 .PHONY: python-venv


### PR DESCRIPTION
# What is being added?
Bug fix for `TESTTARGETS` causing registry images to fail to build.

This is a manual commit of just that change, as the latest `boilerplate` update is in flight which includes a `golangci-lint` bump and some linting changes, and I wanted to keep this bugfix tightly scoped. Follow up PR to do the rest once this is live.

## Checklist before requesting review

- [x] I have tested this locally
- [ ] I have included unit tests
- [ ] I have updated any corresponding documentation

## Steps To Manually Test
_Please provide us steps to reproduce the scenarios needed to test this.  If an integration test is provided, let us know how to run it. If not, enumerate the steps to validate this does what it's supposed to._
1. Start the operator
1. Run the thing
1. Observe X in the spec for the thing
1. Clean up the thing

Ref OSD-0000
