### PR TITLE
fix: add disabledRegions to PKO package manifest

### DIFF
--- a/deploy_pko/manifest.yaml
+++ b/deploy_pko/manifest.yaml
@@ -126,6 +126,10 @@ spec:
           description: Comma-separated list of opt-in regions
           type: string
           default: ""
+        disabledRegions:
+          description: Comma-separated list of regions to skip during opt-in enablement
+          type: string
+          default: ""
         debugLogging:
           description: Enable debug logging
           type: string


### PR DESCRIPTION
## Summary

- Adds `disabledRegions` to the PKO package manifest (`deploy_pko/manifest.yaml`)
- This field was added to `clusterpackage.yaml` and the ConfigMap gotmpl in PR #1062 but was missed in the manifest
- PKO validates config against the manifest schema and drops undeclared fields, causing the gotmpl to fail with `map has no entry for key "disabledRegions"` — **blocking all AAO deployments across int/stage**

## Root Cause

PKO uses `manifest.yaml` `config.openAPIV3Schema` to determine which config fields are valid. Any field not declared in the schema is silently dropped before being passed to gotmpl templates. The template `{{ .config.disabledRegions }}` then fails because the key doesn't exist in the template context.

## Impact

All AAO deployments on int/stage clusters are stuck on the previous version (`ddd0db1`) because PKO cannot render the new package (`f79b7bc`). This is blocking the ME region outage mitigation (ROSAENG-450, ITN-2026-00058).

## Test plan

- [ ] Verify PKO logs no longer show `map has no entry for key "disabledRegions"` after deployment
- [ ] Verify AAO pod rolls to new image on hivei01ue1
- [ ] Verify ConfigMap contains `disabled-regions` key

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a `disabledRegions` configuration option to specify comma-separated regions to skip during opt-in enablement.
  * The setting defaults to an empty value when no regions are excluded.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->