### PR TITLE
Adding permissions to extend the CIDR and create new Subnets in the VPC

### DIFF
--- a/deploy_pko/AWSFederatedRole-network-mgmt.yaml
+++ b/deploy_pko/AWSFederatedRole-network-mgmt.yaml
@@ -107,6 +107,8 @@ spec:
       - effect: Allow
         action:
           - "ec2:CreateTransitGatewayVpcAttachment"
+          - "ec2:AssociateVpcCidrBlock"
+          - "ec2:CreateSubnet"
         resource:
           - "arn:aws:ec2:*:*:subnet/*"
           - "arn:aws:ec2:*:*:transit-gateway/*"

--- a/hack/olm-registry/olm-artifacts-template.yaml
+++ b/hack/olm-registry/olm-artifacts-template.yaml
@@ -271,6 +271,8 @@ objects:
           - effect: Allow
             action:
               - "ec2:CreateTransitGatewayVpcAttachment"
+              - "ec2:AssociateVpcCidrBlock"
+              - "ec2:CreateSubnet"
             resource:
               - "arn:aws:ec2:*:*:subnet/*"
               - "arn:aws:ec2:*:*:transit-gateway/*"

--- a/test/deploy/aws.managed.openshift.io_v1alpha1_awsfederatedrole_networkmgmt_cr.yaml
+++ b/test/deploy/aws.managed.openshift.io_v1alpha1_awsfederatedrole_networkmgmt_cr.yaml
@@ -17,6 +17,8 @@ spec:
       - effect: Allow
         action:
           - "ec2:CreateTransitGatewayVpcAttachment"
+          - "ec2:AssociateVpcCidrBlock"
+          - "ec2:CreateSubnet"
         resource:
           - "arn:aws:ec2:*:*:subnet/*"
           - "arn:aws:ec2:*:*:transit-gateway/*"


### PR DESCRIPTION
# What is being added?
_bugfix ROSAENG-59403_
Adding more permissions to the network-mgmt role, which will unblock more self-service scenarios.

## Checklist before requesting review

- [x] I have tested this locally
- [x] I have included unit tests
- [ ] I have updated any corresponding documentation

## Steps To Manually Test
_Please provide us steps to reproduce the scenarios needed to test this.  If an integration test is provided, let us know how to run it. If not, enumerate the steps to validate this does what it's supposed to._
1. Start the operator
1. Run the thing
1. Check if the network-mgmt AWS roles provisioned for clusters include the AssociateVpcCidrBlock and CreateSubnet permissions.
1. Clean up the thing


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated AWS IAM permissions for network management role to enable additional VPC and subnet operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->