### PR TITLE
fix: Use management account credentials for CloseAccount api

### DIFF
--- a/controllers/accountclaim/reuse.go
+++ b/controllers/accountclaim/reuse.go
@@ -77,6 +77,7 @@ func (r *AccountClaimReconciler) finalizeAccountClaim(reqLogger logr.Logger, acc
 
 	var awsClient awsclient.Client
 	var awsClientInput awsclient.NewAwsClientInput
+	var managementAwsClient awsclient.Client // Client for management/payer account (used for CloseAccount)
 
 	clusterAwsRegion := accountClaim.Spec.Aws.Regions[0].Name
 	if reusedAccount.IsBYOC() {
@@ -116,6 +117,10 @@ func (r *AccountClaimReconciler) finalizeAccountClaim(reqLogger logr.Logger, acc
 			reqLogger.Error(err, connErr)
 			return err
 		}
+
+		// Store the management account client for CloseAccount API calls
+		// CloseAccount must be called from the management/payer account, not the child account
+		managementAwsClient = awsSetupClient
 	}
 
 	if reusedAccount.IsBYOC() {
@@ -171,7 +176,7 @@ func (r *AccountClaimReconciler) finalizeAccountClaim(reqLogger logr.Logger, acc
 	// Close account instead of reusing if feature is enabled
 	// Skip for FedRAMP (different compliance requirements)
 	if utils.IsCloseOnReleaseEnabled(configMap) && !config.IsFedramp() {
-		closeErr := r.closeAndDeleteAccount(context.TODO(), reqLogger, reusedAccount, awsClient, configMap)
+		closeErr := r.closeAndDeleteAccount(context.TODO(), reqLogger, reusedAccount, managementAwsClient, configMap)
 		if closeErr != nil {
 			if errors.Is(closeErr, ErrDryRunMode) {
 				reqLogger.Info("Dry-run mode active, falling back to reuse",
@@ -250,7 +255,7 @@ func (r *AccountClaimReconciler) closeAndDeleteAccount(
 	ctx context.Context,
 	reqLogger logr.Logger,
 	account *awsv1alpha1.Account,
-	awsClient awsclient.Client,
+	managementAwsClient awsclient.Client,
 	configMap *corev1.ConfigMap,
 ) error {
 	awsAccountID := account.Spec.AwsAccountID
@@ -271,12 +276,12 @@ func (r *AccountClaimReconciler) closeAndDeleteAccount(
 		return ErrDryRunMode
 	}
 
-	// Call CloseAccount API
+	// Call CloseAccount API using the management/payer account credentials
 	reqLogger.Info("Closing AWS account", "accountID", awsAccountID)
 	callCtx, cancel := context.WithTimeout(ctx, closeAccountTimeout)
 	defer cancel()
 
-	_, err := awsClient.CloseAccount(callCtx, &organizations.CloseAccountInput{
+	_, err := managementAwsClient.CloseAccount(callCtx, &organizations.CloseAccountInput{
 		AccountId: aws.String(awsAccountID),
 	})
 


### PR DESCRIPTION
The CloseAccount API must be called from the management/payer account, not from the child account. The original implementation passed awsClient (which holds child account credentials via OrganizationAccountAccessRole) to closeAndDeleteAccount(), resulting in AccessDeniedException. This fix stores the management account client (awsSetupClient) before assuming into the child account, and passes it to closeAndDeleteAccount() for the CloseAccount API call.

https://redhat.atlassian.net/browse/ROSAENG-454

# What is being added?
_Is this a fix for a bug?  What's the bug?  Is this a new feature? Please describe it. Is this just a small typo fix?  That's fine too!_

Bug fix for the close-on-release feature (merged in PR #978). The CloseAccount AWS Organizations API was failing with AccessDeniedException because it was being called using child account credentials instead of management/payer account credentials.

## Checklist before requesting review

- [X] I have tested this locally
- [X] I have included unit tests
- [X] I have updated any corresponding documentation

## Steps To Manually Test
_Please provide us steps to reproduce the scenarios needed to test this.  If an integration test is provided, let us know how to run it. If not, enumerate the steps to validate this does what it's supposed to._
1. Enable close-on-release on a staging hive shard:
oc patch cm aws-account-operator-configmap -n aws-account-operator --type merge -p '{"data":{"feature.close_on_release":"true","close_account.dry_run":"false"}}'
2. Delete the AAO pods to pick up the new code
3. Create and then delete a non-CCS test cluster
4. Watch AAO logs for "Successfully initiated account closure" instead of AccessDeniedException

Ref [ROSAENG-454](https://redhat.atlassian.net/browse/ROSAENG-454)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved account-reuse finalization by ensuring account closure requests are processed through the appropriate management account connection.
  * Increased reliability of account cleanup and closure workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->