### PR TITLE
chore: bump ubi-minimal base image to 9.8-1786380870

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -10,7 +10,7 @@ WORKDIR ${OPERATOR_PATH}
 
 RUN make go-build FIPS_ENABLED=${FIPS_ENABLED}
 
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.8-1785906621
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.8-1786380870
 ENV OPERATOR_BIN=aws-account-operator
 
 WORKDIR /root/

--- a/build/Dockerfile.olm-registry
+++ b/build/Dockerfile.olm-registry
@@ -4,7 +4,7 @@ COPY ${SAAS_OPERATOR_DIR} manifests
 RUN initializer --permissive
 
 # ubi-micro does not work for clusters with fips enabled unless we make OpenSSL available
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.8-1785906621
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.8-1786380870
 
 COPY --from=builder /bin/registry-server /bin/registry-server
 COPY --from=builder /bin/grpc_health_probe /bin/grpc_health_probe


### PR DESCRIPTION
## Summary

- Boilerplate update: bumps `ubi9/ubi-minimal` base image from `9.8-1785906621` to `9.8-1786380870` in both Dockerfiles
- Required to unblock CI `validate` check on other PRs

## Test plan

- [ ] CI validate passes (this is the fix for it)
- No code changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)