### PR TITLE
fix: scrub disabled regions on validation and force quota rebuild on reuse

### DIFF
--- a/controllers/accountclaim/accountclaim_finalizer_test.go
+++ b/controllers/accountclaim/accountclaim_finalizer_test.go
@@ -253,7 +253,7 @@ var _ = Describe("resetAccountSpecStatus", func() {
 
 	err := apis.AddToScheme(scheme.Scheme)
 	if err != nil {
-		fmt.Printf("failed adding apis to scheme in reuse tests")
+		panic(fmt.Sprintf("failed adding apis to scheme in reuse tests: %v", err))
 	}
 	localmetrics.Collector = localmetrics.NewMetricsCollector(nil)
 

--- a/controllers/accountclaim/accountclaim_finalizer_test.go
+++ b/controllers/accountclaim/accountclaim_finalizer_test.go
@@ -243,3 +243,128 @@ var _ = Describe("AccountClaim", func() {
 		})
 	})
 })
+
+var _ = Describe("resetAccountSpecStatus", func() {
+	var (
+		nullLogger = testutils.NewTestLogger().Logger()
+		r          *AccountClaimReconciler
+		ctrl       *gomock.Controller
+	)
+
+	err := apis.AddToScheme(scheme.Scheme)
+	if err != nil {
+		fmt.Printf("failed adding apis to scheme in reuse tests")
+	}
+	localmetrics.Collector = localmetrics.NewMetricsCollector(nil)
+
+	BeforeEach(func() {
+		ctrl = gomock.NewController(GinkgoT())
+		r = &AccountClaimReconciler{
+			Scheme: scheme.Scheme,
+			awsClientBuilder: &mock.Builder{
+				MockController: ctrl,
+			},
+		}
+	})
+
+	AfterEach(func() {
+		ctrl.Finish()
+	})
+
+	It("clears RegionalServiceQuotas and SupportCaseID on reuse", func() {
+		reusedAccount := &v1alpha1.Account{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "osd-creds-mgmt-test123",
+				Namespace: v1alpha1.AccountCrNamespace,
+			},
+			Spec: v1alpha1.AccountSpec{
+				AwsAccountID: "123456789012",
+				LegalEntity: v1alpha1.LegalEntity{
+					ID:   "existing-entity",
+					Name: "Existing Corp",
+				},
+				ClaimLink:          "old-claim",
+				ClaimLinkNamespace: "old-namespace",
+			},
+			Status: v1alpha1.AccountStatus{
+				State:   "Ready",
+				Claimed: true,
+				RegionalServiceQuotas: v1alpha1.RegionalServiceQuotas{
+					"us-east-1":  {"L-1216C47A": {Value: 100, Status: v1alpha1.ServiceRequestCompleted}},
+					"me-south-1": {"L-1216C47A": {Value: 100, Status: v1alpha1.ServiceRequestCompleted}},
+				},
+				SupportCaseID: "case-12345",
+			},
+		}
+
+		deletedClaim := &v1alpha1.AccountClaim{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "deleted-claim",
+				Namespace: "claim-namespace",
+			},
+			Spec: v1alpha1.AccountClaimSpec{
+				LegalEntity: v1alpha1.LegalEntity{
+					ID:   "claim-entity",
+					Name: "Claim Corp",
+				},
+			},
+		}
+
+		objs := []runtime.Object{reusedAccount}
+		r.Client = fake.NewClientBuilder().WithScheme(scheme.Scheme).WithRuntimeObjects(objs...).Build()
+
+		err := r.resetAccountSpecStatus(nullLogger, reusedAccount, deletedClaim, v1alpha1.AccountReused, "Ready")
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(reusedAccount.Status.RegionalServiceQuotas).To(BeNil())
+		Expect(reusedAccount.Status.SupportCaseID).To(BeEmpty())
+		Expect(reusedAccount.Status.RotateCredentials).To(BeTrue())
+		Expect(reusedAccount.Status.RotateConsoleCredentials).To(BeTrue())
+		Expect(reusedAccount.Spec.ClaimLink).To(BeEmpty())
+		Expect(reusedAccount.Spec.ClaimLinkNamespace).To(BeEmpty())
+		// LegalEntity should be preserved when already set
+		Expect(reusedAccount.Spec.LegalEntity.ID).To(Equal("existing-entity"))
+	})
+
+	It("carries over LegalEntity from claim when account has none", func() {
+		reusedAccount := &v1alpha1.Account{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "osd-creds-mgmt-test456",
+				Namespace: v1alpha1.AccountCrNamespace,
+			},
+			Spec: v1alpha1.AccountSpec{
+				AwsAccountID:       "123456789012",
+				ClaimLink:          "old-claim",
+				ClaimLinkNamespace: "old-namespace",
+			},
+			Status: v1alpha1.AccountStatus{
+				State:   "Ready",
+				Claimed: true,
+			},
+		}
+
+		deletedClaim := &v1alpha1.AccountClaim{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "deleted-claim",
+				Namespace: "claim-namespace",
+			},
+			Spec: v1alpha1.AccountClaimSpec{
+				LegalEntity: v1alpha1.LegalEntity{
+					ID:   "claim-entity",
+					Name: "Claim Corp",
+				},
+			},
+		}
+
+		objs := []runtime.Object{reusedAccount}
+		r.Client = fake.NewClientBuilder().WithScheme(scheme.Scheme).WithRuntimeObjects(objs...).Build()
+
+		err := r.resetAccountSpecStatus(nullLogger, reusedAccount, deletedClaim, v1alpha1.AccountReused, "Ready")
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(reusedAccount.Spec.LegalEntity.ID).To(Equal("claim-entity"))
+		Expect(reusedAccount.Spec.LegalEntity.Name).To(Equal("Claim Corp"))
+		Expect(reusedAccount.Status.RegionalServiceQuotas).To(BeNil())
+		Expect(reusedAccount.Status.SupportCaseID).To(BeEmpty())
+	})
+})

--- a/controllers/accountclaim/reuse.go
+++ b/controllers/accountclaim/reuse.go
@@ -233,6 +233,11 @@ func (r *AccountClaimReconciler) resetAccountSpecStatus(reqLogger logr.Logger, r
 		"Setting RotateCredentials and RotateConsoleCredentials for account %s", reusedAccount.Spec.AwsAccountID))
 	reusedAccount.Status.RotateConsoleCredentials = true
 	reusedAccount.Status.RotateCredentials = true
+	// Force quota map rebuild on next validation to reflect current disabled-regions config
+	reusedAccount.Status.RegionalServiceQuotas = nil
+	// Clear stale case ID from previous lifecycle so it can't cause the account
+	// controller to skip quota setup if this account ever re-enters the creation pipeline
+	reusedAccount.Status.SupportCaseID = ""
 
 	// Update account status and add conditions indicating account reuse
 	reusedAccount.Status.State = conditionStatus

--- a/controllers/validation/account_validation_controller.go
+++ b/controllers/validation/account_validation_controller.go
@@ -769,6 +769,30 @@ func (r *AccountValidationReconciler) ValidateRegionalServiceQuotas(reqLogger lo
 		return nil
 	}
 
+	// Scrub disabled regions from the quota map on every validation pass.
+	// Accounts can carry stale region entries through reuse, recovery, or
+	// config changes — this ensures they are always cleaned out regardless
+	// of how the account entered the pipeline.
+	if awsAccount.Status.RegionalServiceQuotas != nil && disabledRegions != "" {
+		disabled := account.ParseDisabledRegions(disabledRegions)
+		dirty := false
+		for region := range awsAccount.Status.RegionalServiceQuotas {
+			if disabled[region] {
+				reqLogger.Info("Removing disabled region from quota status", "region", region)
+				delete(awsAccount.Status.RegionalServiceQuotas, region)
+				dirty = true
+			}
+		}
+		if dirty {
+			if err := r.statusUpdate(awsAccount); err != nil {
+				return &AccountValidationError{
+					Type: QuotaStatus,
+					Err:  fmt.Errorf("failed to update account status after removing disabled regions: %w", err),
+				}
+			}
+		}
+	}
+
 	// If status quota fields have not been populated yet, expand them from spec and re-queue.
 	regionalStatusMissing := awsAccount.Spec.RegionalServiceQuotas != nil && awsAccount.Status.RegionalServiceQuotas == nil
 	globalStatusMissing := awsAccount.Spec.GlobalServiceQuotas != nil && awsAccount.Status.GlobalServiceQuotas == nil

--- a/controllers/validation/account_validation_controller.go
+++ b/controllers/validation/account_validation_controller.go
@@ -749,27 +749,13 @@ func (r *AccountValidationReconciler) ValidateOptInRegions(reqLogger logr.Logger
 }
 
 func (r *AccountValidationReconciler) ValidateRegionalServiceQuotas(reqLogger logr.Logger, awsAccount *awsv1alpha1.Account, awsClientBuilder awsclient.IBuilder, disabledRegions string) error {
-	awsRegion := config.GetDefaultRegion()
-	awsSetupClient, err := awsClientBuilder.GetClient(controllerName, r.Client, awsclient.NewAwsClientInput{
-		SecretName: utils.AwsSecretName,
-		NameSpace:  awsv1alpha1.AccountCrNamespace,
-		AwsRegion:  awsRegion,
-	})
-	if err != nil {
-		connErr := fmt.Sprintf("unable to connect to default region %s", awsRegion)
-		reqLogger.Error(err, connErr)
-		return &AccountValidationError{
-			Type: AWSErrorConnecting,
-			Err:  errors.New("unexpected error attempting to connect to AWS in default region"),
-		}
-	}
-
 	// Return early if no quotas (regional or global) are configured in the spec.
 	if awsAccount.Spec.RegionalServiceQuotas == nil && awsAccount.Spec.GlobalServiceQuotas == nil {
 		return nil
 	}
 
 	// Scrub disabled regions from the quota map on every validation pass.
+	// This runs before GetClient so cleanup succeeds even when AWS is unreachable.
 	// Accounts can carry stale region entries through reuse, recovery, or
 	// config changes — this ensures they are always cleaned out regardless
 	// of how the account entered the pipeline.
@@ -790,6 +776,21 @@ func (r *AccountValidationReconciler) ValidateRegionalServiceQuotas(reqLogger lo
 					Err:  fmt.Errorf("failed to update account status after removing disabled regions: %w", err),
 				}
 			}
+		}
+	}
+
+	awsRegion := config.GetDefaultRegion()
+	awsSetupClient, err := awsClientBuilder.GetClient(controllerName, r.Client, awsclient.NewAwsClientInput{
+		SecretName: utils.AwsSecretName,
+		NameSpace:  awsv1alpha1.AccountCrNamespace,
+		AwsRegion:  awsRegion,
+	})
+	if err != nil {
+		connErr := fmt.Sprintf("unable to connect to default region %s", awsRegion)
+		reqLogger.Error(err, connErr)
+		return &AccountValidationError{
+			Type: AWSErrorConnecting,
+			Err:  errors.New("unexpected error attempting to connect to AWS in default region"),
 		}
 	}
 

--- a/controllers/validation/account_validation_controller_test.go
+++ b/controllers/validation/account_validation_controller_test.go
@@ -25,6 +25,7 @@ import (
 	awsv1alpha1 "github.com/openshift/aws-account-operator/api/v1alpha1"
 	"github.com/openshift/aws-account-operator/pkg/awsclient"
 	"github.com/openshift/aws-account-operator/pkg/awsclient/mock"
+	"github.com/openshift/aws-account-operator/pkg/testutils"
 )
 
 func emptyOrganisation(ctrl *gomock.Controller) *mock.MockClient {
@@ -1196,6 +1197,108 @@ func TestValidateRemoval(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if err := ValidateRemoval(tt.args.account); (err != nil) != tt.wantErr {
 				t.Errorf("ValidateRemoval() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestValidateRegionalServiceQuotas_ScrubsDisabledRegions(t *testing.T) {
+	err := apis.AddToScheme(scheme.Scheme)
+	if err != nil {
+		t.Fatalf("failed adding to scheme: %v", err)
+	}
+
+	tests := []struct {
+		name            string
+		disabledRegions string
+		statusQuotas    awsv1alpha1.RegionalServiceQuotas
+		expectedRegions []string
+		removedRegions  []string
+	}{
+		{
+			name:            "removes disabled regions from quota map",
+			disabledRegions: "me-south-1,me-central-1",
+			statusQuotas: awsv1alpha1.RegionalServiceQuotas{
+				"us-east-1":    {"L-1216C47A": {Value: 100, Status: awsv1alpha1.ServiceRequestCompleted}},
+				"eu-west-1":    {"L-1216C47A": {Value: 100, Status: awsv1alpha1.ServiceRequestCompleted}},
+				"me-south-1":   {"L-1216C47A": {Value: 100, Status: awsv1alpha1.ServiceRequestCompleted}},
+				"me-central-1": {"L-1216C47A": {Value: 100, Status: awsv1alpha1.ServiceRequestCompleted}},
+			},
+			expectedRegions: []string{"us-east-1", "eu-west-1"},
+			removedRegions:  []string{"me-south-1", "me-central-1"},
+		},
+		{
+			name:            "no-op when no disabled regions match quota map",
+			disabledRegions: "me-south-1",
+			statusQuotas: awsv1alpha1.RegionalServiceQuotas{
+				"us-east-1": {"L-1216C47A": {Value: 100, Status: awsv1alpha1.ServiceRequestCompleted}},
+				"eu-west-1": {"L-1216C47A": {Value: 100, Status: awsv1alpha1.ServiceRequestCompleted}},
+			},
+			expectedRegions: []string{"us-east-1", "eu-west-1"},
+			removedRegions:  []string{},
+		},
+		{
+			name:            "no-op when disabled regions config is empty",
+			disabledRegions: "",
+			statusQuotas: awsv1alpha1.RegionalServiceQuotas{
+				"us-east-1":  {"L-1216C47A": {Value: 100, Status: awsv1alpha1.ServiceRequestCompleted}},
+				"me-south-1": {"L-1216C47A": {Value: 100, Status: awsv1alpha1.ServiceRequestCompleted}},
+			},
+			expectedRegions: []string{"us-east-1", "me-south-1"},
+			removedRegions:  []string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			acct := &awsv1alpha1.Account{
+				ObjectMeta: v1.ObjectMeta{
+					Name:      "test-account",
+					Namespace: awsv1alpha1.AccountCrNamespace,
+				},
+				Spec: awsv1alpha1.AccountSpec{
+					AwsAccountID: "123456789012",
+					RegionalServiceQuotas: awsv1alpha1.RegionalServiceQuotas{
+						"us-east-1": {"L-1216C47A": {Value: 100}},
+					},
+				},
+				Status: awsv1alpha1.AccountStatus{
+					RegionalServiceQuotas: tt.statusQuotas,
+				},
+			}
+
+			fakeClient := fake.NewClientBuilder().
+				WithScheme(scheme.Scheme).
+				WithRuntimeObjects(acct).
+				Build()
+
+			mockBuilder := mock.NewMockIBuilder(ctrl)
+			mockAWSClient := mock.NewMockClient(ctrl)
+			mockBuilder.EXPECT().GetClient(gomock.Any(), gomock.Any(), gomock.Any()).Return(mockAWSClient, nil)
+
+			r := &AccountValidationReconciler{
+				Client: fakeClient,
+				Scheme: scheme.Scheme,
+			}
+
+			nullLogger := testutils.NewTestLogger().Logger()
+			err := r.ValidateRegionalServiceQuotas(nullLogger, acct, mockBuilder, tt.disabledRegions)
+			if err != nil {
+				t.Errorf("ValidateRegionalServiceQuotas() unexpected error: %v", err)
+			}
+
+			for _, region := range tt.expectedRegions {
+				if _, ok := acct.Status.RegionalServiceQuotas[region]; !ok {
+					t.Errorf("expected region %s to be present in quota map", region)
+				}
+			}
+			for _, region := range tt.removedRegions {
+				if _, ok := acct.Status.RegionalServiceQuotas[region]; ok {
+					t.Errorf("expected region %s to be removed from quota map", region)
+				}
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

- Scrub disabled regions from `status.regionalServiceQuotas` on every validation controller pass — pure in-memory delete + status update, zero AWS API calls
- Null `RegionalServiceQuotas` and clear `SupportCaseID` in `resetAccountSpecStatus` on account reuse, forcing a clean quota map rebuild from `DescribeRegions` with current config
- Add tests for both changes (validation scrub test + reuse field clearing test)

Builds on top of PR #1066 (defense in depth for the account controller creation path). This PR covers the validation controller and reuse paths.

## Scenario Coverage

### Adding regions to `DISABLED_REGIONS` (scrub ME off)

| Scenario | How it's handled |
|---|---|
| **New account created** | `SetCurrentAccountServiceQuotas` already skips disabled regions during initial expansion via `ParseDisabledRegions`. No change needed. |
| **Failed account recovered** (recovery script) | Script patches `regionalServiceQuotas: null`. Rebuild uses current config — ME excluded. |
| **Idle Ready account with stale ME entries** | Validation controller scrubs ME entries on next reconciliation pass. No AWS API calls. |
| **Account reused by same legal entity** | `resetAccountSpecStatus` nulls the quota map. Next validation rebuilds fresh from `DescribeRegions`, excluding disabled regions. LegalEntity is preserved. |
| **LegalEntity patched to "" (anyone can claim)** | Validation controller scrubs ME entries. When eventually claimed and reused, `resetAccountSpecStatus` nulls and forces clean rebuild. |

### Removing regions from `DISABLED_REGIONS` (add ME back)

| Scenario | How it's handled |
|---|---|
| **New account created** | `SetCurrentAccountServiceQuotas` includes ME from `DescribeRegions` since disabled set is empty. |
| **Failed account recovered** | Script patches `regionalServiceQuotas: null`. Rebuild includes ME. |
| **Idle Ready account without ME** | ME stays absent until account is reused — idle accounts aren't serving clusters, so this is safe. On next reuse cycle, `resetAccountSpecStatus` nulls the map → rebuild includes ME. |
| **Account reused by same legal entity** | `resetAccountSpecStatus` nulls → rebuild includes ME automatically. |
| **LegalEntity patched to ""** | Same as idle — ME added back on next reuse cycle. |

## What's NOT affected

- **Accounts actively in use** (claimed, running a cluster) — validation controller skips non-Ready accounts, reuse path only runs on finalizer cleanup. No risk to in-flight workloads.
- **BYOC/CCS accounts** — validation controller skips BYOC at the top of `Reconcile()`.
- **No thundering herd** — validation scrub is a no-op for accounts without disabled region entries. Accounts trickle through naturally.

## Changes

- `controllers/validation/account_validation_controller.go` — scrub block after spec nil check, before `regionalStatusMissing` check
- `controllers/accountclaim/reuse.go` — null `RegionalServiceQuotas` and clear `SupportCaseID` in `resetAccountSpecStatus`
- `controllers/validation/account_validation_controller_test.go` — 3 sub-tests: scrubs ME, no-op when regions don't match, no-op when config empty
- `controllers/accountclaim/accountclaim_finalizer_test.go` — 2 Ginkgo specs: clears quota/supportCaseID on reuse, carries over LegalEntity when account has none

## Test plan

- [x] `go test ./controllers/validation/` — all pass including new scrub test
- [x] `go test ./controllers/accountclaim/` — all 45 Ginkgo specs pass including new reuse tests
- [x] `go build ./...` — compiles clean
- [x] golangci-lint passes
- [ ] CI/Prow full suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Account reuse now clears regional quota assignments and support case references while rotating credentials.
  * Regional quota validation removes disabled regions from existing account status and reports persistence failures.
  * Account legal-entity information is preserved or restored when reusing an account.
* **Tests**
  * Added coverage for account reuse cleanup and disabled-region quota handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->