### PR TITLE
fix: filter disabled regions from service quota expansion path

### DIFF
--- a/controllers/account/account_controller.go
+++ b/controllers/account/account_controller.go
@@ -447,7 +447,7 @@ func (r *AccountReconciler) Reconcile(ctx context.Context, request ctrl.Request)
 
 		// Test PendingVerification state creating support case and checking for case status
 		if currentAcctInstance.IsPendingVerification() {
-			return r.HandleNonCCSPendingVerification(reqLogger, currentAcctInstance, awsSetupClient)
+			return r.HandleNonCCSPendingVerification(reqLogger, currentAcctInstance, awsSetupClient, disabledRegions) //nolint:contextcheck
 		}
 
 		if currentAcctInstance.IsUnclaimedAndHasNoState() {
@@ -595,7 +595,7 @@ func (r *AccountReconciler) handleOptInRegionEnablement(reqLogger logr.Logger, c
 		return reconcile.Result{}, nil
 	}
 
-	disabledSet := parseDisabledRegions(disabledRegions)
+	disabledSet := ParseDisabledRegions(disabledRegions)
 	if len(disabledSet) > 0 {
 		reqLogger.Info("Regions disabled via ConfigMap, will be skipped", "disabledRegions", disabledRegions)
 	}
@@ -820,7 +820,7 @@ func (r *AccountReconciler) handleAccountInitializingRegions(reqLogger logr.Logg
 	return reconcile.Result{}, nil
 }
 
-func (r *AccountReconciler) HandleNonCCSPendingVerification(reqLogger logr.Logger, currentAcctInstance *awsv1alpha1.Account, awsSetupClient awsclient.Client) (reconcile.Result, error) {
+func (r *AccountReconciler) HandleNonCCSPendingVerification(reqLogger logr.Logger, currentAcctInstance *awsv1alpha1.Account, awsSetupClient awsclient.Client, disabledRegions string) (reconcile.Result, error) {
 	// If the supportCaseID is blank and Account State = PendingVerification, create a case
 	if currentAcctInstance.Spec.BYOC {
 		err := errors.New("account is BYOC - should not be handled in NonCCS method")
@@ -839,7 +839,7 @@ func (r *AccountReconciler) HandleNonCCSPendingVerification(reqLogger logr.Logge
 			// Update supportCaseId in CR
 			currentAcctInstance.Status.SupportCaseID = caseID
 			utils.SetAccountStatus(currentAcctInstance, "Account pending verification in AWS", awsv1alpha1.AccountPendingVerification, AccountPendingVerification)
-			err = SetCurrentAccountServiceQuotas(reqLogger, r.awsClientBuilder, awsSetupClient, currentAcctInstance, r.Client)
+			err = SetCurrentAccountServiceQuotas(reqLogger, r.awsClientBuilder, awsSetupClient, currentAcctInstance, r.Client, disabledRegions)
 			if err != nil {
 				reqLogger.Error(err, "failed to set account service quotas")
 				return reconcile.Result{}, err
@@ -911,7 +911,7 @@ func (r *AccountReconciler) HandleNonCCSPendingVerification(reqLogger logr.Logge
 // expands them into the status. Regional quotas (Spec.RegionalServiceQuotas) are expanded once
 // per enabled AWS region. Global quotas (Spec.GlobalServiceQuotas) are copied once into
 // Status.GlobalServiceQuotas and applied via the us-east-1 endpoint by UpdateServiceQuotaRequests.
-func SetCurrentAccountServiceQuotas(reqLogger logr.Logger, awsClientBuilder awsclient.IBuilder, awsSetupClient awsclient.Client, currentAcctInstance *awsv1alpha1.Account, client client.Client) error {
+func SetCurrentAccountServiceQuotas(reqLogger logr.Logger, awsClientBuilder awsclient.IBuilder, awsSetupClient awsclient.Client, currentAcctInstance *awsv1alpha1.Account, client client.Client, disabledRegions string) error {
 
 	// Nothing to do if no regional or global quotas are configured.
 	if currentAcctInstance.Spec.RegionalServiceQuotas == nil && currentAcctInstance.Spec.GlobalServiceQuotas == nil {
@@ -967,9 +967,15 @@ func SetCurrentAccountServiceQuotas(reqLogger logr.Logger, awsClientBuilder awsc
 
 	currentAcctInstance.Status.RegionalServiceQuotas = make(awsv1alpha1.RegionalServiceQuotas)
 
+	disabledSet := ParseDisabledRegions(disabledRegions)
+
 	// By iterating over the regions returned by AWS (not the spec), we avoid setting quotas for
 	// regions the account does not support.
 	for _, region := range regionsEnabledInAccount.Regions {
+		if disabledSet[*region.RegionName] {
+			reqLogger.Info("Skipping disabled region for service quota expansion", "region", *region.RegionName)
+			continue
+		}
 		// Seed this region's quota map from the "default" values, deep-copying to avoid sharing
 		// the same pointer across regions.
 		regionQuotas := make(awsv1alpha1.AccountServiceQuota, len(defaultAccountServiceQuotas))

--- a/controllers/account/account_controller_test.go
+++ b/controllers/account/account_controller_test.go
@@ -2163,7 +2163,7 @@ var _ = Describe("Account Controller", func() {
 		When("Called with a CCS account", func() {
 			account = &newTestAccountBuilder().BYOC(true).WithState(awsv1alpha1.AccountPendingVerification).acct
 			It("does nothing", func() {
-				_, err := r.HandleNonCCSPendingVerification(nullLogger, account, mockAWSClient)
+				_, err := r.HandleNonCCSPendingVerification(nullLogger, account, mockAWSClient, "")
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(Equal("account is BYOC - should not be handled in NonCCS method"))
 			})
@@ -2188,7 +2188,7 @@ var _ = Describe("Account Controller", func() {
 					}, nil)
 					mockAWSClient.EXPECT().RequestServiceQuotaIncrease(gomock.Any(), gomock.Any()).Times(0)
 					Eventually(func() []string {
-						_, err := r.HandleNonCCSPendingVerification(nullLogger, account, mockAWSClient)
+						_, err := r.HandleNonCCSPendingVerification(nullLogger, account, mockAWSClient, "")
 						Expect(err).NotTo(HaveOccurred())
 						return []string{account.Status.State, account.Status.SupportCaseID}
 					}).Should(Equal([]string{AccountReady, "123456"}))
@@ -2340,7 +2340,7 @@ var _ = Describe("Account Controller", func() {
 							},
 						},
 					}, nil)
-					err := SetCurrentAccountServiceQuotas(nullLogger, r.awsClientBuilder, mockAWSClient, account, r.Client)
+					err := SetCurrentAccountServiceQuotas(nullLogger, r.awsClientBuilder, mockAWSClient, account, r.Client, "")
 					Expect(err).ToNot(HaveOccurred())
 					Expect(len(account.Status.RegionalServiceQuotas)).To(Equal(1))
 					Expect(len(account.Status.RegionalServiceQuotas["us-east-1"])).To(Equal(1))
@@ -2377,7 +2377,7 @@ var _ = Describe("Account Controller", func() {
 							},
 						},
 					}, nil)
-					_, err := r.HandleNonCCSPendingVerification(nullLogger, account, mockAWSClient)
+					_, err := r.HandleNonCCSPendingVerification(nullLogger, account, mockAWSClient, "")
 					Expect(err).To(HaveOccurred())
 				})
 				It("does not create a servicequota case if the quota is already higher", func() {
@@ -2420,7 +2420,7 @@ var _ = Describe("Account Controller", func() {
 					}, nil)
 					subClient.EXPECT().RequestServiceQuotaIncrease(gomock.Any(), gomock.Any()).Times(0)
 					Eventually(func() []string {
-						_, err := r.HandleNonCCSPendingVerification(nullLogger, account, mockAWSClient)
+						_, err := r.HandleNonCCSPendingVerification(nullLogger, account, mockAWSClient, "")
 						Expect(err).NotTo(HaveOccurred())
 						return []string{account.Status.State, account.Status.SupportCaseID}
 					}, 60*time.Second).Should(Equal([]string{AccountReady, "123456"}))
@@ -2488,7 +2488,7 @@ var _ = Describe("Account Controller", func() {
 						},
 					}, nil)
 					Eventually(func() []string {
-						_, err = r.HandleNonCCSPendingVerification(nullLogger, account, mockAWSClient)
+						_, err = r.HandleNonCCSPendingVerification(nullLogger, account, mockAWSClient, "")
 						Expect(err).NotTo(HaveOccurred())
 						return []string{account.Status.State, account.Status.SupportCaseID}
 					}).Should(Equal([]string{AccountReady, "123456"}))
@@ -2546,7 +2546,7 @@ var _ = Describe("Account Controller", func() {
 						},
 					}, nil)
 					Eventually(func() []string {
-						_, err = r.HandleNonCCSPendingVerification(nullLogger, account, mockAWSClient)
+						_, err = r.HandleNonCCSPendingVerification(nullLogger, account, mockAWSClient, "")
 						Expect(err).NotTo(HaveOccurred())
 						status := account.Status.RegionalServiceQuotas["us-east-1"][awsv1alpha1.RunningStandardInstances]
 						fmt.Printf("%+v\n", status.Status)
@@ -2588,7 +2588,7 @@ var _ = Describe("Account Controller", func() {
 							},
 						},
 					}, nil)
-					_, err = r.HandleNonCCSPendingVerification(nullLogger, account, mockAWSClient)
+					_, err = r.HandleNonCCSPendingVerification(nullLogger, account, mockAWSClient, "")
 					Expect(err).ToNot(HaveOccurred())
 					Expect(len(account.Status.RegionalServiceQuotas)).To(Equal(2))
 					Expect(len(account.Status.RegionalServiceQuotas["us-east-1"])).To(Equal(1))
@@ -2616,7 +2616,7 @@ var _ = Describe("Account Controller", func() {
 							CaseId: aws.String("234567"),
 						},
 					}, nil).Times(2)
-					_, err = r.HandleNonCCSPendingVerification(nullLogger, account, mockAWSClient)
+					_, err = r.HandleNonCCSPendingVerification(nullLogger, account, mockAWSClient, "")
 					Expect(account.Status.RegionalServiceQuotas["us-east-1"][awsv1alpha1.RunningStandardInstances].Status).To(Equal(awsv1alpha1.ServiceRequestInProgress))
 					Expect(account.Status.RegionalServiceQuotas["us-east-2"][awsv1alpha1.RunningStandardInstances].Status).To(Equal(awsv1alpha1.ServiceRequestInProgress))
 					Expect(account.Status.State).To(Equal(AccountPendingVerification))
@@ -2635,10 +2635,10 @@ var _ = Describe("Account Controller", func() {
 							Value:     aws.Float64(100),
 						},
 					}, nil).Times(2)
-					_, err = r.HandleNonCCSPendingVerification(nullLogger, account, mockAWSClient)
+					_, err = r.HandleNonCCSPendingVerification(nullLogger, account, mockAWSClient, "")
 					Expect(account.Status.RegionalServiceQuotas["us-east-1"][awsv1alpha1.RunningStandardInstances].Status).To(Equal(awsv1alpha1.ServiceRequestCompleted))
 					Expect(account.Status.RegionalServiceQuotas["us-east-2"][awsv1alpha1.RunningStandardInstances].Status).To(Equal(awsv1alpha1.ServiceRequestCompleted))
-					_, err = r.HandleNonCCSPendingVerification(nullLogger, account, mockAWSClient)
+					_, err = r.HandleNonCCSPendingVerification(nullLogger, account, mockAWSClient, "")
 					Expect(account.Status.State).To(Equal(AccountReady))
 				})
 				It("fails the account if a request is denied", func() {
@@ -2665,7 +2665,7 @@ var _ = Describe("Account Controller", func() {
 							},
 						},
 					}, nil)
-					_, err = r.HandleNonCCSPendingVerification(nullLogger, account, mockAWSClient)
+					_, err = r.HandleNonCCSPendingVerification(nullLogger, account, mockAWSClient, "")
 					Expect(err).ToNot(HaveOccurred())
 					Expect(len(account.Status.RegionalServiceQuotas)).To(Equal(1))
 					Expect(len(account.Status.RegionalServiceQuotas["us-east-1"])).To(Equal(1))
@@ -2694,7 +2694,7 @@ var _ = Describe("Account Controller", func() {
 							Value:     aws.Float64(0),
 						},
 					}, nil).Times(1)
-					_, err = r.HandleNonCCSPendingVerification(nullLogger, account, mockAWSClient)
+					_, err = r.HandleNonCCSPendingVerification(nullLogger, account, mockAWSClient, "")
 					Expect(account.Status.RegionalServiceQuotas["us-east-1"][awsv1alpha1.RunningStandardInstances].Status).To(Equal(awsv1alpha1.ServiceRequestDenied))
 					Expect(account.Status.State).To(Equal(AccountFailed))
 				})
@@ -2733,7 +2733,7 @@ var _ = Describe("Account Controller", func() {
 						},
 					}, nil)
 
-					err := SetCurrentAccountServiceQuotas(nullLogger, r.awsClientBuilder, mockAWSClient, account, r.Client)
+					err := SetCurrentAccountServiceQuotas(nullLogger, r.awsClientBuilder, mockAWSClient, account, r.Client, "")
 					Expect(err).ToNot(HaveOccurred())
 
 					// Global quota lands in the dedicated GlobalServiceQuotas status field
@@ -2821,7 +2821,7 @@ var _ = Describe("Account Controller", func() {
 					r.Client = fake.NewClientBuilder().WithScheme(scheme.Scheme).WithRuntimeObjects([]runtime.Object{account, configMap}...).Build()
 
 					// No DescribeRegions mock — test will fail if it's called unexpectedly
-					err := SetCurrentAccountServiceQuotas(nullLogger, r.awsClientBuilder, mockAWSClient, account, r.Client)
+					err := SetCurrentAccountServiceQuotas(nullLogger, r.awsClientBuilder, mockAWSClient, account, r.Client, "")
 					Expect(err).ToNot(HaveOccurred())
 
 					// Global quota should be in status
@@ -2850,7 +2850,7 @@ var _ = Describe("Account Controller", func() {
 					}
 					r.Client = fake.NewClientBuilder().WithScheme(scheme.Scheme).WithRuntimeObjects([]runtime.Object{account, configMap}...).Build()
 
-					result, err := r.HandleNonCCSPendingVerification(nullLogger, account, mockAWSClient)
+					result, err := r.HandleNonCCSPendingVerification(nullLogger, account, mockAWSClient, "")
 					Expect(err).ToNot(HaveOccurred())
 					Expect(account.Status.State).ToNot(Equal(AccountReady),
 						"account should not be Ready while global quotas are IN_PROGRESS")
@@ -2874,7 +2874,7 @@ var _ = Describe("Account Controller", func() {
 					}
 					r.Client = fake.NewClientBuilder().WithScheme(scheme.Scheme).WithRuntimeObjects([]runtime.Object{account, configMap}...).Build()
 
-					_, err := r.HandleNonCCSPendingVerification(nullLogger, account, mockAWSClient)
+					_, err := r.HandleNonCCSPendingVerification(nullLogger, account, mockAWSClient, "")
 					Expect(err).ToNot(HaveOccurred())
 					Expect(account.Status.State).To(Equal(AccountReady),
 						"account should be Ready when all global quotas are COMPLETED")

--- a/controllers/account/account_controller_test.go
+++ b/controllers/account/account_controller_test.go
@@ -2345,6 +2345,33 @@ var _ = Describe("Account Controller", func() {
 					Expect(len(account.Status.RegionalServiceQuotas)).To(Equal(1))
 					Expect(len(account.Status.RegionalServiceQuotas["us-east-1"])).To(Equal(1))
 				})
+				It("skips disabled regions during quota expansion", func() {
+					subClient := mock.NewMockClient(ctrl)
+					AssumeRoleAndCreateClient = func(
+						reqLogger logr.Logger,
+						awsClientBuilder awsclient.IBuilder,
+						currentAcctInstance *awsv1alpha1.Account,
+						client client.Client,
+						awsSetupClient awsclient.Client,
+						region string,
+						roleToAssume string,
+						ccsRoleID string) (awsclient.Client, *sts.AssumeRoleOutput, error) {
+						return subClient, &sts.AssumeRoleOutput{}, nil
+					}
+					subClient.EXPECT().DescribeRegions(gomock.Any(), gomock.Any()).Return(&ec2.DescribeRegionsOutput{
+						Regions: []ec2types.Region{
+							{RegionName: aws.String("us-east-1")},
+							{RegionName: aws.String("me-south-1")},
+							{RegionName: aws.String("me-central-1")},
+						},
+					}, nil)
+					err := SetCurrentAccountServiceQuotas(nullLogger, r.awsClientBuilder, mockAWSClient, account, r.Client, "me-south-1,me-central-1")
+					Expect(err).ToNot(HaveOccurred())
+					Expect(account.Status.RegionalServiceQuotas).To(HaveLen(1))
+					Expect(account.Status.RegionalServiceQuotas).To(HaveKey("us-east-1"))
+					Expect(account.Status.RegionalServiceQuotas).ToNot(HaveKey("me-south-1"))
+					Expect(account.Status.RegionalServiceQuotas).ToNot(HaveKey("me-central-1"))
+				})
 				It("errors when called with a unsupported (by us) servicequota", func() {
 					account = &newTestAccountBuilder().BYOC(false).WithServiceQuota(awsv1alpha1.RegionalServiceQuotas{
 						"default": awsv1alpha1.AccountServiceQuota{

--- a/controllers/account/region_enablement.go
+++ b/controllers/account/region_enablement.go
@@ -338,7 +338,7 @@ func checkOptInRegionStatus(reqLogger logr.Logger, awsClient awsclient.Client, r
 	}
 }
 
-func parseDisabledRegions(disabledRegions string) map[string]bool {
+func ParseDisabledRegions(disabledRegions string) map[string]bool {
 	disabled := make(map[string]bool)
 	if disabledRegions == "" {
 		return disabled

--- a/controllers/account/region_enablement_test.go
+++ b/controllers/account/region_enablement_test.go
@@ -59,7 +59,7 @@ func TestParseDisabledRegions(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := parseDisabledRegions(tt.input)
+			result := ParseDisabledRegions(tt.input)
 			assert.Equal(t, tt.expected, result)
 		})
 	}

--- a/controllers/validation/account_validation_controller.go
+++ b/controllers/validation/account_validation_controller.go
@@ -636,7 +636,7 @@ func (r *AccountValidationReconciler) Reconcile(ctx context.Context, request ctr
 		optInRegions, ok := cm.Data["opt-in-regions"]
 		// ValidateOptInRegions
 		if ok && isOptInRegionFeatureEnabled {
-			err = r.ValidateOptInRegions(reqLogger, &account, r.awsClientBuilder, optInRegions)
+			err = r.ValidateOptInRegions(reqLogger, &account, r.awsClientBuilder, optInRegions, cm.Data["disabled-regions"]) //nolint:contextcheck
 			if err != nil {
 				validationError, ok := err.(*AccountValidationError)
 				if ok && validationError.Type == NotAllOptInRegionsEnabled {
@@ -647,7 +647,7 @@ func (r *AccountValidationReconciler) Reconcile(ctx context.Context, request ctr
 
 		}
 
-		err = r.ValidateRegionalServiceQuotas(reqLogger, &account, r.awsClientBuilder)
+		err = r.ValidateRegionalServiceQuotas(reqLogger, &account, r.awsClientBuilder, cm.Data["disabled-regions"]) //nolint:contextcheck
 		if err != nil {
 			validationError, ok := err.(*AccountValidationError)
 			if ok && validationError.Type == NotAllServicequotasApplied {
@@ -659,11 +659,20 @@ func (r *AccountValidationReconciler) Reconcile(ctx context.Context, request ctr
 	}
 	return utils.DoNotRequeue()
 }
-func (r *AccountValidationReconciler) ValidateOptInRegions(reqLogger logr.Logger, currentAcctInstance *awsv1alpha1.Account, awsClientBuilder awsclient.IBuilder, optInRegions string) error {
+func (r *AccountValidationReconciler) ValidateOptInRegions(reqLogger logr.Logger, currentAcctInstance *awsv1alpha1.Account, awsClientBuilder awsclient.IBuilder, optInRegions string, disabledRegions string) error {
+	disabledSet := account.ParseDisabledRegions(disabledRegions)
 	var regionList []string
 	regions := strings.Split(optInRegions, ",")
 	for _, region := range regions {
-		regionList = append(regionList, strings.TrimSpace(region))
+		region = strings.TrimSpace(region)
+		if region == "" {
+			continue
+		}
+		if disabledSet[region] {
+			reqLogger.Info("Skipping disabled region for opt-in validation", "region", region)
+			continue
+		}
+		regionList = append(regionList, region)
 	}
 
 	numberOfAccountsOptingIn, err := account.CalculateOptingInRegionAccounts(reqLogger, r.Client)
@@ -734,7 +743,7 @@ func (r *AccountValidationReconciler) ValidateOptInRegions(reqLogger logr.Logger
 
 }
 
-func (r *AccountValidationReconciler) ValidateRegionalServiceQuotas(reqLogger logr.Logger, awsAccount *awsv1alpha1.Account, awsClientBuilder awsclient.IBuilder) error {
+func (r *AccountValidationReconciler) ValidateRegionalServiceQuotas(reqLogger logr.Logger, awsAccount *awsv1alpha1.Account, awsClientBuilder awsclient.IBuilder, disabledRegions string) error {
 	awsRegion := config.GetDefaultRegion()
 	awsSetupClient, err := awsClientBuilder.GetClient(controllerName, r.Client, awsclient.NewAwsClientInput{
 		SecretName: utils.AwsSecretName,
@@ -759,7 +768,7 @@ func (r *AccountValidationReconciler) ValidateRegionalServiceQuotas(reqLogger lo
 	regionalStatusMissing := awsAccount.Spec.RegionalServiceQuotas != nil && awsAccount.Status.RegionalServiceQuotas == nil
 	globalStatusMissing := awsAccount.Spec.GlobalServiceQuotas != nil && awsAccount.Status.GlobalServiceQuotas == nil
 	if regionalStatusMissing || globalStatusMissing {
-		err = account.SetCurrentAccountServiceQuotas(reqLogger, awsClientBuilder, awsSetupClient, awsAccount, r.Client)
+		err = account.SetCurrentAccountServiceQuotas(reqLogger, awsClientBuilder, awsSetupClient, awsAccount, r.Client, disabledRegions)
 		if err != nil {
 			reqLogger.Error(err, "failed to set account service quotas")
 			return &AccountValidationError{

--- a/controllers/validation/account_validation_controller.go
+++ b/controllers/validation/account_validation_controller.go
@@ -675,6 +675,11 @@ func (r *AccountValidationReconciler) ValidateOptInRegions(reqLogger logr.Logger
 		regionList = append(regionList, region)
 	}
 
+	if len(regionList) == 0 {
+		reqLogger.Info("No opt-in regions to validate after filtering disabled regions")
+		return nil
+	}
+
 	numberOfAccountsOptingIn, err := account.CalculateOptingInRegionAccounts(reqLogger, r.Client)
 	if err != nil {
 		return &AccountValidationError{


### PR DESCRIPTION
## Summary
- Thread `disabledRegions` ConfigMap value through `HandleNonCCSPendingVerification` → `SetCurrentAccountServiceQuotas` to skip disabled regions when seeding `Status.RegionalServiceQuotas`
- Filter disabled regions in the validation controller's `ValidateOptInRegions` to prevent re-introduction via validation reconciliation
- Export `ParseDisabledRegions` for cross-package use

## Problem
`DISABLED_REGIONS` (PR #1062) only filtered at opt-in region enablement time. During `PendingVerification`, `SetCurrentAccountServiceQuotas` calls `DescribeRegions` which returns **all** enabled regions including ME regions. This caused `servicequotas.me-central-1.amazonaws.com` and `me-south-1` endpoint timeouts (~5 min per attempt per account), burning controller time on every reconcile.

## Changes
- `controllers/account/account_controller.go` — add `disabledRegions` parameter to `HandleNonCCSPendingVerification` and `SetCurrentAccountServiceQuotas`; filter disabled regions before populating quota status map
- `controllers/account/region_enablement.go` — export `ParseDisabledRegions` (renamed from `parseDisabledRegions`)
- `controllers/validation/account_validation_controller.go` — add `disabledRegions` to `ValidateOptInRegions` and `ValidateRegionalServiceQuotas`; filter disabled regions from opt-in region list

## Backwards Compatibility
If the `disabled-regions` ConfigMap key is missing or empty, `ParseDisabledRegions("")` returns an empty map — no regions are skipped. Fully backwards compatible.

## In-flight Account Impact
This fix only affects **new** accounts entering `PendingVerification`. Existing accounts that already have ME regions in `Status.RegionalServiceQuotas` will continue retrying but clear naturally via timeout or success. No need to fail in-flight accounts after rollout.

## Test plan
- [ ] `go test ./controllers/account/` passes
- [ ] `go test ./controllers/validation/` passes
- [ ] `go build ./...` clean
- [ ] Verify ME regions no longer appear in `Status.RegionalServiceQuotas` for newly created accounts on staging
- [ ] Verify accounts without `disabled-regions` ConfigMap key behave unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configuring disabled regions during account reconciliation.
  * Disabled regions are now excluded from opt-in region validation and regional service-quota processing.
  * Region configuration parsing is available through an exported helper for broader integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->