### PR TITLE
[DO NOT MERGE]fix: use available+progressing for pool satisfaction and fail stuck N…

### DIFF
--- a/controllers/account/account_controller.go
+++ b/controllers/account/account_controller.go
@@ -157,11 +157,32 @@ func (r *AccountReconciler) Reconcile(ctx context.Context, request ctrl.Request)
 		return reconcile.Result{}, errors.New(errMsg)
 	}
 
-	// Check account limit before doing any expensive work
+	// Check account limit before doing any expensive work.
+	// If the account has been stuck waiting for the limit to clear for too long,
+	// fail it so the pool controller's satisfaction check isn't inflated by
+	// accounts that will never provision.
 	if !currentAcctInstance.IsPendingDeletion() && !currentAcctInstance.IsBYOC() && currentAcctInstance.IsUnclaimedAndHasNoState() && !currentAcctInstance.HasAwsAccountID() {
 		if !totalaccountwatcher.TotalAccountWatcher.AccountsCanBeCreated() {
 			if !config.IsFedramp() {
-				reqLogger.Info("AWS Account limit reached. This does not always indicate a problem, it's a limit we enforce in the configmap to prevent runaway account creation")
+				stuckDuration := time.Since(currentAcctInstance.CreationTimestamp.Time)
+				if stuckDuration > createPendTime {
+					errMsg := fmt.Sprintf("Account limit reached for longer than %d minutes, failing account", utils.WaitTime)
+					reqLogger.Info(errMsg, "stuckFor", stuckDuration.String())
+					_, stateErr := r.setAccountFailed( //nolint:contextcheck // pre-existing function signature
+						reqLogger,
+						currentAcctInstance,
+						awsv1alpha1.AccountCreationFailed,
+						"AccountLimitTimeout",
+						errMsg,
+						AccountFailed,
+					)
+					if stateErr != nil {
+						reqLogger.Error(stateErr, "failed setting account state", "desiredState", AccountFailed)
+						return reconcile.Result{}, stateErr
+					}
+					return reconcile.Result{}, errors.New(errMsg)
+				}
+				reqLogger.Info("AWS Account limit reached, will retry", "stuckFor", stuckDuration.String())
 				return reconcile.Result{Requeue: true, RequeueAfter: time.Duration(5) * time.Minute}, nil
 			}
 		}

--- a/controllers/accountpool/accountpool_controller.go
+++ b/controllers/accountpool/accountpool_controller.go
@@ -3,6 +3,8 @@ package accountpool
 import (
 	"context"
 	"fmt"
+	"time"
+
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -23,6 +25,11 @@ import (
 
 const (
 	controllerName = "accountpool"
+
+	// Delay between creating individual Account CRs to prevent burst-creating
+	// many AWS accounts simultaneously, which can cause creation timeouts
+	// when MaxConcurrentReconciles for the account controller is low.
+	accountCreationDelay = 30 * time.Second
 )
 
 var log = logf.Log.WithName("controller_accountpool")
@@ -77,12 +84,13 @@ func (r *AccountPoolReconciler) Reconcile(ctx context.Context, request ctrl.Requ
 
 	// Get the number of desired unclaimed AWS accounts in the pool
 	poolSizeCount := currentAccountPool.Spec.PoolSize
-	unclaimedAccountCount := calculatedStatus.UnclaimedAccounts
+	effectiveCount := calculatedStatus.AvailableAccounts + calculatedStatus.AccountsProgressing
 
 	reqLogger.Info(fmt.Sprintf("AccountPool Calculations Completed: %+v", calculatedStatus))
 
-	if unclaimedAccountCount >= poolSizeCount {
-		reqLogger.Info(fmt.Sprintf("unclaimed account pool satisfied, unclaimedAccounts %d >= poolSize %d", unclaimedAccountCount, poolSizeCount))
+	if effectiveCount >= poolSizeCount {
+		reqLogger.Info(fmt.Sprintf("account pool satisfied, available %d + progressing %d = %d >= poolSize %d",
+			calculatedStatus.AvailableAccounts, calculatedStatus.AccountsProgressing, effectiveCount, poolSizeCount))
 		return reconcile.Result{}, nil
 	}
 
@@ -100,13 +108,17 @@ func (r *AccountPoolReconciler) Reconcile(ctx context.Context, request ctrl.Requ
 		return reconcile.Result{}, err
 	}
 
-	reqLogger.Info(fmt.Sprintf("Creating account %s for accountpool. Unclaimed accounts: %d, poolsize%d", newAccount.Name, unclaimedAccountCount, poolSizeCount))
+	reqLogger.Info(fmt.Sprintf("Creating account %s for accountpool. Available: %d, Progressing: %d, poolSize: %d", newAccount.Name, calculatedStatus.AvailableAccounts, calculatedStatus.AccountsProgressing, poolSizeCount))
 	err = r.Create(context.TODO(), newAccount)
 	if err != nil {
 		return reconcile.Result{}, err
 	}
 
-	return reconcile.Result{}, nil
+	// Delay before creating the next account to prevent burst-provisioning
+	// many AWS accounts at once. Without this, each Account CR creation triggers
+	// an immediate re-reconcile (via ownership watch), causing the pool to
+	// rapidly create all CRs in quick succession.
+	return reconcile.Result{RequeueAfter: accountCreationDelay}, nil
 }
 
 func (r *AccountPoolReconciler) handleServiceQuotas(ctx context.Context, reqLogger logr.Logger, account *awsv1alpha1.Account) error {

--- a/controllers/accountpool/accountpool_controller_test.go
+++ b/controllers/accountpool/accountpool_controller_test.go
@@ -54,6 +54,24 @@ const (
 	claimed   = true
 )
 
+// createNoStateAccountMock creates an Account CR that simulates a zombie stuck on account-limit:
+// no state, no AWS account ID, never claimed.
+func createNoStateAccountMock(name string) *awsv1alpha1.Account {
+	return &awsv1alpha1.Account{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            name,
+			Namespace:       "aws-account-operator",
+			OwnerReferences: []metav1.OwnerReference{{Kind: "AccountPool"}},
+		},
+		Spec: awsv1alpha1.AccountSpec{
+			AwsAccountID: "",
+		},
+		Status: awsv1alpha1.AccountStatus{
+			State: "",
+		},
+	}
+}
+
 func createAccountMock(name string, state string, claimed bool) *awsv1alpha1.Account {
 	leID := ""
 	if claimed {
@@ -181,6 +199,39 @@ func TestReconcileAccountPool(t *testing.T) {
 			},
 			expectedAWSCount:      1,
 			expectedLimit:         1,
+			verifyAccountFunction: verifyAccountCreated,
+		},
+		{
+			name: "NoState zombies do not satisfy pool",
+			localObjects: []runtime.Object{
+				&awsv1alpha1.AccountPool{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test",
+						Namespace: "aws-account-operator",
+					},
+					Spec: awsv1alpha1.AccountPoolSpec{
+						PoolSize: 2,
+					},
+				},
+				configmap,
+				createNoStateAccountMock("zombie1"),
+				createNoStateAccountMock("zombie2"),
+			},
+			expectedAccountPool: awsv1alpha1.AccountPool{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test",
+					Namespace: "aws-account-operator",
+				},
+				Spec: awsv1alpha1.AccountPoolSpec{
+					PoolSize: 2,
+				},
+				Status: awsv1alpha1.AccountPoolStatus{
+					PoolSize:          2,
+					UnclaimedAccounts: 3, // 2 zombies + 1 newly created
+				},
+			},
+			expectedAWSCount:      2,
+			expectedLimit:         2,
 			verifyAccountFunction: verifyAccountCreated,
 		},
 		{


### PR DESCRIPTION
…oState accounts

The pool controller used unclaimedAccounts to determine if the pool was satisfied, which included NoState zombie CRs that will never provision. This prevented new accounts from being created when the pool was full of stuck accounts.

Additionally, accounts stuck on the account-limit requeued every 5 minutes forever without being marked Failed, inflating the unclaimed count permanently. They are now failed after 25 minutes (matching the existing creation timeout).

The pool also created all Account CRs in rapid succession via the ownership watch re-reconcile, causing burst CreateAccount API calls that overwhelmed the single-threaded account controller. A 30-second delay between creates prevents this.

# What is being added?
_Is this a fix for a bug?  What's the bug?  Is this a new feature? Please describe it. Is this just a small typo fix?  That's fine too!_

## Checklist before requesting review

- [ ] I have tested this locally
- [ ] I have included unit tests
- [ ] I have updated any corresponding documentation

## Steps To Manually Test
_Please provide us steps to reproduce the scenarios needed to test this.  If an integration test is provided, let us know how to run it. If not, enumerate the steps to validate this does what it's supposed to._
1. Start the operator
1. Run the thing
1. Observe X in the spec for the thing
1. Clean up the thing

Ref OSD-0000


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Account provisioning now fails with a clear timeout when the account creation limit remains blocked too long.
  * Account pools no longer count incomplete or “zombie” accounts toward the required pool size.
  * Account creation is throttled to prevent burst provisioning and improve pool reconciliation reliability.
* **Tests**
  * Added coverage verifying that incomplete accounts are excluded and replacement accounts are created as needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->