### PR TITLE
fix: bounded retry for STS client errors instead of infinite requeue

### DIFF
--- a/controllers/account/account_controller.go
+++ b/controllers/account/account_controller.go
@@ -76,8 +76,6 @@ const (
 	// PauseReconciliationAnnotation is the annotation key to pause all reconciliation for an account
 	PauseReconciliationAnnotation = "aws.managed.openshift.com/pause-reconciliation"
 
-	// STSClientErrorRetryAnnotation tracks the number of STS client error retries for bounded retry.
-	STSClientErrorRetryAnnotation = "aws.managed.openshift.com/sts-client-error-count"
 	// maxSTSClientErrorRetries is the maximum number of reconcile-level retries for transient
 	// STS AssumeRole failures before permanently failing the account. Each retry includes the
 	// 100-iteration in-loop retry in GetSTSCredentials (~50s), so 3 retries = ~2.5 minutes of
@@ -99,6 +97,7 @@ type AccountReconciler struct {
 	Scheme           *runtime.Scheme
 	awsClientBuilder awsclient.IBuilder
 	shardName        string
+	stsRetryCount    map[string]int
 }
 
 //+kubebuilder:rbac:groups=aws.managed.openshift.io,resources=accounts,verbs=get;list;watch;create;update;patch;delete
@@ -402,13 +401,7 @@ func (r *AccountReconciler) Reconcile(ctx context.Context, request ctrl.Request)
 					return reconcile.Result{}, err
 				}
 			} else {
-				if _, hasRetry := currentAcctInstance.Annotations[STSClientErrorRetryAnnotation]; hasRetry {
-					delete(currentAcctInstance.Annotations, STSClientErrorRetryAnnotation)
-					if err := r.Update(ctx, currentAcctInstance); err != nil {
-						reqLogger.Error(err, "failed clearing STS retry annotation")
-						return reconcile.Result{}, err
-					}
-				}
+				delete(r.stsRetryCount, currentAcctInstance.Name)
 				utils.SetAccountStatus(currentAcctInstance, "AWS account already created", awsv1alpha1.AccountCreating, AccountCreating)
 				err = r.statusUpdate(currentAcctInstance)
 
@@ -657,21 +650,11 @@ func (r *AccountReconciler) handleAWSClientError(reqLogger logr.Logger, currentA
 		reason = aerr.ErrorCode()
 	}
 
-	retryCount := 0
-	if v, ok := currentAcctInstance.Annotations[STSClientErrorRetryAnnotation]; ok {
-		retryCount, _ = strconv.Atoi(v)
-	}
+	retryCount := r.stsRetryCount[currentAcctInstance.Name]
 
 	if retryCount < maxSTSClientErrorRetries {
 		retryCount++
-		if currentAcctInstance.Annotations == nil {
-			currentAcctInstance.Annotations = map[string]string{}
-		}
-		currentAcctInstance.Annotations[STSClientErrorRetryAnnotation] = strconv.Itoa(retryCount)
-		if updateErr := r.accountSpecUpdate(reqLogger, currentAcctInstance); updateErr != nil {
-			reqLogger.Error(updateErr, "failed to update STS retry annotation")
-			return reconcile.Result{}, updateErr
-		}
+		r.stsRetryCount[currentAcctInstance.Name] = retryCount
 		backoff := time.Duration(retryCount) * 30 * time.Second
 		reqLogger.Info("STS client error, will retry",
 			"attempt", retryCount, "maxRetries", maxSTSClientErrorRetries,
@@ -679,6 +662,7 @@ func (r *AccountReconciler) handleAWSClientError(reqLogger logr.Logger, currentA
 		return reconcile.Result{RequeueAfter: backoff}, nil
 	}
 
+	delete(r.stsRetryCount, currentAcctInstance.Name)
 	errMsg := fmt.Sprintf("Failed to create STS Credentials for account ID %s after %d retries: %s",
 		currentAcctInstance.Spec.AwsAccountID, maxSTSClientErrorRetries, err)
 	_, stateErr := r.setAccountFailed(
@@ -1630,6 +1614,7 @@ func (r *AccountReconciler) SetupWithManager(mgr ctrl.Manager) error {
 
 	// Initialize shardName to empty string. It will be read from configMap in Reconcile()
 	r.shardName = ""
+	r.stsRetryCount = make(map[string]int)
 
 	rwm := utils.NewReconcilerWithMetrics(r, controllerName)
 	return ctrl.NewControllerManagedBy(mgr).

--- a/controllers/account/account_controller.go
+++ b/controllers/account/account_controller.go
@@ -76,6 +76,14 @@ const (
 	// PauseReconciliationAnnotation is the annotation key to pause all reconciliation for an account
 	PauseReconciliationAnnotation = "aws.managed.openshift.com/pause-reconciliation"
 
+	// STSClientErrorRetryAnnotation tracks the number of STS client error retries for bounded retry.
+	STSClientErrorRetryAnnotation = "aws.managed.openshift.com/sts-client-error-count"
+	// maxSTSClientErrorRetries is the maximum number of reconcile-level retries for transient
+	// STS AssumeRole failures before permanently failing the account. Each retry includes the
+	// 100-iteration in-loop retry in GetSTSCredentials (~50s), so 3 retries = ~2.5 minutes of
+	// actual AWS API attempts spread across ~6 minutes of wall clock (with backoff).
+	maxSTSClientErrorRetries = 3
+
 	// number of service quota requests we are allowed to open concurrently in AWS
 	MaxOpenQuotaRequests = 20
 
@@ -394,7 +402,13 @@ func (r *AccountReconciler) Reconcile(ctx context.Context, request ctrl.Request)
 					return reconcile.Result{}, err
 				}
 			} else {
-				// set state creating if the account was already created
+				if _, hasRetry := currentAcctInstance.Annotations[STSClientErrorRetryAnnotation]; hasRetry {
+					delete(currentAcctInstance.Annotations, STSClientErrorRetryAnnotation)
+					if err := r.Update(ctx, currentAcctInstance); err != nil {
+						reqLogger.Error(err, "failed clearing STS retry annotation")
+						return reconcile.Result{}, err
+					}
+				}
 				utils.SetAccountStatus(currentAcctInstance, "AWS account already created", awsv1alpha1.AccountCreating, AccountCreating)
 				err = r.statusUpdate(currentAcctInstance)
 
@@ -637,13 +651,36 @@ func (r *AccountReconciler) handleIAMUserCreation(reqLogger logr.Logger, current
 }
 
 func (r *AccountReconciler) handleAWSClientError(reqLogger logr.Logger, currentAcctInstance *awsv1alpha1.Account, err error) (reconcile.Result, error) {
-	// Get custom failure reason to update account status
 	reason := ""
 	var aerr smithy.APIError
 	if errors.As(err, &aerr) {
 		reason = aerr.ErrorCode()
 	}
-	errMsg := fmt.Sprintf("Failed to create STS Credentials for account ID %s: %s", currentAcctInstance.Spec.AwsAccountID, err)
+
+	retryCount := 0
+	if v, ok := currentAcctInstance.Annotations[STSClientErrorRetryAnnotation]; ok {
+		retryCount, _ = strconv.Atoi(v)
+	}
+
+	if retryCount < maxSTSClientErrorRetries {
+		retryCount++
+		if currentAcctInstance.Annotations == nil {
+			currentAcctInstance.Annotations = map[string]string{}
+		}
+		currentAcctInstance.Annotations[STSClientErrorRetryAnnotation] = strconv.Itoa(retryCount)
+		if updateErr := r.accountSpecUpdate(reqLogger, currentAcctInstance); updateErr != nil {
+			reqLogger.Error(updateErr, "failed to update STS retry annotation")
+			return reconcile.Result{}, updateErr
+		}
+		backoff := time.Duration(retryCount) * 30 * time.Second
+		reqLogger.Info("STS client error, will retry",
+			"attempt", retryCount, "maxRetries", maxSTSClientErrorRetries,
+			"retryAfter", backoff.String(), "errorCode", reason)
+		return reconcile.Result{RequeueAfter: backoff}, nil
+	}
+
+	errMsg := fmt.Sprintf("Failed to create STS Credentials for account ID %s after %d retries: %s",
+		currentAcctInstance.Spec.AwsAccountID, maxSTSClientErrorRetries, err)
 	_, stateErr := r.setAccountFailed(
 		reqLogger,
 		currentAcctInstance,
@@ -654,9 +691,9 @@ func (r *AccountReconciler) handleAWSClientError(reqLogger logr.Logger, currentA
 	)
 	if stateErr != nil {
 		reqLogger.Error(stateErr, "failed setting account state", "desiredState", AccountFailed)
+		return reconcile.Result{}, stateErr
 	}
-
-	return reconcile.Result{}, err
+	return reconcile.Result{}, nil
 }
 
 func (r *AccountReconciler) handleAccountInitializingRegions(reqLogger logr.Logger, currentAcctInstance *awsv1alpha1.Account) (reconcile.Result, error) {

--- a/controllers/account/account_controller_test.go
+++ b/controllers/account/account_controller_test.go
@@ -2869,8 +2869,9 @@ var _ = Describe("Account Controller", func() {
 			r.stsRetryCount[testAcct.Name] = maxSTSClientErrorRetries
 
 			stsErr := &smithy.GenericAPIError{Code: "AccessDenied", Message: "access denied"}
-			_, _ = r.handleAWSClientError(nullLogger, testAcct, stsErr)
+			_, err := r.handleAWSClientError(nullLogger, testAcct, stsErr)
 
+			Expect(err).ToNot(HaveOccurred())
 			_, exists := r.stsRetryCount[testAcct.Name]
 			Expect(exists).To(BeFalse(),
 				"retry count should be cleaned up after permanent failure")

--- a/controllers/account/account_controller_test.go
+++ b/controllers/account/account_controller_test.go
@@ -2825,43 +2825,36 @@ var _ = Describe("Account Controller", func() {
 				acct
 			testAcct.Name = accountName
 			testAcct.Namespace = awsv1alpha1.AccountCrNamespace
+			r.stsRetryCount = make(map[string]int)
 			r.Client = fake.NewClientBuilder().WithScheme(scheme.Scheme).
 				WithRuntimeObjects([]runtime.Object{testAcct}...).
 				Build()
 		})
 
-		It("should increment retry annotation and requeue on first failure", func() {
+		It("should increment retry count and requeue on first failure", func() {
 			stsErr := &smithy.GenericAPIError{Code: "AccessDenied", Message: "access denied"}
 			result, err := r.handleAWSClientError(nullLogger, testAcct, stsErr)
 
 			Expect(err).ToNot(HaveOccurred())
 			Expect(result.RequeueAfter).To(Equal(30 * time.Second))
-			Expect(testAcct.Annotations[STSClientErrorRetryAnnotation]).To(Equal("1"))
+			Expect(r.stsRetryCount[testAcct.Name]).To(Equal(1))
 			Expect(testAcct.Status.State).To(Equal(AccountCreating),
 				"account should NOT be Failed yet on first retry")
 		})
 
-		It("should increment retry annotation on subsequent failures with increasing backoff", func() {
-			testAcct.Annotations = map[string]string{STSClientErrorRetryAnnotation: "1"}
-			r.Client = fake.NewClientBuilder().WithScheme(scheme.Scheme).
-				WithRuntimeObjects([]runtime.Object{testAcct}...).
-				Build()
+		It("should increment retry count on subsequent failures with increasing backoff", func() {
+			r.stsRetryCount[testAcct.Name] = 1
 
 			stsErr := &smithy.GenericAPIError{Code: "AccessDenied", Message: "access denied"}
 			result, err := r.handleAWSClientError(nullLogger, testAcct, stsErr)
 
 			Expect(err).ToNot(HaveOccurred())
 			Expect(result.RequeueAfter).To(Equal(60 * time.Second))
-			Expect(testAcct.Annotations[STSClientErrorRetryAnnotation]).To(Equal("2"))
+			Expect(r.stsRetryCount[testAcct.Name]).To(Equal(2))
 		})
 
 		It("should permanently fail the account after max retries", func() {
-			testAcct.Annotations = map[string]string{
-				STSClientErrorRetryAnnotation: fmt.Sprintf("%d", maxSTSClientErrorRetries),
-			}
-			r.Client = fake.NewClientBuilder().WithScheme(scheme.Scheme).
-				WithRuntimeObjects([]runtime.Object{testAcct}...).
-				Build()
+			r.stsRetryCount[testAcct.Name] = maxSTSClientErrorRetries
 
 			stsErr := &smithy.GenericAPIError{Code: "AccessDenied", Message: "access denied"}
 			result, err := r.handleAWSClientError(nullLogger, testAcct, stsErr)
@@ -2872,19 +2865,15 @@ var _ = Describe("Account Controller", func() {
 			Expect(testAcct.Status.State).To(Equal(AccountFailed))
 		})
 
-		It("should initialize annotations map if nil", func() {
-			testAcct.Annotations = nil
-			r.Client = fake.NewClientBuilder().WithScheme(scheme.Scheme).
-				WithRuntimeObjects([]runtime.Object{testAcct}...).
-				Build()
+		It("should clean up retry count after permanent failure", func() {
+			r.stsRetryCount[testAcct.Name] = maxSTSClientErrorRetries
 
 			stsErr := &smithy.GenericAPIError{Code: "AccessDenied", Message: "access denied"}
-			result, err := r.handleAWSClientError(nullLogger, testAcct, stsErr)
+			_, _ = r.handleAWSClientError(nullLogger, testAcct, stsErr)
 
-			Expect(err).ToNot(HaveOccurred())
-			Expect(result.RequeueAfter).To(Equal(30 * time.Second))
-			Expect(testAcct.Annotations).ToNot(BeNil())
-			Expect(testAcct.Annotations[STSClientErrorRetryAnnotation]).To(Equal("1"))
+			_, exists := r.stsRetryCount[testAcct.Name]
+			Expect(exists).To(BeFalse(),
+				"retry count should be cleaned up after permanent failure")
 		})
 	})
 })

--- a/controllers/account/account_controller_test.go
+++ b/controllers/account/account_controller_test.go
@@ -2814,4 +2814,77 @@ var _ = Describe("Account Controller", func() {
 			})
 		})
 	})
+
+	Context("handleAWSClientError bounded retry", func() {
+		var testAcct *awsv1alpha1.Account
+
+		BeforeEach(func() {
+			testAcct = &newTestAccountBuilder().
+				WithAwsAccountID("123456789012").
+				WithState(AccountCreating).
+				acct
+			testAcct.Name = accountName
+			testAcct.Namespace = awsv1alpha1.AccountCrNamespace
+			r.Client = fake.NewClientBuilder().WithScheme(scheme.Scheme).
+				WithRuntimeObjects([]runtime.Object{testAcct}...).
+				Build()
+		})
+
+		It("should increment retry annotation and requeue on first failure", func() {
+			stsErr := &smithy.GenericAPIError{Code: "AccessDenied", Message: "access denied"}
+			result, err := r.handleAWSClientError(nullLogger, testAcct, stsErr)
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result.RequeueAfter).To(Equal(30 * time.Second))
+			Expect(testAcct.Annotations[STSClientErrorRetryAnnotation]).To(Equal("1"))
+			Expect(testAcct.Status.State).To(Equal(AccountCreating),
+				"account should NOT be Failed yet on first retry")
+		})
+
+		It("should increment retry annotation on subsequent failures with increasing backoff", func() {
+			testAcct.Annotations = map[string]string{STSClientErrorRetryAnnotation: "1"}
+			r.Client = fake.NewClientBuilder().WithScheme(scheme.Scheme).
+				WithRuntimeObjects([]runtime.Object{testAcct}...).
+				Build()
+
+			stsErr := &smithy.GenericAPIError{Code: "AccessDenied", Message: "access denied"}
+			result, err := r.handleAWSClientError(nullLogger, testAcct, stsErr)
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result.RequeueAfter).To(Equal(60 * time.Second))
+			Expect(testAcct.Annotations[STSClientErrorRetryAnnotation]).To(Equal("2"))
+		})
+
+		It("should permanently fail the account after max retries", func() {
+			testAcct.Annotations = map[string]string{
+				STSClientErrorRetryAnnotation: fmt.Sprintf("%d", maxSTSClientErrorRetries),
+			}
+			r.Client = fake.NewClientBuilder().WithScheme(scheme.Scheme).
+				WithRuntimeObjects([]runtime.Object{testAcct}...).
+				Build()
+
+			stsErr := &smithy.GenericAPIError{Code: "AccessDenied", Message: "access denied"}
+			result, err := r.handleAWSClientError(nullLogger, testAcct, stsErr)
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result.RequeueAfter).To(BeZero(),
+				"should not requeue — account is permanently failed")
+			Expect(testAcct.Status.State).To(Equal(AccountFailed))
+		})
+
+		It("should initialize annotations map if nil", func() {
+			testAcct.Annotations = nil
+			r.Client = fake.NewClientBuilder().WithScheme(scheme.Scheme).
+				WithRuntimeObjects([]runtime.Object{testAcct}...).
+				Build()
+
+			stsErr := &smithy.GenericAPIError{Code: "AccessDenied", Message: "access denied"}
+			result, err := r.handleAWSClientError(nullLogger, testAcct, stsErr)
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result.RequeueAfter).To(Equal(30 * time.Second))
+			Expect(testAcct.Annotations).ToNot(BeNil())
+			Expect(testAcct.Annotations[STSClientErrorRetryAnnotation]).To(Equal("1"))
+		})
+	})
 })


### PR DESCRIPTION
## Summary
- `handleAWSClientError` was returning the original error after setting the account to Failed, causing controller-runtime to requeue indefinitely
- Each requeue burned ~50s on STS AssumeRole timeout, and the status update triggered another watch event — creating an infinite retry loop that consumed all reconcile capacity of the single-worker account controller
- Replaced the two extremes (retry forever vs fail immediately) with a **bounded retry**: track attempt count via annotation, requeue with linear backoff (30s/60s/90s), permanently fail after 3 attempts
- Handles genuine transient failures (IAM eventual consistency, STS throttling, brief AWS blips) while guaranteeing convergence

## Changes
- **Bounded retry via annotation** (`aws.managed.openshift.com/sts-client-error-count`): on STS client error, increment counter and requeue with backoff. After 3 attempts (~6 min wall clock including the ~50s in-loop retry per attempt), permanently set account to Failed.
- **Annotation cleanup on recovery**: when a recovered account (NoState + existing AWS ID) re-enters processing, the retry annotation is cleared so it gets a fresh retry budget.

## Test plan
- [x] `make build` succeeds
- [x] `make test` passes (unit tests)
- [x] `golangci-lint` passes (pre-commit hook)
- [ ] Verify on staging: AccessDenied accounts retry 3 times then permanently fail, freeing the reconcile queue
- [ ] Verify on staging: legitimate accounts process without being starved by broken accounts
- [ ] Verify on staging: recovered accounts (reset from Failed to NoState) get a fresh retry budget

[ROSAENG-63162](https://redhat.atlassian.net/browse/ROSAENG-63162)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of temporary account setup errors with automatic retries.
  - Retries now use increasing delays and stop after a fixed limit.
  - Accounts are marked as failed with a clear error message when retries are exhausted.
  - Retry tracking resets after successful account assignment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->