### PR TITLE
ROSAENG-454 Add close-on-release feature to delete unused AWS accounts

### DIFF
--- a/controllers/accountclaim/reuse.go
+++ b/controllers/accountclaim/reuse.go
@@ -14,6 +14,8 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
 	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
+	"github.com/aws/aws-sdk-go-v2/service/organizations"
+	orgtypes "github.com/aws/aws-sdk-go-v2/service/organizations/types"
 	"github.com/aws/aws-sdk-go-v2/service/route53"
 	route53types "github.com/aws/aws-sdk-go-v2/service/route53/types"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
@@ -23,6 +25,7 @@ import (
 	"github.com/openshift/aws-account-operator/pkg/awsclient"
 	"github.com/openshift/aws-account-operator/pkg/localmetrics"
 	"github.com/openshift/aws-account-operator/pkg/utils"
+	corev1 "k8s.io/api/core/v1"
 )
 
 const (
@@ -30,7 +33,15 @@ const (
 	AccountReady = "Ready"
 	// AccountFailed indicates account reuse has failed
 	AccountFailed = "Failed"
+	// closeAccountTimeout is the timeout for CloseAccount API calls
+	closeAccountTimeout = 30 * time.Second
 )
+
+// ErrDryRunMode is returned when close-on-release is in dry-run mode
+var ErrDryRunMode = errors.New("dry-run mode enabled")
+
+// ErrRateLimited is returned when CloseAccount hits AWS quota limits
+var ErrRateLimited = errors.New("rate limited")
 
 func (r *AccountClaimReconciler) finalizeAccountClaim(reqLogger logr.Logger, accountClaim *awsv1alpha1.AccountClaim) error {
 
@@ -151,6 +162,39 @@ func (r *AccountClaimReconciler) finalizeAccountClaim(reqLogger logr.Logger, acc
 	}
 	localmetrics.Collector.SetAccountReusedCleanupDuration(time.Since(before).Seconds())
 
+	// Check if close-on-release feature is enabled
+	configMap, cmErr := utils.GetOperatorConfigMap(r.Client)
+	if cmErr != nil {
+		reqLogger.Info("Could not get operator configmap, defaulting to reuse behavior", "error", cmErr)
+	}
+
+	// Close account instead of reusing if feature is enabled
+	// Skip for FedRAMP (different compliance requirements)
+	if utils.IsCloseOnReleaseEnabled(configMap) && !config.IsFedramp() {
+		closeErr := r.closeAndDeleteAccount(context.TODO(), reqLogger, reusedAccount, awsClient, configMap)
+		if closeErr != nil {
+			if errors.Is(closeErr, ErrDryRunMode) {
+				reqLogger.Info("Dry-run mode active, falling back to reuse",
+					"accountID", reusedAccount.Spec.AwsAccountID)
+				// Continue to reuse logic below
+			} else if errors.Is(closeErr, ErrRateLimited) {
+				// Rate limited - don't put account back in pool, let finalizer retry
+				reqLogger.Info("Account closure rate limited, will retry",
+					"accountID", reusedAccount.Spec.AwsAccountID,
+					"error", closeErr)
+				return closeErr
+			} else {
+				reqLogger.Error(closeErr, "Failed to close account, falling back to reuse",
+					"accountID", reusedAccount.Spec.AwsAccountID)
+				// Continue to reuse logic below
+			}
+		} else {
+			reqLogger.Info("Successfully closed and deleted account",
+				"accountID", reusedAccount.Spec.AwsAccountID)
+			return nil
+		}
+	}
+
 	err = r.resetAccountSpecStatus(reqLogger, reusedAccount, accountClaim, awsv1alpha1.AccountReused, "Ready")
 	if err != nil {
 		reqLogger.Error(err, "Failed to reset account entity")
@@ -198,6 +242,106 @@ func (r *AccountClaimReconciler) resetAccountSpecStatus(reqLogger logr.Logger, r
 	}
 
 	return nil
+}
+
+// closeAndDeleteAccount closes the AWS account via Organizations API and deletes the Account CR
+// This is called when close-on-release feature is enabled instead of resetting for reuse
+func (r *AccountClaimReconciler) closeAndDeleteAccount(
+	ctx context.Context,
+	reqLogger logr.Logger,
+	account *awsv1alpha1.Account,
+	awsClient awsclient.Client,
+	configMap *corev1.ConfigMap,
+) error {
+	awsAccountID := account.Spec.AwsAccountID
+
+	// Check if we're currently rate limited
+	if retryAfter := utils.GetCloseAccountRetryAfter(account.Annotations); retryAfter > 0 {
+		reqLogger.Info("Account closure is rate limited, will retry later",
+			"accountID", awsAccountID,
+			"retryAfter", retryAfter.Round(time.Minute))
+		return fmt.Errorf("%w: retry after %v", ErrRateLimited, retryAfter)
+	}
+
+	// Check dry-run mode
+	if utils.IsCloseAccountDryRun(configMap) {
+		reqLogger.Info("DRY-RUN: Would close account",
+			"accountID", awsAccountID,
+			"accountCR", account.Name)
+		return ErrDryRunMode
+	}
+
+	// Call CloseAccount API
+	reqLogger.Info("Closing AWS account", "accountID", awsAccountID)
+	callCtx, cancel := context.WithTimeout(ctx, closeAccountTimeout)
+	defer cancel()
+
+	_, err := awsClient.CloseAccount(callCtx, &organizations.CloseAccountInput{
+		AccountId: aws.String(awsAccountID),
+	})
+
+	if err != nil {
+		// Check if account is already closed
+		var alreadyClosedErr *orgtypes.AccountAlreadyClosedException
+		if errors.As(err, &alreadyClosedErr) {
+			reqLogger.Info("Account already closed, proceeding with CR deletion",
+				"accountID", awsAccountID)
+			// Continue to delete the Account CR
+		} else if isCloseAccountRateLimitError(err) {
+			// Rate limit hit - set backoff and return error
+			reqLogger.Info("CloseAccount rate limit exceeded, setting backoff",
+				"accountID", awsAccountID)
+
+			account.Annotations = utils.SetCloseAccountRateLimited(account.Annotations)
+			if updateErr := r.Update(ctx, account); updateErr != nil {
+				reqLogger.Error(updateErr, "Failed to update account annotations for rate limit")
+				return fmt.Errorf("failed to persist rate limit state: %w", updateErr)
+			}
+
+			retryAfter := utils.GetCloseAccountRetryAfter(account.Annotations)
+			return fmt.Errorf("%w: will retry after %v", ErrRateLimited, retryAfter)
+		} else {
+			// Other error - log and return
+			reqLogger.Error(err, "Failed to close AWS account", "accountID", awsAccountID)
+			return err
+		}
+	} else {
+		reqLogger.Info("Successfully initiated account closure",
+			"accountID", awsAccountID,
+			"note", "Account will be in PENDING_CLOSURE for 90 days")
+
+		// Clear any rate limit state on success
+		account.Annotations = utils.ClearCloseAccountRateLimited(account.Annotations)
+	}
+
+	// Delete the Account CR
+	// This triggers the Account controller's finalizer which cleans up IAM resources
+	reqLogger.Info("Deleting Account CR", "accountCR", account.Name)
+	if err := r.Delete(ctx, account); err != nil {
+		reqLogger.Error(err, "Failed to delete Account CR after closing AWS account",
+			"accountID", awsAccountID,
+			"accountCR", account.Name)
+		return err
+	}
+
+	localmetrics.Collector.AddAccountClosed()
+	return nil
+}
+
+// isCloseAccountRateLimitError checks if the error is a rate limit error from CloseAccount
+func isCloseAccountRateLimitError(err error) bool {
+	var constraintErr *orgtypes.ConstraintViolationException
+	if errors.As(err, &constraintErr) {
+		//nolint:exhaustive // We only care about close-account-related rate limit reasons
+		switch constraintErr.Reason {
+		case orgtypes.ConstraintViolationExceptionReasonCloseAccountQuotaExceeded,
+			orgtypes.ConstraintViolationExceptionReasonCloseAccountRequestsLimitExceeded:
+			return true
+		default:
+			return false
+		}
+	}
+	return false
 }
 
 func (r *AccountClaimReconciler) cleanUpAwsAccount(reqLogger logr.Logger, awsClient awsclient.Client) error {

--- a/pkg/awsclient/client.go
+++ b/pkg/awsclient/client.go
@@ -124,6 +124,8 @@ type Client interface {
 	UntagResource(context.Context, *organizations.UntagResourceInput) (*organizations.UntagResourceOutput, error)
 	ListParents(context.Context, *organizations.ListParentsInput) (*organizations.ListParentsOutput, error)
 	ListTagsForResource(context.Context, *organizations.ListTagsForResourceInput) (*organizations.ListTagsForResourceOutput, error)
+	CloseAccount(context.Context, *organizations.CloseAccountInput) (*organizations.CloseAccountOutput, error)
+	DescribeAccount(context.Context, *organizations.DescribeAccountInput) (*organizations.DescribeAccountOutput, error)
 
 	//sts
 	AssumeRole(context.Context, *sts.AssumeRoleInput) (*sts.AssumeRoleOutput, error)
@@ -459,6 +461,14 @@ func (c *awsClient) ListParents(ctx context.Context, input *organizations.ListPa
 
 func (c *awsClient) ListTagsForResource(ctx context.Context, input *organizations.ListTagsForResourceInput) (*organizations.ListTagsForResourceOutput, error) {
 	return c.orgClient.ListTagsForResource(ctx, input)
+}
+
+func (c *awsClient) CloseAccount(ctx context.Context, input *organizations.CloseAccountInput) (*organizations.CloseAccountOutput, error) {
+	return c.orgClient.CloseAccount(ctx, input)
+}
+
+func (c *awsClient) DescribeAccount(ctx context.Context, input *organizations.DescribeAccountInput) (*organizations.DescribeAccountOutput, error) {
+	return c.orgClient.DescribeAccount(ctx, input)
 }
 
 func (c *awsClient) AssumeRole(ctx context.Context, input *sts.AssumeRoleInput) (*sts.AssumeRoleOutput, error) {

--- a/pkg/awsclient/mock/zz_generated.mock_client.go
+++ b/pkg/awsclient/mock/zz_generated.mock_client.go
@@ -124,6 +124,21 @@ func (mr *MockClientMockRecorder) ChangeResourceRecordSets(arg0, arg1 any) *gomo
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ChangeResourceRecordSets", reflect.TypeOf((*MockClient)(nil).ChangeResourceRecordSets), arg0, arg1)
 }
 
+// CloseAccount mocks base method.
+func (m *MockClient) CloseAccount(arg0 context.Context, arg1 *organizations.CloseAccountInput) (*organizations.CloseAccountOutput, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CloseAccount", arg0, arg1)
+	ret0, _ := ret[0].(*organizations.CloseAccountOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CloseAccount indicates an expected call of CloseAccount.
+func (mr *MockClientMockRecorder) CloseAccount(arg0, arg1 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CloseAccount", reflect.TypeOf((*MockClient)(nil).CloseAccount), arg0, arg1)
+}
+
 // CreateAccessKey mocks base method.
 func (m *MockClient) CreateAccessKey(arg0 context.Context, arg1 *iam.CreateAccessKeyInput) (*iam.CreateAccessKeyOutput, error) {
 	m.ctrl.T.Helper()
@@ -467,6 +482,21 @@ func (m *MockClient) DeleteVpcEndpointServiceConfigurations(arg0 context.Context
 func (mr *MockClientMockRecorder) DeleteVpcEndpointServiceConfigurations(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteVpcEndpointServiceConfigurations", reflect.TypeOf((*MockClient)(nil).DeleteVpcEndpointServiceConfigurations), arg0, arg1)
+}
+
+// DescribeAccount mocks base method.
+func (m *MockClient) DescribeAccount(arg0 context.Context, arg1 *organizations.DescribeAccountInput) (*organizations.DescribeAccountOutput, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DescribeAccount", arg0, arg1)
+	ret0, _ := ret[0].(*organizations.DescribeAccountOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DescribeAccount indicates an expected call of DescribeAccount.
+func (mr *MockClientMockRecorder) DescribeAccount(arg0, arg1 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeAccount", reflect.TypeOf((*MockClient)(nil).DescribeAccount), arg0, arg1)
 }
 
 // DescribeCases mocks base method.

--- a/pkg/localmetrics/localmetrics.go
+++ b/pkg/localmetrics/localmetrics.go
@@ -60,6 +60,7 @@ type MetricsCollector struct {
 	ccsAccountClaimPendingDuration  prometheus.Histogram
 	accountReuseCleanupDuration     prometheus.Histogram
 	accountReuseCleanupFailureCount prometheus.Counter
+	accountClosedCount              prometheus.Counter
 	reconcileDuration               *prometheus.HistogramVec
 	apiCallDuration                 *prometheus.HistogramVec
 }
@@ -171,6 +172,11 @@ func NewMetricsCollector(store cache.Cache) *MetricsCollector {
 			Help:        "Number of account reuse cleanup failures",
 			ConstLabels: prometheus.Labels{"name": operatorName},
 		}),
+		accountClosedCount: prometheus.NewCounter(prometheus.CounterOpts{
+			Name:        "aws_account_operator_accounts_closed_total",
+			Help:        "Total number of AWS accounts closed via CloseAccount API",
+			ConstLabels: prometheus.Labels{"name": operatorName},
+		}),
 		reconcileDuration: prometheus.NewHistogramVec(prometheus.HistogramOpts{
 			Name:        "aws_account_operator_reconcile_duration_seconds",
 			Help:        "Distribution of the number of seconds a Reconcile takes, broken down by controller",
@@ -211,6 +217,7 @@ func (c *MetricsCollector) Describe(ch chan<- *prometheus.Desc) {
 	c.ccsAccountClaimPendingDuration.Describe(ch)
 	c.accountReuseCleanupDuration.Describe(ch)
 	c.accountReuseCleanupFailureCount.Describe(ch)
+	c.accountClosedCount.Describe(ch)
 	c.reconcileDuration.Describe(ch)
 	c.apiCallDuration.Describe(ch)
 }
@@ -235,6 +242,7 @@ func (c *MetricsCollector) Collect(ch chan<- prometheus.Metric) {
 	c.ccsAccountClaimPendingDuration.Collect(ch)
 	c.accountReuseCleanupDuration.Collect(ch)
 	c.accountReuseCleanupFailureCount.Collect(ch)
+	c.accountClosedCount.Collect(ch)
 	c.reconcileDuration.Collect(ch)
 	c.apiCallDuration.Collect(ch)
 }
@@ -352,6 +360,11 @@ func (c *MetricsCollector) SetAccountReusedCleanupDuration(duration float64) {
 // AddAccountReuseCleanupFailure describes the number of accounts that have failed reuse
 func (c *MetricsCollector) AddAccountReuseCleanupFailure() {
 	c.accountReuseCleanupFailureCount.Inc()
+}
+
+// AddAccountClosed increments the counter for AWS accounts closed via CloseAccount API
+func (c *MetricsCollector) AddAccountClosed() {
+	c.accountClosedCount.Inc()
 }
 
 type ReportedError struct {

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -304,6 +304,159 @@ func GetFeatureFlagValue(configMap *corev1.ConfigMap, key string) (bool, error) 
 	return false, nil // Default to false if key not found
 }
 
+// Feature flag keys for account closure
+const (
+	// FeatureCloseOnRelease enables closing AWS accounts when AccountClaims are deleted
+	// instead of returning them to the pool for reuse
+	FeatureCloseOnRelease = "feature.close_on_release"
+
+	// CloseAccountDryRun when true, logs what would be closed without calling CloseAccount API
+	CloseAccountDryRun = "close_account.dry_run"
+)
+
+// IsCloseOnReleaseEnabled returns true if the close-on-release feature is enabled
+// When enabled, AWS accounts will be closed when their AccountClaim is deleted
+// instead of being returned to the account pool for reuse
+func IsCloseOnReleaseEnabled(configMap *corev1.ConfigMap) bool {
+	if configMap == nil {
+		return false
+	}
+	enabled, err := GetFeatureFlagValue(configMap, FeatureCloseOnRelease)
+	if err != nil {
+		return false
+	}
+	return enabled
+}
+
+// IsCloseAccountDryRun returns true if account closure is in dry-run mode
+// In dry-run mode, the operator logs which accounts would be closed but does not
+// actually call the AWS CloseAccount API
+func IsCloseAccountDryRun(configMap *corev1.ConfigMap) bool {
+	if configMap == nil {
+		return true // Default to dry-run if no configmap (safer)
+	}
+	dryRun, err := GetFeatureFlagValue(configMap, CloseAccountDryRun)
+	if err != nil {
+		return true // Default to dry-run on error (safer)
+	}
+	// If the key is not set, default to true (dry-run enabled for safety)
+	if _, ok := configMap.Data[CloseAccountDryRun]; !ok {
+		return true
+	}
+	return dryRun
+}
+
+// Rate limiting constants for CloseAccount API
+const (
+	// CloseAccountRateLimitAnnotation stores the timestamp until which we should
+	// not retry closing this account due to AWS quota limits
+	CloseAccountRateLimitAnnotation = "aws.managed.openshift.io/close-rate-limited-until"
+
+	// CloseAccountBackoffAnnotation stores the current backoff duration for exponential backoff
+	CloseAccountBackoffAnnotation = "aws.managed.openshift.io/close-backoff-seconds"
+
+	// CloseAccountInitialBackoff is the initial backoff duration when rate limited
+	CloseAccountInitialBackoff = 1 * time.Hour
+
+	// CloseAccountMaxBackoff is the maximum backoff duration (check once daily)
+	// This is appropriate for a 30-day rolling quota window
+	CloseAccountMaxBackoff = 24 * time.Hour
+)
+
+// IsCloseAccountRateLimited checks if the account is currently rate-limited for closure
+// Returns true if we should skip attempting to close this account, along with the
+// time when we should retry
+func IsCloseAccountRateLimited(annotations map[string]string) (bool, time.Time) {
+	if annotations == nil {
+		return false, time.Time{}
+	}
+
+	untilStr, ok := annotations[CloseAccountRateLimitAnnotation]
+	if !ok || untilStr == "" {
+		return false, time.Time{}
+	}
+
+	rateLimitedUntil, err := time.Parse(time.RFC3339, untilStr)
+	if err != nil {
+		// Invalid timestamp, treat as not rate limited
+		return false, time.Time{}
+	}
+
+	if time.Now().Before(rateLimitedUntil) {
+		return true, rateLimitedUntil
+	}
+
+	// Backoff period has expired
+	return false, time.Time{}
+}
+
+// CalculateCloseAccountBackoff calculates the next backoff duration using exponential backoff
+// Returns the backoff duration and the timestamp when we should retry
+func CalculateCloseAccountBackoff(annotations map[string]string) (time.Duration, time.Time) {
+	var backoff time.Duration
+
+	if annotations != nil {
+		if backoffStr, ok := annotations[CloseAccountBackoffAnnotation]; ok {
+			backoffSeconds, err := strconv.ParseInt(backoffStr, 10, 64)
+			if err == nil && backoffSeconds > 0 {
+				// Double the previous backoff
+				backoff = time.Duration(backoffSeconds) * time.Second * 2
+			}
+		}
+	}
+
+	// Use initial backoff if this is the first rate limit hit
+	if backoff == 0 {
+		backoff = CloseAccountInitialBackoff
+	}
+
+	// Cap at maximum backoff
+	if backoff > CloseAccountMaxBackoff {
+		backoff = CloseAccountMaxBackoff
+	}
+
+	retryAt := time.Now().Add(backoff)
+	return backoff, retryAt
+}
+
+// SetCloseAccountRateLimited sets the rate limit annotations on an account
+// Call this when CloseAccount fails with quota exceeded error
+func SetCloseAccountRateLimited(annotations map[string]string) map[string]string {
+	if annotations == nil {
+		annotations = make(map[string]string)
+	}
+
+	backoff, retryAt := CalculateCloseAccountBackoff(annotations)
+
+	annotations[CloseAccountRateLimitAnnotation] = retryAt.Format(time.RFC3339)
+	annotations[CloseAccountBackoffAnnotation] = strconv.FormatInt(int64(backoff.Seconds()), 10)
+
+	return annotations
+}
+
+// ClearCloseAccountRateLimited removes the rate limit annotations from an account
+// Call this when CloseAccount succeeds
+func ClearCloseAccountRateLimited(annotations map[string]string) map[string]string {
+	if annotations == nil {
+		return annotations
+	}
+
+	delete(annotations, CloseAccountRateLimitAnnotation)
+	delete(annotations, CloseAccountBackoffAnnotation)
+
+	return annotations
+}
+
+// GetCloseAccountRetryAfter returns the duration to wait before retrying account closure
+// Returns 0 if not rate limited
+func GetCloseAccountRetryAfter(annotations map[string]string) time.Duration {
+	isLimited, retryAt := IsCloseAccountRateLimited(annotations)
+	if !isLimited {
+		return 0
+	}
+	return time.Until(retryAt)
+}
+
 func DoNotRequeue() (reconcile.Result, error) {
 	return reconcile.Result{Requeue: false}, nil
 }

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"reflect"
 	"testing"
+	"time"
 
 	"github.com/go-logr/logr"
 	. "github.com/onsi/ginkgo/v2"
@@ -353,6 +354,358 @@ func TestJoinLabelMaps(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestIsCloseOnReleaseEnabled(t *testing.T) {
+	tests := []struct {
+		name      string
+		configMap *v1.ConfigMap
+		expected  bool
+	}{
+		{
+			name:      "nil configmap returns false",
+			configMap: nil,
+			expected:  false,
+		},
+		{
+			name: "feature not set returns false",
+			configMap: &v1.ConfigMap{
+				Data: map[string]string{},
+			},
+			expected: false,
+		},
+		{
+			name: "feature set to false returns false",
+			configMap: &v1.ConfigMap{
+				Data: map[string]string{
+					FeatureCloseOnRelease: "false",
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "feature set to true returns true",
+			configMap: &v1.ConfigMap{
+				Data: map[string]string{
+					FeatureCloseOnRelease: "true",
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "feature set to invalid value returns false",
+			configMap: &v1.ConfigMap{
+				Data: map[string]string{
+					FeatureCloseOnRelease: "invalid",
+				},
+			},
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := IsCloseOnReleaseEnabled(tt.configMap)
+			if result != tt.expected {
+				t.Errorf("IsCloseOnReleaseEnabled() = %v, want %v", result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestIsCloseAccountDryRun(t *testing.T) {
+	tests := []struct {
+		name      string
+		configMap *v1.ConfigMap
+		expected  bool
+	}{
+		{
+			name:      "nil configmap returns true (safe default)",
+			configMap: nil,
+			expected:  true,
+		},
+		{
+			name: "dry_run not set returns true (safe default)",
+			configMap: &v1.ConfigMap{
+				Data: map[string]string{},
+			},
+			expected: true,
+		},
+		{
+			name: "dry_run set to true returns true",
+			configMap: &v1.ConfigMap{
+				Data: map[string]string{
+					CloseAccountDryRun: "true",
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "dry_run set to false returns false",
+			configMap: &v1.ConfigMap{
+				Data: map[string]string{
+					CloseAccountDryRun: "false",
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "dry_run set to invalid value returns true (safe default)",
+			configMap: &v1.ConfigMap{
+				Data: map[string]string{
+					CloseAccountDryRun: "invalid",
+				},
+			},
+			expected: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := IsCloseAccountDryRun(tt.configMap)
+			if result != tt.expected {
+				t.Errorf("IsCloseAccountDryRun() = %v, want %v", result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestIsCloseAccountRateLimited(t *testing.T) {
+	tests := []struct {
+		name        string
+		annotations map[string]string
+		wantLimited bool
+		description string
+	}{
+		{
+			name:        "nil annotations returns not limited",
+			annotations: nil,
+			wantLimited: false,
+			description: "nil map should not be rate limited",
+		},
+		{
+			name:        "empty annotations returns not limited",
+			annotations: map[string]string{},
+			wantLimited: false,
+			description: "empty map should not be rate limited",
+		},
+		{
+			name: "missing annotation returns not limited",
+			annotations: map[string]string{
+				"other-annotation": "value",
+			},
+			wantLimited: false,
+			description: "missing rate limit annotation should not be rate limited",
+		},
+		{
+			name: "future timestamp returns limited",
+			annotations: map[string]string{
+				CloseAccountRateLimitAnnotation: time.Now().Add(1 * time.Hour).Format(time.RFC3339),
+			},
+			wantLimited: true,
+			description: "future timestamp should be rate limited",
+		},
+		{
+			name: "past timestamp returns not limited",
+			annotations: map[string]string{
+				CloseAccountRateLimitAnnotation: time.Now().Add(-1 * time.Hour).Format(time.RFC3339),
+			},
+			wantLimited: false,
+			description: "past timestamp should not be rate limited",
+		},
+		{
+			name: "invalid timestamp returns not limited",
+			annotations: map[string]string{
+				CloseAccountRateLimitAnnotation: "invalid-timestamp",
+			},
+			wantLimited: false,
+			description: "invalid timestamp should not be rate limited",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			isLimited, _ := IsCloseAccountRateLimited(tt.annotations)
+			if isLimited != tt.wantLimited {
+				t.Errorf("IsCloseAccountRateLimited() = %v, want %v: %s", isLimited, tt.wantLimited, tt.description)
+			}
+		})
+	}
+}
+
+func TestCalculateCloseAccountBackoff(t *testing.T) {
+	tests := []struct {
+		name            string
+		annotations     map[string]string
+		expectedBackoff time.Duration
+	}{
+		{
+			name:            "nil annotations returns initial backoff",
+			annotations:     nil,
+			expectedBackoff: CloseAccountInitialBackoff,
+		},
+		{
+			name:            "empty annotations returns initial backoff",
+			annotations:     map[string]string{},
+			expectedBackoff: CloseAccountInitialBackoff,
+		},
+		{
+			name: "first backoff is initial value",
+			annotations: map[string]string{
+				CloseAccountBackoffAnnotation: "0",
+			},
+			expectedBackoff: CloseAccountInitialBackoff,
+		},
+		{
+			name: "second backoff doubles initial (1h -> 2h)",
+			annotations: map[string]string{
+				CloseAccountBackoffAnnotation: "3600", // 1 hour in seconds
+			},
+			expectedBackoff: 2 * time.Hour,
+		},
+		{
+			name: "third backoff doubles again (2h -> 4h)",
+			annotations: map[string]string{
+				CloseAccountBackoffAnnotation: "7200", // 2 hours in seconds
+			},
+			expectedBackoff: 4 * time.Hour,
+		},
+		{
+			name: "backoff caps at max (24h)",
+			annotations: map[string]string{
+				CloseAccountBackoffAnnotation: "86400", // 24 hours in seconds
+			},
+			expectedBackoff: CloseAccountMaxBackoff,
+		},
+		{
+			name: "large backoff caps at max",
+			annotations: map[string]string{
+				CloseAccountBackoffAnnotation: "172800", // 48 hours in seconds
+			},
+			expectedBackoff: CloseAccountMaxBackoff,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			backoff, _ := CalculateCloseAccountBackoff(tt.annotations)
+			if backoff != tt.expectedBackoff {
+				t.Errorf("CalculateCloseAccountBackoff() = %v, want %v", backoff, tt.expectedBackoff)
+			}
+		})
+	}
+}
+
+func TestSetCloseAccountRateLimited(t *testing.T) {
+	t.Run("sets annotations on nil map", func(t *testing.T) {
+		result := SetCloseAccountRateLimited(nil)
+		if result == nil {
+			t.Error("SetCloseAccountRateLimited(nil) returned nil, want non-nil map")
+		}
+		if _, ok := result[CloseAccountRateLimitAnnotation]; !ok {
+			t.Error("SetCloseAccountRateLimited() did not set rate limit annotation")
+		}
+		if _, ok := result[CloseAccountBackoffAnnotation]; !ok {
+			t.Error("SetCloseAccountRateLimited() did not set backoff annotation")
+		}
+	})
+
+	t.Run("sets annotations on empty map", func(t *testing.T) {
+		result := SetCloseAccountRateLimited(map[string]string{})
+		if _, ok := result[CloseAccountRateLimitAnnotation]; !ok {
+			t.Error("SetCloseAccountRateLimited() did not set rate limit annotation")
+		}
+	})
+
+	t.Run("preserves existing annotations", func(t *testing.T) {
+		annotations := map[string]string{
+			"existing-key": "existing-value",
+		}
+		result := SetCloseAccountRateLimited(annotations)
+		if result["existing-key"] != "existing-value" {
+			t.Error("SetCloseAccountRateLimited() did not preserve existing annotation")
+		}
+	})
+
+	t.Run("doubles backoff on subsequent calls", func(t *testing.T) {
+		// First call
+		annotations := SetCloseAccountRateLimited(nil)
+		backoff1, _ := CalculateCloseAccountBackoff(nil)
+
+		// Second call with annotations from first
+		annotations = SetCloseAccountRateLimited(annotations)
+		backoff2, _ := CalculateCloseAccountBackoff(map[string]string{
+			CloseAccountBackoffAnnotation: annotations[CloseAccountBackoffAnnotation],
+		})
+
+		// The stored backoff should have doubled
+		if backoff2 <= backoff1 {
+			t.Errorf("Backoff did not increase: first=%v, second=%v", backoff1, backoff2)
+		}
+	})
+}
+
+func TestClearCloseAccountRateLimited(t *testing.T) {
+	t.Run("handles nil map", func(t *testing.T) {
+		result := ClearCloseAccountRateLimited(nil)
+		if result != nil {
+			t.Error("ClearCloseAccountRateLimited(nil) should return nil")
+		}
+	})
+
+	t.Run("removes rate limit annotations", func(t *testing.T) {
+		annotations := map[string]string{
+			CloseAccountRateLimitAnnotation: time.Now().Format(time.RFC3339),
+			CloseAccountBackoffAnnotation:   "3600",
+			"other-annotation":              "value",
+		}
+		result := ClearCloseAccountRateLimited(annotations)
+
+		if _, ok := result[CloseAccountRateLimitAnnotation]; ok {
+			t.Error("ClearCloseAccountRateLimited() did not remove rate limit annotation")
+		}
+		if _, ok := result[CloseAccountBackoffAnnotation]; ok {
+			t.Error("ClearCloseAccountRateLimited() did not remove backoff annotation")
+		}
+		if result["other-annotation"] != "value" {
+			t.Error("ClearCloseAccountRateLimited() removed unrelated annotation")
+		}
+	})
+}
+
+func TestGetCloseAccountRetryAfter(t *testing.T) {
+	t.Run("returns zero when not limited", func(t *testing.T) {
+		duration := GetCloseAccountRetryAfter(nil)
+		if duration != 0 {
+			t.Errorf("GetCloseAccountRetryAfter(nil) = %v, want 0", duration)
+		}
+	})
+
+	t.Run("returns positive duration when limited", func(t *testing.T) {
+		retryAt := time.Now().Add(1 * time.Hour)
+		annotations := map[string]string{
+			CloseAccountRateLimitAnnotation: retryAt.Format(time.RFC3339),
+		}
+		duration := GetCloseAccountRetryAfter(annotations)
+		if duration <= 0 {
+			t.Errorf("GetCloseAccountRetryAfter() = %v, want positive duration", duration)
+		}
+		// Should be approximately 1 hour (allow some tolerance for test execution)
+		if duration < 59*time.Minute || duration > 61*time.Minute {
+			t.Errorf("GetCloseAccountRetryAfter() = %v, want ~1 hour", duration)
+		}
+	})
+
+	t.Run("returns zero when backoff expired", func(t *testing.T) {
+		retryAt := time.Now().Add(-1 * time.Hour)
+		annotations := map[string]string{
+			CloseAccountRateLimitAnnotation: retryAt.Format(time.RFC3339),
+		}
+		duration := GetCloseAccountRetryAfter(annotations)
+		if duration != 0 {
+			t.Errorf("GetCloseAccountRetryAfter() with expired backoff = %v, want 0", duration)
+		}
+	})
 }
 
 var _ = Describe("Utils", func() {


### PR DESCRIPTION
Previously, when an AccountClaim was deleted, AAO would clean up AWS resources and return the Account to the pool for reuse. Over time, this led to thousands of dormant osd-creds-* accounts accumulating in AWS Organizations.

This change adds a new feature flag that, when enabled, closes the AWS account via the Organizations CloseAccount API instead of reusing it.

Changes:
- Add CloseAccount and DescribeAccount methods to AWS client interface
- Add feature.close_on_release ConfigMap flag (default: disabled)
- Add close_account.dry_run ConfigMap flag (default: enabled for safety)
- Implement closeAndDeleteAccount() in accountclaim controller
- Add exponential backoff for AWS rate limits (1h-24h, stored in Account CR annotations)
- Add aws_account_operator_accounts_closed_total metric
- Skip closure for FedRAMP, CCS/BYOC, and STS accounts

The feature uses safe defaults:
- Disabled by default (no behavior change)
- Dry-run enabled by default (logs only, no API calls)
- Falls back to reuse if closure fails

AWS rate limit handling:
- AWS allows closing max(250, 20% of accounts) per rolling 30-day window
- On CLOSE_ACCOUNT_QUOTA_EXCEEDED, sets exponential backoff via annotations
- Automatically retries as quota frees up

# What is being added?
_Is this a fix for a bug?  What's the bug?  Is this a new feature? Please describe it. Is this just a small typo fix?  That's fine too!_

## Checklist before requesting review

- [ ] I have tested this locally
- [X] I have included unit tests
- [X] I have updated any corresponding documentation

## Steps To Manually Test
_Please provide us steps to reproduce the scenarios needed to test this.  If an integration test is provided, let us know how to run it. If not, enumerate the steps to validate this does what it's supposed to._
Step 1: Deploy with Dry-Run (Safe)
# Edit the ConfigMap
oc edit cm aws-account-operator-configmap -n aws-account-operator
Add:

data:
  feature.close_on_release: "true"
  close_account.dry_run: "true"
Step 2: Delete an AccountClaim
# Find a test AccountClaim
oc get accountclaims -A
# Delete it
oc delete accountclaim <name> -n <namespace>
Step 3: Check Logs
oc logs -n aws-account-operator deployment/aws-account-operator -f | grep -E "DRY-RUN|close"
Expected output:

INFO DRY-RUN: Would close account  accountID=123456789012 accountCR=osd-creds-mgmt-abc123
Step 4: Enable Real Closure (When Ready)
oc patch cm aws-account-operator-configmap -n aws-account-operator \
  --type merge -p '{"data":{"close_account.dry_run":"false"}}'
Step 5: Monitor
# Watch for closures
oc logs -n aws-account-operator deployment/aws-account-operator -f | grep -E "Successfully closed|rate limit|CloseAccount"
# Check metrics
curl -s <metrics-endpoint> | grep accounts_closed
Step 6: Verify in AWS Console
After a real closure, check AWS Organizations console:

Account should show status PENDING_CLOSURE or SUSPENDED

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added AWS account closure capability when released (controlled by "close-on-release" feature flag).
  * Added dry-run mode support for testing closure operations without AWS impact.
  * Implemented rate-limiting and exponential backoff handling for account closure quota management.
  * New metrics to track the total number of closed accounts.

* **Tests**
  * Added comprehensive unit tests for account closure utilities and feature configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->