### PR TITLE
EDIT: TEST DO NOT MERGE refine ClusterRole permissions for ROSAENG-61347 (v2)

### DIFF
--- a/deploy/cluster_role.yaml
+++ b/deploy/cluster_role.yaml
@@ -7,30 +7,52 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - pods
-  - services
-  - endpoints
-  - persistentvolumeclaims
-  - events
-  - configmaps
   - secrets
   verbs:
-  - '*'
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - services
+  verbs:
+  - get
+  - create
+  - update
 - apiGroups:
   - ""
   resources:
   - namespaces
   verbs:
   - get
-- apiGroups:
-  - apps
-  resources:
-  - deployments
-  - daemonsets
-  - replicasets
-  - statefulsets
-  verbs:
-  - '*'
 - apiGroups:
   - monitoring.coreos.com
   resources:
@@ -54,4 +76,6 @@ rules:
   resources:
   - routes
   verbs:
-  - '*'
+  - get
+  - create
+  - update

--- a/deploy_pko/ClusterRole-aws-account-operator.yaml
+++ b/deploy_pko/ClusterRole-aws-account-operator.yaml
@@ -10,30 +10,52 @@ rules:
 - apiGroups:
   - ''
   resources:
-  - pods
-  - services
-  - endpoints
-  - persistentvolumeclaims
-  - events
-  - configmaps
   - secrets
   verbs:
-  - '*'
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - delete
+- apiGroups:
+  - ''
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - delete
+- apiGroups:
+  - ''
+  resources:
+  - pods
+  verbs:
+  - get
+  - delete
+- apiGroups:
+  - ''
+  resources:
+  - nodes
+  verbs:
+  - get
+- apiGroups:
+  - ''
+  resources:
+  - services
+  verbs:
+  - get
+  - create
+  - update
 - apiGroups:
   - ''
   resources:
   - namespaces
   verbs:
   - get
-- apiGroups:
-  - apps
-  resources:
-  - deployments
-  - daemonsets
-  - replicasets
-  - statefulsets
-  verbs:
-  - '*'
 - apiGroups:
   - monitoring.coreos.com
   resources:
@@ -57,4 +79,6 @@ rules:
   resources:
   - routes
   verbs:
-  - '*'
+  - get
+  - create
+  - update


### PR DESCRIPTION
## Summary

Redo of the ClusterRole permission narrowing for [ROSAENG-61347](https://redhat.atlassian.net/browse/ROSAENG-61347). The first attempt (#1071) removed too much and crash-looped on hivei01ue1 within a minute of rollout; it was reverted in #1073. This version was built by tracing every Kubernetes API call across the **entire binary** — not just the reconcilers in `controllers/` — before touching the manifest.

## What went wrong last time

The first attempt only searched `controllers/` for resource usage and removed `pods`, `services`, and `route.openshift.io/routes` entirely. Two framework-level dependencies in `main.go` were missed because they aren't invoked from any reconciler:

- **Leader election** (`operator-framework/operator-lib`, direct/uncached client): calls `Get` on the operator's own Pod to establish lock ownership, then `Create`s a ConfigMap lock. Missing `pods: get` caused the crash (`Unable to become leader` → `os.Exit(1)`); missing `configmaps: create` would have been the *next* crash immediately after.
- **Metrics** (`openshift/operator-custom-metrics`, direct/uncached client): unconditionally creates/updates a Service, and — since `.WithRoute()` is set — a Route. Both failures are fatal (`os.Exit(1)`) despite a stale code comment claiming otherwise.

## What's different this time

Traced every API call in `main.go`, the vendored `operator-lib` leader package, and `operator-custom-metrics`, in addition to the reconcilers, before writing any RBAC. Applied to both `deploy/cluster_role.yaml` and `deploy_pko/ClusterRole-aws-account-operator.yaml`:

| Resource | Verbs | Why |
|---|---|---|
| `secrets` | get, list, watch, create, update, delete | Reconcilers — cross-namespace IAM credential management |
| `configmaps` | get, list, watch, create, update, delete | Reconciler reads + leader-election lock (create) + CCS-Access-Arn write in `main.go` |
| `pods` | get, delete | Leader election: get own pod (fatal path), delete evicted leader pod (non-fatal edge case) |
| `nodes` | get | Leader election: detect NotReady node holding a stale lock |
| `services` | get, create, update | Metrics library — unconditional Service create/update |
| `route.openshift.io/routes` | get, create, update | Metrics library — Route create/update (`.WithRoute()` is active) |
| `servicemonitors` | get, create | Unchanged — ServiceMonitor path is inactive in this operator |
| `namespaces` | get | Unchanged |

Confirmed zero usage anywhere in the binary (not just `controllers/`) for `endpoints`, `persistentvolumeclaims`, `events`, and all `apps/v1` resources — these remain removed, along with all wildcard (`*`) verbs.

## Testing

- ✅ `make test` / `make lint` pass
- ✅ **Live cluster validation**: deployed to a personal test cluster with this exact ClusterRole. Pod reached `1/1 Running` and stayed there with `0` restarts for 20+ minutes. Logs confirm:
  - `Trying to become the leader.` → `No pre-existing lock was found.` → `Became the leader.`
  - `Generated metrics service object` → `Metrics Service object created`
  - `Generated metrics route object` → `Metrics Route object Created`
  - All 5 controllers (AccountClaim, Account, AccountPool, AWSFederatedRole, AWSFederatedAccountAccess) started their EventSources/watches
  - Zero `forbidden`/`denied` errors in the logs. The only errors present are unrelated expired-AWS-token issues from placeholder test credentials, non-fatal by design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security Improvements**
  * Refined operator permissions to use resource-specific access instead of broad wildcard permissions.
  * Limited route access to only the actions required for viewing and managing routes.
  * Removed access to unused resources and application workload types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->