### PR TITLE
Fix nil pointer dereference in RunInstance

### DIFF
--- a/controllers/account/ec2.go
+++ b/controllers/account/ec2.go
@@ -332,7 +332,7 @@ func CreateEC2Instance(reqLogger logr.Logger, account *awsv1alpha1.Account, clie
 			if errors.As(runErr, &aerr) {
 				// We want to ensure that we don't leave any instances around when there is an error
 				// possible that there is no instance here
-				if len(runResult.Instances) > 0 {
+				if runResult != nil && len(runResult.Instances) > 0 {
 					timeoutInstanceID = *runResult.Instances[0].InstanceId
 				}
 				switch aerr.ErrorCode() {


### PR DESCRIPTION
# What is being added?
```
github.com/openshift/aws-account-operator/controllers/account.CreateEC2Instance({{0x3d9ae10?, 0xc010e04ff0?}, 0xc0122d73b0?}, 0xc00eecae00, {0x3db3b48, 0xc011a9e0a0}, {{0xc0122f8180, 0x15}, {0xc011b68168, 0x8}}, ...)
        src/github.com/openshift/aws-account-operator/controllers/account/ec2.go:335 +0xb70
github.com/openshift/aws-account-operator/controllers/account.(*AccountReconciler).BuildAndDestroyEC2Instances(0x0?, {{0x3d9ae10?, 0xc010e04ff0?}, 0x385b29e?}, 0xc00eecae00, {0x3db3b48, 0xc011a9e0a0}, {{0xc0122f8180, 0x15}, {0xc011b68168, ...}}, ...)
        src/github.com/openshift/aws-account-operator/controllers/account/ec2.go:212 +0xf8
github.com/openshift/aws-account-operator/controllers/account.(*AccountReconciler).InitializeRegion(0xc000281cc0, {{0x3d9ae10?, 0xc010e04ff0?}, 0xc010e04ff0?}, 0xc00eecae00, {0xc00ee81470, 0x9}, {0xc00a9ae8e0, 0xc}, 0x0, ...)
        src/github.com/openshift/aws-account-operator/controllers/account/ec2.go:188 +0x5e5
github.com/openshift/aws-account-operator/controllers/account.(*AccountReconciler).InitializeSupportedRegions.func1()
        src/github.com/openshift/aws-account-operator/controllers/account/ec2.go:70 +0x12e
created by github.com/openshift/aws-account-operator/controllers/account.(*AccountReconciler).InitializeSupportedRegions in goroutine 5375
        src/github.com/openshift/aws-account-operator/controllers/account/ec2.go:68 +0x4f4
```

## Checklist before requesting review

- [x] I have tested this locally
- [ ] I have included unit tests
- [ ] I have updated any corresponding documentation

## Steps To Manually Test
_Please provide us steps to reproduce the scenarios needed to test this.  If an integration test is provided, let us know how to run it. If not, enumerate the steps to validate this does what it's supposed to._
1. Start the operator
1. Run the thing
1. Observe X in the spec for the thing
1. Clean up the thing

Ref OSD-0000
