### PR TITLE
fix: filter disabled regions from quota update and validation paths

### DIFF
--- a/controllers/account/account_controller.go
+++ b/controllers/account/account_controller.go
@@ -885,7 +885,7 @@ func (r *AccountReconciler) HandleNonCCSPendingVerification(reqLogger logr.Logge
 	if currentAcctInstance.HasOpenQuotaIncreaseRequests() {
 		switch utils.DetectDevMode {
 		case utils.DevModeProduction:
-			return GetServiceQuotaRequest(reqLogger, r.awsClientBuilder, awsSetupClient, currentAcctInstance, r.Client)
+			return GetServiceQuotaRequest(reqLogger, r.awsClientBuilder, awsSetupClient, currentAcctInstance, r.Client, disabledRegions)
 		}
 	}
 

--- a/controllers/account/account_controller_test.go
+++ b/controllers/account/account_controller_test.go
@@ -2961,6 +2961,64 @@ var _ = Describe("Account Controller", func() {
 					Expect(account.Status.State).To(Equal(AccountFailed),
 						"account should be failed when global quota request is denied")
 				})
+				It("removes disabled regions from account status during quota processing", func() {
+					account = &newTestAccountBuilder().BYOC(false).
+						WithState(awsv1alpha1.AccountPendingVerification).WithAwsAccountID("4321").acct
+					account.Status.RegionalServiceQuotas = awsv1alpha1.RegionalServiceQuotas{
+						"us-east-1": awsv1alpha1.AccountServiceQuota{
+							awsv1alpha1.RunningStandardInstances: &awsv1alpha1.ServiceQuotaStatus{
+								Value:  500,
+								Status: awsv1alpha1.ServiceRequestInProgress,
+							},
+						},
+						"me-south-1": awsv1alpha1.AccountServiceQuota{
+							awsv1alpha1.RunningStandardInstances: &awsv1alpha1.ServiceQuotaStatus{
+								Value:  500,
+								Status: awsv1alpha1.ServiceRequestInProgress,
+							},
+						},
+						"me-central-1": awsv1alpha1.AccountServiceQuota{
+							awsv1alpha1.RunningStandardInstances: &awsv1alpha1.ServiceQuotaStatus{
+								Value:  500,
+								Status: awsv1alpha1.ServiceRequestTodo,
+							},
+						},
+					}
+					r.Client = fake.NewClientBuilder().WithScheme(scheme.Scheme).WithRuntimeObjects([]runtime.Object{account, configMap}...).Build()
+
+					subClient := mock.NewMockClient(ctrl)
+					AssumeRoleAndCreateClient = func(
+						reqLogger logr.Logger,
+						awsClientBuilder awsclient.IBuilder,
+						currentAcctInstance *awsv1alpha1.Account,
+						client client.Client,
+						awsSetupClient awsclient.Client,
+						region string,
+						roleToAssume string,
+						ccsRoleID string) (awsclient.Client, *sts.AssumeRoleOutput, error) {
+						Expect(region).ToNot(HavePrefix("me-"), "should never assume role in disabled ME region")
+						return subClient, &sts.AssumeRoleOutput{}, nil
+					}
+
+					subClient.EXPECT().GetServiceQuota(gomock.Any(), gomock.Any()).Return(&servicequotas.GetServiceQuotaOutput{
+						Quota: &servicequotastypes.ServiceQuota{
+							QuotaCode: aws.String(string(awsv1alpha1.RunningStandardInstances)),
+							Value:     aws.Float64(500),
+						},
+					}, nil).AnyTimes()
+					subClient.EXPECT().ListRequestedServiceQuotaChangeHistoryByQuota(gomock.Any(), gomock.Any()).Return(
+						&servicequotas.ListRequestedServiceQuotaChangeHistoryByQuotaOutput{
+							RequestedQuotas: []servicequotastypes.RequestedServiceQuotaChange{},
+						}, nil).AnyTimes()
+
+					_, err := GetServiceQuotaRequest(nullLogger, r.awsClientBuilder, mockAWSClient, account, r.Client, "me-south-1,me-central-1")
+					Expect(err).ToNot(HaveOccurred())
+					Expect(account.Status.RegionalServiceQuotas).To(HaveKey("us-east-1"))
+					Expect(account.Status.RegionalServiceQuotas).ToNot(HaveKey("me-south-1"),
+						"disabled region me-south-1 should be removed from status")
+					Expect(account.Status.RegionalServiceQuotas).ToNot(HaveKey("me-central-1"),
+						"disabled region me-central-1 should be removed from status")
+				})
 			})
 		})
 	})

--- a/controllers/account/service_quota.go
+++ b/controllers/account/service_quota.go
@@ -379,7 +379,18 @@ func changeRequestMatches(change servicequotastypes.RequestedServiceQuotaChange,
 	return true
 }
 
-func GetServiceQuotaRequest(reqLogger logr.Logger, awsClientBuilder awsclient.IBuilder, awsSetupClient awsclient.Client, currentAcctInstance *awsv1alpha1.Account, client client.Client) (reconcile.Result, error) {
+func GetServiceQuotaRequest(reqLogger logr.Logger, awsClientBuilder awsclient.IBuilder, awsSetupClient awsclient.Client, currentAcctInstance *awsv1alpha1.Account, client client.Client, disabledRegions string) (reconcile.Result, error) {
+	disabled := ParseDisabledRegions(disabledRegions)
+
+	// Remove disabled regions from the account status so they no longer
+	// block progress (HasOpenQuotaIncreaseRequests checks status directly).
+	for region := range currentAcctInstance.Status.RegionalServiceQuotas {
+		if disabled[region] {
+			reqLogger.Info("Removing disabled region from quota status", "region", region)
+			delete(currentAcctInstance.Status.RegionalServiceQuotas, region)
+		}
+	}
+
 	// Collect in-flight and pending requests for both regional and global quotas.
 	regionalInFlightCount, inFlightRegional := currentAcctInstance.GetQuotaRequestsByStatus(awsv1alpha1.ServiceRequestInProgress)
 	globalInFlightCount, inFlightGlobal := currentAcctInstance.GetGlobalQuotaRequestsByStatus(awsv1alpha1.ServiceRequestInProgress)

--- a/controllers/validation/account_validation_controller.go
+++ b/controllers/validation/account_validation_controller.go
@@ -796,7 +796,7 @@ func (r *AccountValidationReconciler) ValidateRegionalServiceQuotas(reqLogger lo
 	}
 
 	if awsAccount.HasOpenQuotaIncreaseRequests() && utils.DetectDevMode == utils.DevModeProduction {
-		_, err = account.GetServiceQuotaRequest(reqLogger, awsClientBuilder, awsSetupClient, awsAccount, r.Client)
+		_, err = account.GetServiceQuotaRequest(reqLogger, awsClientBuilder, awsSetupClient, awsAccount, r.Client, disabledRegions)
 		if err != nil {
 			return &AccountValidationError{
 				Type: NotAllServicequotasApplied,


### PR DESCRIPTION
## Summary
- Closes the gap where `GetServiceQuotaRequest` (used by both account and validation controllers) iterated over ME regions already in `status.RegionalServiceQuotas`, causing 5-min timeouts on every reconcile
- Disabled regions are now deleted from the account's status at the top of `GetServiceQuotaRequest`, preventing API calls to unreachable endpoints and unblocking `HasOpenQuotaIncreaseRequests` so accounts can progress to Ready
- Self-healing: 82+ existing Ready accounts with ME contamination will auto-clean on their next validation cycle
- Fully backwards compatible — empty `disabled-regions` ConfigMap key means no regions filtered

Follows up on #1064 which filtered disabled regions in the creation path (`SetCurrentAccountServiceQuotas`) and opt-in validation (`ValidateOptInRegions`) but missed the quota update path (`GetServiceQuotaRequest` → `UpdateServiceQuotaRequests`).

## Test plan
- [x] New Ginkgo test: seeds account with ME regions in status, calls `GetServiceQuotaRequest` with disabled regions, verifies ME removed from status and never passed to `AssumeRole`
- [x] Existing tests pass (`go test ./controllers/account/ ./controllers/validation/`)
- [x] `go build ./...` clean
- [x] `golangci-lint` zero issues
- [x] Verified on int cluster: recovered accounts going through clean path with no ME hits

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Disabled regions are now excluded from regional service quota processing.
  * Pending quota requests no longer remain blocked by regions that are unavailable or disabled.
  * Account status now removes quota entries for disabled regions while retaining enabled-region information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->