### PR TITLE
OSD-29696: Bump `Dockerfile.olm-registry` to newer images for CVE fixes

### DIFF
--- a/build/Dockerfile.olm-registry
+++ b/build/Dockerfile.olm-registry
@@ -1,10 +1,10 @@
-FROM registry.redhat.io/openshift4/ose-operator-registry:v4.14 AS builder
+FROM registry.redhat.io/openshift4/ose-operator-registry-rhel9:v4.18.0 AS builder
 ARG SAAS_OPERATOR_DIR
 COPY ${SAAS_OPERATOR_DIR} manifests
 RUN initializer --permissive
 
 # ubi-micro does not work for clusters with fips enabled unless we make OpenSSL available
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.10-1179.1741863533
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.5-1742914212
 
 COPY --from=builder /bin/registry-server /bin/registry-server
 COPY --from=builder /bin/grpc_health_probe /bin/grpc_health_probe


### PR DESCRIPTION
# What is being added?
In order to resolve `GHSA-hcg3-q754-cr77` we need to bump the `ose-operator-registry` image to a newer version. However, the image we were using is an older one and the OLM team suggested moving to this one.

Additionally, the new one is rhel9, so we had to bump to `ubi9` as well. I verified with @sam-nguyen7 that `ubi9` is FIPS compliant as well, which has come up in the past. https://redhat-internal.slack.com/archives/CCX9DB894/p1738943003295999

The intent of this PR is to ensure this works in stage, and then apply the same change to `boilerplate` instead.

## Local build and run
```
 docker build -f build/Dockerfile.olm-registry -t aws-account-operator-registry .
[+] Building 8.4s (17/17) FINISHED                                                                                                                              docker:default
 => [internal] load build definition from Dockerfile.olm-registry                                                                                                         0.0s
 => => transferring dockerfile: 941B                                                                                                                                      0.0s
 => [internal] load metadata for registry.access.redhat.com/ubi9/ubi-minimal:9.5-1742914212                                                                               6.0s
 => [internal] load metadata for registry.redhat.io/openshift4/ose-operator-registry-rhel9:v4.18.0                                                                        3.9s
 => [auth] openshift4/ose-operator-registry-rhel9:pull token for registry.redhat.io                                                                                       0.0s
 => [internal] load .dockerignore                                                                                                                                         0.0s
 => => transferring context: 208B                                                                                                                                         0.0s
 => [stage-1 1/7] FROM registry.access.redhat.com/ubi9/ubi-minimal:9.5-1742914212@sha256:ac61c96b93894b9169221e87718733354dd3765dd4a62b275893c7ff0d876869                 0.0s
 => CACHED [builder 1/3] FROM registry.redhat.io/openshift4/ose-operator-registry-rhel9:v4.18.0@sha256:86255848630c6dfcfdad62ee1444ee70822063f0e56ed2b1b09158ab13fa7e5a   0.0s
 => [internal] load build context                                                                                                                                         0.1s
 => => transferring context: 388.74kB                                                                                                                                     0.1s
 => [builder 2/3] COPY  manifests                                                                                                                                         0.5s
 => [builder 3/3] RUN initializer --permissive                                                                                                                            0.7s
 => CACHED [stage-1 2/7] COPY --from=builder /bin/registry-server /bin/registry-server                                                                                    0.0s 
 => CACHED [stage-1 3/7] COPY --from=builder /bin/grpc_health_probe /bin/grpc_health_probe                                                                                0.0s 
 => CACHED [stage-1 4/7] COPY --from=builder /bin/initializer /bin/initializer                                                                                            0.0s 
 => CACHED [stage-1 5/7] WORKDIR /registry                                                                                                                                0.0s 
 => CACHED [stage-1 6/7] RUN chgrp -R 0 /registry && chmod -R g+rwx /registry                                                                                             0.0s 
 => [stage-1 7/7] COPY --from=builder /registry /registry                                                                                                                 0.3s 
 => exporting to image                                                                                                                                                    0.3s
 => => exporting layers                                                                                                                                                   0.3s
 => => writing image sha256:b313f47d9d4d61678b65bfee26f127b6e9142c4e1f833a686833a03e0c90315f                                                                              0.0s
 => => naming to docker.io/library/aws-account-operator-registry                                                                                                          0.0s

....
 docker run aws-account-operator-registry                                        
time="2025-04-23T19:59:06Z" level=warning msg="\x1b[1;33mDEPRECATION NOTICE:\nSqlite-based catalogs and their related subcommands are deprecated. Support for\nthem will be removed in a future release. Please migrate your catalog workflows\nto the new file-based catalog format.\x1b[0m"
time="2025-04-23T19:59:06Z" level=info msg="serving registry" database=bundles.db port=50051

```

## Checklist before requesting review

- [ ] I have tested this locally
- [ ] I have included unit tests
- [ ] I have updated any corresponding documentation

## Steps To Manually Test
_Please provide us steps to reproduce the scenarios needed to test this.  If an integration test is provided, let us know how to run it. If not, enumerate the steps to validate this does what it's supposed to._
1. Start the operator
1. Run the thing
1. Observe X in the spec for the thing
1. Clean up the thing

Ref OSD-0000
