### PR TITLE
fix: refine ClusterRole permissions for ROSAENG-61347

### DIFF
--- a/deploy/cluster_role.yaml
+++ b/deploy/cluster_role.yaml
@@ -7,30 +7,52 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - pods
-  - services
-  - endpoints
-  - persistentvolumeclaims
-  - events
-  - configmaps
   - secrets
   verbs:
-  - '*'
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - services
+  verbs:
+  - get
+  - create
+  - update
 - apiGroups:
   - ""
   resources:
   - namespaces
   verbs:
   - get
-- apiGroups:
-  - apps
-  resources:
-  - deployments
-  - daemonsets
-  - replicasets
-  - statefulsets
-  verbs:
-  - '*'
 - apiGroups:
   - monitoring.coreos.com
   resources:
@@ -54,4 +76,6 @@ rules:
   resources:
   - routes
   verbs:
-  - '*'
+  - get
+  - create
+  - update

--- a/deploy_pko/ClusterRole-aws-account-operator.yaml
+++ b/deploy_pko/ClusterRole-aws-account-operator.yaml
@@ -10,30 +10,52 @@ rules:
 - apiGroups:
   - ''
   resources:
-  - pods
-  - services
-  - endpoints
-  - persistentvolumeclaims
-  - events
-  - configmaps
   - secrets
   verbs:
-  - '*'
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - delete
+- apiGroups:
+  - ''
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - delete
+- apiGroups:
+  - ''
+  resources:
+  - pods
+  verbs:
+  - get
+  - delete
+- apiGroups:
+  - ''
+  resources:
+  - nodes
+  verbs:
+  - get
+- apiGroups:
+  - ''
+  resources:
+  - services
+  verbs:
+  - get
+  - create
+  - update
 - apiGroups:
   - ''
   resources:
   - namespaces
   verbs:
   - get
-- apiGroups:
-  - apps
-  resources:
-  - deployments
-  - daemonsets
-  - replicasets
-  - statefulsets
-  verbs:
-  - '*'
 - apiGroups:
   - monitoring.coreos.com
   resources:
@@ -57,4 +79,6 @@ rules:
   resources:
   - routes
   verbs:
-  - '*'
+  - get
+  - create
+  - update


### PR DESCRIPTION
## Summary

Narrows the operator's ClusterRole permissions for [ROSAENG-61347](https://redhat.atlassian.net/browse/ROSAENG-61347). Replaced wildcard (`*`) verbs and unused resources with an explicit, least-privilege ruleset, verified against every Kubernetes API call actually made across the operator binary — reconcilers, `main.go`, and the vendored leader-election and metrics libraries.

## Rationale

Leader election (`operator-framework/operator-lib`) uses a direct, uncached client that calls `Get` on the operator's own Pod to establish lock ownership, then `Create`s a ConfigMap as the lock. The metrics library (`openshift/operator-custom-metrics`) unconditionally creates/updates a Service, and since `.WithRoute()` is set, a Route. Both are fatal (`os.Exit(1)`) if the underlying calls are forbidden. Neither of these lives in `controllers/`, so both needed to be traced separately from the reconciler logic.

Applied to both `deploy/cluster_role.yaml` and `deploy_pko/ClusterRole-aws-account-operator.yaml`:

| Resource | Verbs | Why |
|---|---|---|
| `secrets` | get, list, watch, create, update, delete | Reconcilers — cross-namespace IAM credential management |
| `configmaps` | get, list, watch, create, update, delete | Reconciler reads + leader-election lock (create) + CCS-Access-Arn write in `main.go` |
| `pods` | get, delete | Leader election: get own pod (fatal path), delete evicted leader pod (non-fatal edge case) |
| `nodes` | get | Leader election: detect NotReady node holding a stale lock |
| `services` | get, create, update | Metrics library — unconditional Service create/update |
| `route.openshift.io/routes` | get, create, update | Metrics library — Route create/update (`.WithRoute()` is active) |
| `servicemonitors` | get, create | Unchanged — ServiceMonitor path is inactive in this operator |
| `namespaces` | get | Unchanged |

Confirmed zero usage anywhere in the binary (not just `controllers/`) for `endpoints`, `persistentvolumeclaims`, `events`, and all `apps/v1` resources — these are removed, along with all wildcard verbs.

## Testing

- ✅ `make test` / `make lint` pass
- ✅ **Live cluster validation**: deployed to a personal test cluster with this exact ClusterRole. Pod reached `1/1 Running` and stayed there with `0` restarts for 20+ minutes. Logs confirm:
  - `Trying to become the leader.` → `No pre-existing lock was found.` → `Became the leader.`
  - `Generated metrics service object` → `Metrics Service object created`
  - `Generated metrics route object` → `Metrics Route object Created`
  - All 5 controllers (AccountClaim, Account, AccountPool, AWSFederatedRole, AWSFederatedAccountAccess) started their EventSources/watches
  - Zero `forbidden`/`denied` errors in the logs. The only errors present are unrelated expired-AWS-token issues from placeholder test credentials, non-fatal by design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)