### PR TITLE
SREP-1631- add DEBUG_LOGGING env var to OLM template

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -10,7 +10,7 @@ WORKDIR ${OPERATOR_PATH}
 
 RUN make go-build FIPS_ENABLED=${FIPS_ENABLED}
 
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.6-1755695350
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.6-1758184547
 ENV OPERATOR_BIN=aws-account-operator
 
 WORKDIR /root/

--- a/build/Dockerfile.olm-registry
+++ b/build/Dockerfile.olm-registry
@@ -4,7 +4,7 @@ COPY ${SAAS_OPERATOR_DIR} manifests
 RUN initializer --permissive
 
 # ubi-micro does not work for clusters with fips enabled unless we make OpenSSL available
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.6-1755695350
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.6-1758184547
 
 COPY --from=builder /bin/registry-server /bin/registry-server
 COPY --from=builder /bin/grpc_health_probe /bin/grpc_health_probe

--- a/hack/olm-registry/olm-artifacts-template.yaml
+++ b/hack/olm-registry/olm-artifacts-template.yaml
@@ -70,6 +70,9 @@ parameters:
     value: "309956199498"
   - name: OPT_IN_REGIONS
     required: false
+  - name: DEBUG_LOGGING
+    required: false
+    value: "false"
 
 objects:
   - apiVersion: operators.coreos.com/v1alpha1
@@ -102,6 +105,10 @@ objects:
       name: aws-account-operator
       source: aws-account-operator-catalog
       sourceNamespace: aws-account-operator
+      config:
+        env:
+          - name: DEBUG_LOGGING
+            value: ${DEBUG_LOGGING}
 
   - apiVersion: v1
     kind: ConfigMap


### PR DESCRIPTION
# What is being added?
The environment variable DEBUG_LOGGING is being added to the OLM template. 

## Checklist before requesting review

- [ ] I have tested this locally
- [ ] I have included unit tests
- [ ] I have updated any corresponding documentation

## Steps To Manually Test
_Please provide us steps to reproduce the scenarios needed to test this.  If an integration test is provided, let us know how to run it. If not, enumerate the steps to validate this does what it's supposed to._
1. Start the operator
1. Run the thing
1. Observe X in the spec for the thing
1. Clean up the thing

Ref [SREP-1631](https://issues.redhat.com/browse/SREP-1631)
