### PR TITLE
Remove memory limit to prevent OOMKilled in integration

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -10,7 +10,7 @@ WORKDIR ${OPERATOR_PATH}
 
 RUN make go-build FIPS_ENABLED=${FIPS_ENABLED}
 
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.8-1782708562
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.8-1782797275
 ENV OPERATOR_BIN=aws-account-operator
 
 WORKDIR /root/

--- a/build/Dockerfile.olm-registry
+++ b/build/Dockerfile.olm-registry
@@ -4,7 +4,7 @@ COPY ${SAAS_OPERATOR_DIR} manifests
 RUN initializer --permissive
 
 # ubi-micro does not work for clusters with fips enabled unless we make OpenSSL available
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.8-1782708562
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.8-1782797275
 
 COPY --from=builder /bin/registry-server /bin/registry-server
 COPY --from=builder /bin/grpc_health_probe /bin/grpc_health_probe

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -24,7 +24,6 @@ spec:
           resources:
             limits:
               cpu: "200m"
-              memory: "3Gi"
           env:
             - name: WATCH_NAMESPACE
               value: ""

--- a/deploy_pko/Deployment-aws-account-operator.yaml.gotmpl
+++ b/deploy_pko/Deployment-aws-account-operator.yaml.gotmpl
@@ -26,7 +26,6 @@ spec:
         resources:
           limits:
             cpu: 200m
-            memory: 3Gi
         env:
         - name: WATCH_NAMESPACE
           value: ''


### PR DESCRIPTION
## Problem
The aws-account-operator is experiencing OOMKilled restarts in hivei01ue1 integration environment where there are 586 Account CRs to reconcile. With the current 3Gi memory limit, the pod crashes every ~23 minutes with exit code 137.

**Current state:**
```
NAME                                    READY   STATUS    RESTARTS         AGE
aws-account-operator-77d7d79c96-jjc5l   1/1     Running   46 (4m59s ago)   18h
```

Each restart shows:
```
Last State:     Terminated
  Reason:       OOMKilled
  Exit Code:    137
```

## History
- **PR #847** (March 2025): Initial 2Gi memory limit added
- **Commit a18a47aa** (March 2026): Bumped to 3Gi due to OOM issues
- **Today** (June 2026): Still OOMing at 3Gi with 586 Account CRs

## Solution
Remove the memory limit entirely to allow the operator to use as much memory as needed based on the number of Account CRs it manages. The operator's memory usage scales with the number of Account CRs, and with 586 CRs in integration, a fixed limit is not sustainable.

## Changes
- Removed `memory: 3Gi` limit from `deploy/operator.yaml`
- Removed `memory: 3Gi` limit from `deploy_pko/Deployment-aws-account-operator.yaml.gotmpl`
- Kept CPU limit at 200m

## Testing
This will be validated in integration (hivei01ue1) where the OOM issue is currently occurring.

Slack thread: https://redhat-internal.slack.com/archives/C0AKBJST8QH/p1782833436353699

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment settings to remove the container memory limit while keeping the CPU limit in place.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->