### PR TITLE
Revert "fix: refine ClusterRole permissions for ROSAENG-61347 (#1071)"

### DIFF
--- a/deploy/cluster_role.yaml
+++ b/deploy/cluster_role.yaml
@@ -7,28 +7,30 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - pods
+  - services
+  - endpoints
+  - persistentvolumeclaims
+  - events
+  - configmaps
   - secrets
   verbs:
-  - get
-  - list
-  - watch
-  - create
-  - update
-  - delete
-- apiGroups:
-  - ""
-  resources:
-  - configmaps
-  verbs:
-  - get
-  - list
-  - watch
+  - '*'
 - apiGroups:
   - ""
   resources:
   - namespaces
   verbs:
   - get
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  - daemonsets
+  - replicasets
+  - statefulsets
+  verbs:
+  - '*'
 - apiGroups:
   - monitoring.coreos.com
   resources:
@@ -45,5 +47,11 @@ rules:
   - accountpools
   - awsfederatedaccountaccesses
   - awsfederatedroles
+  verbs:
+  - '*'
+- apiGroups:
+  - route.openshift.io
+  resources:
+  - routes
   verbs:
   - '*'

--- a/deploy_pko/ClusterRole-aws-account-operator.yaml
+++ b/deploy_pko/ClusterRole-aws-account-operator.yaml
@@ -10,28 +10,30 @@ rules:
 - apiGroups:
   - ''
   resources:
+  - pods
+  - services
+  - endpoints
+  - persistentvolumeclaims
+  - events
+  - configmaps
   - secrets
   verbs:
-  - get
-  - list
-  - watch
-  - create
-  - update
-  - delete
-- apiGroups:
-  - ''
-  resources:
-  - configmaps
-  verbs:
-  - get
-  - list
-  - watch
+  - '*'
 - apiGroups:
   - ''
   resources:
   - namespaces
   verbs:
   - get
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  - daemonsets
+  - replicasets
+  - statefulsets
+  verbs:
+  - '*'
 - apiGroups:
   - monitoring.coreos.com
   resources:
@@ -48,5 +50,11 @@ rules:
   - accountpools
   - awsfederatedaccountaccesses
   - awsfederatedroles
+  verbs:
+  - '*'
+- apiGroups:
+  - route.openshift.io
+  resources:
+  - routes
   verbs:
   - '*'


### PR DESCRIPTION
## Summary

Reverts #1071. That change removed the `pods` resource (among others) from the operator's ClusterRole, but the operator-framework `operator-lib` leader-election library requires `get` on its own Pod at startup to establish ownership of the leader-election lock. Without it, the operator crash-loops on every pod restart.

## Evidence

Observed on hivei01ue1 immediately after rollout:

```
ERROR	leader	Failed to get Pod	{"Pod.Namespace": "aws-account-operator", "Pod.Name": "aws-account-operator-7b5cf6c69f-skkcf", "error": "pods \"aws-account-operator-7b5cf6c69f-skkcf\" is forbidden: User \"system:serviceaccount:aws-account-operator:aws-account-operator\" cannot get resource \"pods\" in API group \"\" in the namespace \"aws-account-operator\""}
...
ERROR	setup	Unable to become leader
```

Pod entered a crash-loop (exit code 1, restart backoff) as a direct result.

## Plan

Reverting now to restore service. The permission-narrowing work in #1071 will be reopened as a follow-up with `pods: get` (scoped appropriately) retained for leader election, since that dependency lives in the vendored `operator-lib` package and isn't visible to a search of `controllers/`.

## Testing

- ✅ `make test` passing on the revert

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improved Compatibility**
  * Expanded platform permissions to support managing workloads, networking resources, storage, configuration, and secrets more reliably.
  * Improved support for OpenShift routes and common application components.

* **Maintenance**
  * Added automated weekly checks for container dependency updates.
  * Updated build and validation tooling to newer supported revisions.
  * Corrected the default build image version used by the release process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->